### PR TITLE
Remove generics from ISerialize

### DIFF
--- a/bench/JsonToString.cs
+++ b/bench/JsonToString.cs
@@ -33,7 +33,7 @@ namespace Benchmarks
         }
 
         [Benchmark]
-        public string SerdeJson() => Serde.JsonSerializer.Serialize(value);
+        public string SerdeJson() => Serde.Json.JsonSerializer.Serialize(value);
 
         // DataContractJsonSerializer does not provide an API to serialize to string
         // so it's not included here (apples vs apples thing)

--- a/src/generator/SerializeGenerator.cs
+++ b/src/generator/SerializeGenerator.cs
@@ -114,7 +114,7 @@ namespace Serde
 
             if (statements is not null)
             {
-                // Generate method `void ISerialize.Serialize<TSerializer, TSerializeType, TSerializeEnumerable, TSerializeDictionary>(ref TSerializer serializer) { ... }`
+                // Generate method `void ISerialize.Serialize(ISerializer serializer) { ... }`
                 var newMethod = MethodDeclaration(
                     attributeLists: default,
                     modifiers: default,
@@ -122,13 +122,11 @@ namespace Serde
                     explicitInterfaceSpecifier: ExplicitInterfaceSpecifier(
                         QualifiedName(IdentifierName("Serde"), IdentifierName("ISerialize"))),
                     identifier: Identifier("Serialize"),
-                    typeParameterList: TypeParameterList(SeparatedList(new[] {
-                        "TSerializer", "TSerializeType", "TSerializeEnumerable", "TSerializeDictionary"
-                    }.Select(s => TypeParameter(s)))),
-                    parameterList: ParameterList(SeparatedList(new[] { Parameter("TSerializer", "serializer", byRef: true) })),
+                    typeParameterList: null,
+                    parameterList: ParameterList(SeparatedList(new[] { Parameter("ISerializer", "serializer") })),
                     constraintClauses: default,
                     body: Block(statements.ToArray()),
-                    semicolonToken: default
+                    expressionBody: null
                     );
 
                 MemberDeclarationSyntax newType = typeDecl

--- a/src/serde-dn/ISerialize.cs
+++ b/src/serde-dn/ISerialize.cs
@@ -1,19 +1,23 @@
-﻿using System;
+﻿
+using System;
 using System.Diagnostics;
 
 namespace Serde
 {
     [AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct, AllowMultiple = false, Inherited = false)]
     [Conditional("EMIT_GENERATE_SERDE_ATTRIBUTE")]
-    public sealed class GenerateSerializeAttribute : Attribute { }
+    public sealed class GenerateSerializeAttribute : Attribute
+    {
+        /// <summary>
+        /// Whether or not to generate an implementation for ISerializeStatic.
+        /// Currently always false, as the generator does not support it yet.
+        /// </summary>
+        public bool Static { get; } = false;
+    }
 
     public interface ISerialize
     {
-        void Serialize<TSerializer, TSerializeType, TSerializeEnumerable, TSerializeDictionary>(ref TSerializer serializer)
-            where TSerializeType : ISerializeType
-            where TSerializeEnumerable : ISerializeEnumerable
-            where TSerializeDictionary : ISerializeDictionary
-            where TSerializer : ISerializer<TSerializeType, TSerializeEnumerable, TSerializeDictionary>;
+        void Serialize(ISerializer serializer);
     }
 
     public interface ISerializeType
@@ -36,14 +40,7 @@ namespace Serde
         void End();
     }
 
-    public interface ISerializer<
-        out TSerializeType,
-        out TSerializeEnumerable,
-        out TSerializeDictionary
-        >
-        where TSerializeType : ISerializeType
-        where TSerializeEnumerable : ISerializeEnumerable
-        where TSerializeDictionary : ISerializeDictionary
+    public interface ISerializer
     {
         void Serialize(bool b);
         void Serialize(char c);
@@ -58,8 +55,8 @@ namespace Serde
         void Serialize(float f);
         void Serialize(double d);
         void Serialize(string s);
-        TSerializeType SerializeType(string name, int numFields);
-        TSerializeEnumerable SerializeEnumerable(int? length);
-        TSerializeDictionary SerializeDictionary(int? length);
+        ISerializeType SerializeType(string name, int numFields);
+        ISerializeEnumerable SerializeEnumerable(int? length);
+        ISerializeDictionary SerializeDictionary(int? length);
     }
 }

--- a/src/serde-dn/ISerializeStatic.cs
+++ b/src/serde-dn/ISerializeStatic.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using System.Diagnostics;
+
+namespace Serde
+{
+    public interface ISerializeStatic : ISerialize
+    {
+        void Serialize<TSerializer, TSerializeType, TSerializeEnumerable, TSerializeDictionary>(ref TSerializer serializer)
+            where TSerializeType : ISerializeTypeStatic
+            where TSerializeEnumerable : ISerializeEnumerableStatic
+            where TSerializeDictionary : ISerializeDictionaryStatic
+            where TSerializer : ISerializerStatic<TSerializeType, TSerializeEnumerable, TSerializeDictionary>;
+    }
+
+    public interface ISerializeTypeStatic : ISerializeType
+    {
+        new void SerializeField<T>(string name, T value) where T : ISerializeStatic;
+    }
+
+    public interface ISerializeEnumerableStatic : ISerializeEnumerable
+    {
+        new void SerializeElement<T>(T value) where T : ISerializeStatic;
+    }
+
+    public interface ISerializeDictionaryStatic : ISerializeDictionary
+    {
+        new void SerializeKey<T>(T key) where T : ISerializeStatic;
+        new void SerializeValue<T>(T value) where T : ISerializeStatic;
+    }
+
+    public interface ISerializerStatic<
+        out TSerializeType,
+        out TSerializeEnumerable,
+        out TSerializeDictionary
+        > : ISerializer
+        where TSerializeType : ISerializeTypeStatic
+        where TSerializeEnumerable : ISerializeEnumerableStatic
+        where TSerializeDictionary : ISerializeDictionaryStatic
+    {
+        new TSerializeType SerializeType(string name, int numFields);
+        new TSerializeEnumerable SerializeEnumerable(int? length);
+        new TSerializeDictionary SerializeDictionary(int? length);
+    }
+}

--- a/src/serde-dn/JsonSerializer.cs
+++ b/src/serde-dn/JsonSerializer.cs
@@ -3,9 +3,11 @@ using System;
 using System.Text;
 using System.Text.Json;
 
-namespace Serde
+namespace Serde.Json
 {
-    public static partial class JsonSerializer
+    public sealed class KeyNotStringException : Exception { }
+
+    public sealed partial class JsonSerializer
     {
         /// <summary>
         /// Serialize the given type to a string.
@@ -14,185 +16,122 @@ namespace Serde
         {
             using var bufferWriter = new PooledByteBufferWriter(16 * 1024);
             using var writer = new Utf8JsonWriter(bufferWriter);
-            var serializer = new Impl(writer);
-            s.Serialize<Impl, SerializeType, SerializeEnumerable, SerializeDictionary>(ref serializer);
+            var serializer = new JsonSerializer(writer);
+            s.Serialize(serializer);
             writer.Flush();
             return Encoding.UTF8.GetString(bufferWriter.WrittenMemory.Span);
         }
 
-        // Using a mutable struct allows for an efficient low-allocation implementation of the
-        // ISerializer interface, but mutable structs are easy to misuse in C#, so hide the
-        // implementation for now.
-        private partial struct Impl
+        /// <summary>
+        /// Serialize the given type to a string.
+        /// </summary>
+        public static string SerializeStatic<T>(T s) where T : ISerializeStatic
         {
-            public readonly Utf8JsonWriter _writer;
-            public Impl(Utf8JsonWriter writer)
-            {
-                _writer = writer;
-            }
+            using var bufferWriter = new PooledByteBufferWriter(16 * 1024);
+            using var writer = new Utf8JsonWriter(bufferWriter);
+            var serializer = new JsonSerializerStatic(writer);
+            s.Serialize<JsonSerializerStatic, SerializeTypeStatic, SerializeEnumerableStatic, SerializeDictionaryStatic>(ref serializer);
+            writer.Flush();
+            return Encoding.UTF8.GetString(bufferWriter.WrittenMemory.Span);
         }
     }
 
     // Implementations of ISerializer interfaces
-    partial class JsonSerializer
+    partial class JsonSerializer : ISerializer
     {
-        partial struct Impl : ISerializer<SerializeType, SerializeEnumerable, SerializeDictionary>
+        private JsonSerializerStatic _impl;
+        internal JsonSerializer(Utf8JsonWriter writer)
         {
-            public void Serialize(bool b) => _writer.WriteBooleanValue(b);
-
-            public void Serialize(char c) => Serialize(c.ToString());
-
-            public void Serialize(byte b) => _writer.WriteNumberValue(b);
-
-            public void Serialize(ushort u16) => _writer.WriteNumberValue(u16);
-
-            public void Serialize(uint u32) => _writer.WriteNumberValue(u32);
-
-            public void Serialize(ulong u64) => _writer.WriteNumberValue(u64);
-
-            public void Serialize(sbyte b) => _writer.WriteNumberValue(b);
-
-            public void Serialize(short i16) => _writer.WriteNumberValue(i16);
-
-            public void Serialize(int i32) => _writer.WriteNumberValue(i32);
-
-            public void Serialize(long i64) => _writer.WriteNumberValue(i64);
-
-            public void Serialize(float f) => _writer.WriteNumberValue(f);
-
-            public void Serialize(double d) => _writer.WriteNumberValue(d);
-
-            public void Serialize(string s) => _writer.WriteStringValue(s);
-
-            public SerializeType SerializeType(string name, int numFields)
-            {
-                _writer.WriteStartObject();
-                return new SerializeType(ref this);
-            }
-
-            public SerializeEnumerable SerializeEnumerable(int? count)
-            {
-                _writer.WriteStartArray();
-                return new SerializeEnumerable(ref this);
-            }
-
-            public SerializeDictionary SerializeDictionary(int? count)
-            {
-                _writer.WriteStartObject();
-                return new SerializeDictionary(ref this);
-            }
+            _impl = new JsonSerializerStatic(writer);
         }
 
-        struct SerializeType : ISerializeType
+        public ISerializeType SerializeType(string name, int numFields)
         {
-            private Impl _impl;
-            public SerializeType(ref Impl impl)
-            {
-                // Copies Impl, since we can't hold a ref. This forces the persistant state to be a
-                // reference type, but that works for now.
-                _impl = impl;
-            }
-
-            public void SerializeField<T>(string name, T value)
-                where T : ISerialize
-            {
-                _impl._writer.WritePropertyName(name);
-                value.Serialize<Impl, SerializeType, SerializeEnumerable, SerializeDictionary>(ref _impl);
-            }
-
-            public void End()
-            {
-                _impl._writer.WriteEndObject();
-            }
+            _impl._writer.WriteStartObject();
+            return this;
         }
 
-        struct SerializeEnumerable : ISerializeEnumerable
+        public ISerializeEnumerable SerializeEnumerable(int? count)
         {
-            private Impl _impl;
-            public SerializeEnumerable(ref Impl impl)
-            {
-                // Copies Impl, since we can't hold a ref. This forces the persistant state to be a
-                // reference type, but that works for now.
-                _impl = impl;
-            }
-            void ISerializeEnumerable.SerializeElement<T>(T value)
-            {
-                value.Serialize<Impl, SerializeType, SerializeEnumerable, SerializeDictionary>(ref _impl);
-            }
-
-            void ISerializeEnumerable.End()
-            {
-                _impl._writer.WriteEndArray();
-            }
+            _impl._writer.WriteStartArray();
+            return this;
         }
 
-        struct SerializeDictionary : ISerializeDictionary
+        public ISerializeDictionary SerializeDictionary(int? count)
         {
-            private Impl _impl;
-            public SerializeDictionary(ref Impl impl)
-            {
-                // Copies Impl, since we can't hold a ref. This forces the persistant state to be a
-                // reference type, but that works for now.
-                _impl = impl;
-            }
-            void ISerializeDictionary.SerializeKey<T>(T key)
-            {
-                // Grab a string value
-                var keySerializer = new KeySerializer();
-                key.Serialize<KeySerializer, ISerializeType, ISerializeEnumerable, ISerializeDictionary>(ref keySerializer);
-                _impl._writer.WritePropertyName(keySerializer.StringResult!);
-            }
-            void ISerializeDictionary.SerializeValue<T>(T value)
-            {
-                value.Serialize<Impl, SerializeType, SerializeEnumerable, SerializeDictionary>(ref _impl);
-            }
-            void ISerializeDictionary.End()
-            {
-                _impl._writer.WriteEndObject();
-            }
+            _impl._writer.WriteStartObject();
+            return this;
         }
 
-        public sealed class KeyNotStringException : Exception { }
+        public void Serialize(bool b) => _impl.Serialize(b);
 
-        struct KeySerializer : ISerializer<ISerializeType, ISerializeEnumerable, ISerializeDictionary>
+        public void Serialize(char c) => _impl.Serialize(c);
+
+        public void Serialize(byte b) => _impl.Serialize(b);
+
+        public void Serialize(ushort u16) => _impl.Serialize(u16);
+
+        public void Serialize(uint u32) => _impl.Serialize(u32);
+
+        public void Serialize(ulong u64) => _impl.Serialize(u64);
+
+        public void Serialize(sbyte b) => _impl.Serialize(b);
+
+        public void Serialize(short i16) => _impl.Serialize(i16);
+
+        public void Serialize(int i32) => _impl.Serialize(i32);
+
+        public void Serialize(long i64) => _impl.Serialize(i64);
+
+        public void Serialize(float f) => _impl.Serialize(f);
+
+        public void Serialize(double d) => _impl.Serialize(d);
+
+        public void Serialize(string s) => _impl.Serialize(s);
+    }
+
+    partial class JsonSerializer : ISerializeType
+    {
+        void ISerializeType.SerializeField<T>(string name, T value)
         {
-            public string? StringResult;
-            public KeySerializer(int dummy)
-            {
-                StringResult = null;
-            }
+            _impl._writer.WritePropertyName(name);
+            value.Serialize(this);
+        }
 
-            public void Serialize(bool b) => throw new KeyNotStringException();
-            public void Serialize(char c) => throw new KeyNotStringException();
-            public void Serialize(byte b) => throw new KeyNotStringException();
-            public void Serialize(ushort u16) => throw new KeyNotStringException();
+        void ISerializeType.End()
+        {
+            _impl._writer.WriteEndObject();
+        }
+    }
 
-            public void Serialize(uint u32) => throw new KeyNotStringException();
+    partial class JsonSerializer : ISerializeEnumerable
+    {
+        void ISerializeEnumerable.SerializeElement<T>(T value)
+        {
+            value.Serialize(this);
+        }
 
-            public void Serialize(ulong u64) => throw new KeyNotStringException();
+        void ISerializeEnumerable.End()
+        {
+            _impl._writer.WriteEndArray();
+        }
+    }
 
-            public void Serialize(sbyte b) => throw new KeyNotStringException();
+    partial class JsonSerializer : ISerializeDictionary
+    {
+        void ISerializeDictionary.SerializeKey<T>(T key)
+        {
+            SerializeDictionaryStatic.SerializeKey(ref _impl, key);
+        }
 
-            public void Serialize(short i16) => throw new KeyNotStringException();
+        void ISerializeDictionary.SerializeValue<T>(T value)
+        {
+            value.Serialize(this);
+        }
 
-            public void Serialize(int i32) => throw new KeyNotStringException();
-
-            public void Serialize(long i64) => throw new KeyNotStringException();
-
-            public void Serialize(float f) => throw new KeyNotStringException();
-
-            public void Serialize(double d) => throw new KeyNotStringException();
-
-            public void Serialize(string s)
-            {
-                StringResult = s;
-            }
-
-            public ISerializeDictionary SerializeDictionary(int? length) => throw new KeyNotStringException();
-
-            public ISerializeEnumerable SerializeEnumerable(int? length) => throw new KeyNotStringException();
-
-            public ISerializeType SerializeType(string name, int numFields) => throw new KeyNotStringException();
+        void ISerializeDictionary.End()
+        {
+            _impl._writer.WriteEndObject();
         }
     }
 }

--- a/src/serde-dn/JsonSerializerStatic.cs
+++ b/src/serde-dn/JsonSerializerStatic.cs
@@ -1,0 +1,225 @@
+
+using System;
+using System.Text;
+using System.Text.Json;
+
+namespace Serde.Json
+{
+    // Using a mutable struct allows for an efficient low-allocation implementation of the
+    // ISerializer interface, but mutable structs are easy to misuse in C#, so hide the
+    // implementation for now.
+    internal partial struct JsonSerializerStatic
+    {
+        internal readonly Utf8JsonWriter _writer;
+        public JsonSerializerStatic(Utf8JsonWriter writer)
+        {
+            _writer = writer;
+        }
+    }
+
+    // Implementations of ISerializerStatic
+    partial struct JsonSerializerStatic : ISerializerStatic<SerializeTypeStatic, SerializeEnumerableStatic, SerializeDictionaryStatic>
+    {
+        public void Serialize(bool b) => _writer.WriteBooleanValue(b);
+
+        public void Serialize(char c) => Serialize(c.ToString());
+
+        public void Serialize(byte b) => _writer.WriteNumberValue(b);
+
+        public void Serialize(ushort u16) => _writer.WriteNumberValue(u16);
+
+        public void Serialize(uint u32) => _writer.WriteNumberValue(u32);
+
+        public void Serialize(ulong u64) => _writer.WriteNumberValue(u64);
+
+        public void Serialize(sbyte b) => _writer.WriteNumberValue(b);
+
+        public void Serialize(short i16) => _writer.WriteNumberValue(i16);
+
+        public void Serialize(int i32) => _writer.WriteNumberValue(i32);
+
+        public void Serialize(long i64) => _writer.WriteNumberValue(i64);
+
+        public void Serialize(float f) => _writer.WriteNumberValue(f);
+
+        public void Serialize(double d) => _writer.WriteNumberValue(d);
+
+        public void Serialize(string s) => _writer.WriteStringValue(s);
+
+        public SerializeTypeStatic SerializeType(string name, int numFields)
+        {
+            _writer.WriteStartObject();
+            return new SerializeTypeStatic(ref this);
+        }
+
+        public SerializeEnumerableStatic SerializeEnumerable(int? count)
+        {
+            _writer.WriteStartArray();
+            return new SerializeEnumerableStatic(ref this);
+        }
+
+        public SerializeDictionaryStatic SerializeDictionary(int? count)
+        {
+            _writer.WriteStartObject();
+            return new SerializeDictionaryStatic(ref this);
+        }
+
+        ISerializeType ISerializer.SerializeType(string name, int numFields)
+            => SerializeType(name, numFields);
+
+        ISerializeEnumerable ISerializer.SerializeEnumerable(int? length)
+            => SerializeEnumerable(length);
+
+        ISerializeDictionary ISerializer.SerializeDictionary(int? length)
+            => SerializeDictionary(length);
+    }
+
+    internal struct SerializeTypeStatic : ISerializeTypeStatic
+    {
+        private JsonSerializerStatic _impl;
+        public SerializeTypeStatic(ref JsonSerializerStatic impl)
+        {
+            // Copies Impl, since we can't hold a ref. This forces the persistant state to be a
+            // reference type, but that works for now.
+            _impl = impl;
+        }
+
+        void ISerializeTypeStatic.SerializeField<T>(string name, T value)
+        {
+            _impl._writer.WritePropertyName(name);
+            value.Serialize<JsonSerializerStatic, SerializeTypeStatic, SerializeEnumerableStatic, SerializeDictionaryStatic>(ref _impl);
+        }
+
+        void ISerializeType.SerializeField<T>(string name, T value)
+        {
+            _impl._writer.WritePropertyName(name);
+            value.Serialize(_impl);
+        }
+
+        public void End()
+        {
+            _impl._writer.WriteEndObject();
+        }
+    }
+
+    struct SerializeEnumerableStatic : ISerializeEnumerableStatic
+    {
+        private JsonSerializerStatic _impl;
+        public SerializeEnumerableStatic(ref JsonSerializerStatic impl)
+        {
+            // Copies Impl, since we can't hold a ref. This forces the persistant state to be a
+            // reference type, but that works for now.
+            _impl = impl;
+        }
+
+        void ISerializeEnumerableStatic.SerializeElement<T>(T value)
+        {
+            value.Serialize<JsonSerializerStatic, SerializeTypeStatic, SerializeEnumerableStatic, SerializeDictionaryStatic>(ref _impl);
+        }
+
+        void ISerializeEnumerable.SerializeElement<T>(T value)
+        {
+            value.Serialize(_impl);
+        }
+
+        void ISerializeEnumerable.End()
+        {
+            _impl._writer.WriteEndArray();
+        }
+    }
+
+    struct SerializeDictionaryStatic : ISerializeDictionaryStatic
+    {
+        private JsonSerializerStatic _impl;
+        public SerializeDictionaryStatic(ref JsonSerializerStatic impl)
+        {
+            // Copies Impl, since we can't hold a ref. This forces the persistant state to be a
+            // reference type, but that works for now.
+            _impl = impl;
+        }
+        void ISerializeDictionaryStatic.SerializeKey<T>(T key)
+        {
+            // Grab a string value
+            var keySerializer = new KeySerializer();
+            key.Serialize(keySerializer);
+            _impl._writer.WritePropertyName(keySerializer.StringResult!);
+        }
+        void ISerializeDictionaryStatic.SerializeValue<T>(T value)
+        {
+            value.Serialize<JsonSerializerStatic, SerializeTypeStatic, SerializeEnumerableStatic, SerializeDictionaryStatic>(ref _impl);
+        }
+        public void End()
+        {
+            _impl._writer.WriteEndObject();
+        }
+
+        // Share implementation with JsonSerializer
+        public static void SerializeKey<T>(ref JsonSerializerStatic impl, T key) where T : ISerialize
+        {
+            // Grab a string value. Box to prevent internal copying and losing side-effects
+            ISerializer keySerializer = new KeySerializer();
+            key.Serialize(keySerializer);
+            impl._writer.WritePropertyName(((KeySerializer)keySerializer).StringResult!);
+        }
+
+        void ISerializeDictionary.SerializeKey<T>(T key)
+        {
+            SerializeKey(ref _impl, key);
+        }
+
+        void ISerializeDictionary.SerializeValue<T>(T value)
+        {
+            value.Serialize(_impl);
+        }
+
+        private struct KeySerializer : ISerializer, ISerializerStatic<ISerializeTypeStatic, ISerializeEnumerableStatic, ISerializeDictionaryStatic>
+        {
+            public string? StringResult;
+            public KeySerializer(int dummy)
+            {
+                StringResult = null;
+            }
+
+            public void Serialize(bool b) => throw new KeyNotStringException();
+            public void Serialize(char c) => throw new KeyNotStringException();
+            public void Serialize(byte b) => throw new KeyNotStringException();
+            public void Serialize(ushort u16) => throw new KeyNotStringException();
+
+            public void Serialize(uint u32) => throw new KeyNotStringException();
+
+            public void Serialize(ulong u64) => throw new KeyNotStringException();
+
+            public void Serialize(sbyte b) => throw new KeyNotStringException();
+
+            public void Serialize(short i16) => throw new KeyNotStringException();
+
+            public void Serialize(int i32) => throw new KeyNotStringException();
+
+            public void Serialize(long i64) => throw new KeyNotStringException();
+
+            public void Serialize(float f) => throw new KeyNotStringException();
+
+            public void Serialize(double d) => throw new KeyNotStringException();
+
+            public void Serialize(string s)
+            {
+                StringResult = s;
+            }
+
+            public ISerializeDictionaryStatic SerializeDictionary(int? length) => throw new KeyNotStringException();
+
+            public ISerializeEnumerableStatic SerializeEnumerable(int? length) => throw new KeyNotStringException();
+
+            public ISerializeTypeStatic SerializeType(string name, int numFields) => throw new KeyNotStringException();
+
+            ISerializeDictionary ISerializer.SerializeDictionary(int? length)
+                => SerializeDictionary(length);
+
+            ISerializeEnumerable ISerializer.SerializeEnumerable(int? length)
+                => SerializeEnumerable(length);
+
+            ISerializeType ISerializer.SerializeType(string name, int numFields)
+                => SerializeType(name, numFields);
+        }
+    }
+}

--- a/src/serde-dn/Wrappers.Dictionary.cs
+++ b/src/serde-dn/Wrappers.Dictionary.cs
@@ -17,7 +17,7 @@ namespace Serde
             _dict = dict;
         }
 
-        void ISerialize.Serialize<TSerializer, TSerializeType, TSerializeEnumerable, TSerializeDictionary>(ref TSerializer serializer)
+        void ISerialize.Serialize(ISerializer serializer)
         {
             var sd = serializer.SerializeDictionary(_dict.Count);
             var kwrap = default(TKeyWrap);
@@ -44,8 +44,9 @@ namespace Serde
         {
             _dict = dict;
         }
-        void ISerialize.Serialize<TSerializer, TSerializeType, TSerializeEnumerable, TSerializeDictionary>(ref TSerializer serializer)
-        {
+
+        void ISerialize.Serialize(ISerializer serializer)
+        {            
             var sd = serializer.SerializeDictionary(_dict.Count);
             var kwrap = default(TKeyWrap);
             var vwrap = default(TValueWrap);
@@ -71,7 +72,8 @@ namespace Serde
         {
             _dict = dict;
         }
-        void ISerialize.Serialize<TSerializer, TSerializeType, TSerializeEnumerable, TSerializeDictionary>(ref TSerializer serializer)
+
+        void ISerialize.Serialize(ISerializer serializer)
         {
             var sd = serializer.SerializeDictionary(_dict.Count);
             var kwrap = default(TKeyWrap);

--- a/src/serde-dn/Wrappers.List.cs
+++ b/src/serde-dn/Wrappers.List.cs
@@ -9,13 +9,8 @@ namespace Serde
 {
     internal static class EnumerableHelpers
     {
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void SerializeArray<T, TWrap, TSerializer, TSerializeType, TSerializeEnumerable, TSerializeDictionary>(T[] arr, ref TSerializer serializer)
+        public static void SerializeArray<T, TWrap>(T[] arr, ISerializer serializer)
             where TWrap : struct, IWrap<T, TWrap>, ISerialize
-            where TSerializer : ISerializer<TSerializeType, TSerializeEnumerable, TSerializeDictionary>
-            where TSerializeType : ISerializeType
-            where TSerializeEnumerable : ISerializeEnumerable
-            where TSerializeDictionary : ISerializeDictionary
         {
             var enumerable = serializer.SerializeEnumerable(arr.Length);
             var wrapper = default(TWrap);
@@ -27,12 +22,8 @@ namespace Serde
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void SerializeList<T, TWrap, TSerializer, TSerializeType, TSerializeEnumerable, TSerializeDictionary>(List<T> list, ref TSerializer serializer)
-            where TWrap : struct, ISerialize, IWrap<T, TWrap>
-            where TSerializer : ISerializer<TSerializeType, TSerializeEnumerable, TSerializeDictionary>
-            where TSerializeType : ISerializeType
-            where TSerializeEnumerable : ISerializeEnumerable
-            where TSerializeDictionary : ISerializeDictionary
+        public static void SerializeList<T, TWrap>(List<T> list, ISerializer serializer)
+            where TWrap : struct, IWrap<T, TWrap>, ISerialize
         {
             var enumerable = serializer.SerializeEnumerable(list.Count);
             var wrapper = default(TWrap);
@@ -44,12 +35,8 @@ namespace Serde
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void SerializeImmutableArray<T, TWrap, TSerializer, TSerializeType, TSerializeEnumerable, TSerializeDictionary>(ImmutableArray<T> list, ref TSerializer serializer)
-            where TWrap : struct, ISerialize, IWrap<T, TWrap>
-            where TSerializer : ISerializer<TSerializeType, TSerializeEnumerable, TSerializeDictionary>
-            where TSerializeType : ISerializeType
-            where TSerializeEnumerable : ISerializeEnumerable
-            where TSerializeDictionary : ISerializeDictionary
+        public static void SerializeImmutableArray<T, TWrap>(ImmutableArray<T> list, ISerializer serializer)
+            where TWrap : struct, IWrap<T, TWrap>, ISerialize
         {
             var enumerable = serializer.SerializeEnumerable(list.Length);
             var wrapper = default(TWrap);
@@ -61,37 +48,12 @@ namespace Serde
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void SerializeIList<T, TList, TWrapper, TWrapped, TSerializer, TSerializeType, TSerializeEnumerable, TSerializeDictionary>(TList list, ref TSerializer serializer)
-            where TList : IList<T>
-            where TWrapped : ISerialize
-            where TWrapper : struct, IWrap<T, TWrapped>
-            where TSerializer : ISerializer<TSerializeType, TSerializeEnumerable, TSerializeDictionary>
-            where TSerializeType : ISerializeType
-            where TSerializeEnumerable : ISerializeEnumerable
-            where TSerializeDictionary : ISerializeDictionary
+        public static void SerializeIList<T, TWrap>(IList<T> list, ISerializer serializer)
+            where TWrap : struct, IWrap<T, TWrap>, ISerialize
         {
             var enumerable = serializer.SerializeEnumerable(list.Count);
-            var wrapper = default(TWrapper);
+            var wrapper = default(TWrap);
             foreach (var item in list)
-            {
-                enumerable.SerializeElement(wrapper.Create(item));
-            }
-            enumerable.End();
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void SerializeEnumerable<T, TEnum, TWrapper, TWrapped, TSerializer, TSerializeType, TSerializeEnumerable, TSerializeDictionary>(TEnum e, ref TSerializer serializer)
-            where TEnum : IEnumerable<T>
-            where TWrapped : ISerialize
-            where TWrapper : struct, IWrap<T, TWrapped>
-            where TSerializer : ISerializer<TSerializeType, TSerializeEnumerable, TSerializeDictionary>
-            where TSerializeType : ISerializeType
-            where TSerializeEnumerable : ISerializeEnumerable
-            where TSerializeDictionary : ISerializeDictionary
-        {
-            var enumerable = serializer.SerializeEnumerable(null);
-            var wrapper = default(TWrapper);
-            foreach (var item in e)
             {
                 enumerable.SerializeElement(wrapper.Create(item));
             }
@@ -109,12 +71,12 @@ namespace Serde
             _t = t;
         }
 
-        void ISerialize.Serialize<TSerializer, TSerializeType, TSerializeEnumerable, TSerializeDictionary>(ref TSerializer serializer)
-            => _t.Serialize<TSerializer, TSerializeType, TSerializeEnumerable, TSerializeDictionary>(ref serializer);
+        void ISerialize.Serialize(ISerializer serializer)
+            => _t.Serialize(serializer);
     }
 
     public readonly struct ArrayWrap<T, TWrap> : ISerialize, IWrap<T[], ArrayWrap<T, TWrap>>
-        where TWrap: struct, ISerialize, IWrap<T, TWrap>
+        where TWrap: struct, IWrap<T, TWrap>, ISerialize
     {
         public ArrayWrap<T, TWrap> Create(T[] t) => new ArrayWrap<T, TWrap>(t);
 
@@ -124,14 +86,8 @@ namespace Serde
             _a = a;
         }
 
-        void ISerialize.Serialize<TSerializer, TSerializeType, TSerializeEnumerable, TSerializeDictionary>(ref TSerializer serializer)
-            => EnumerableHelpers.SerializeArray<
-                T,
-                TWrap,
-                TSerializer,
-                TSerializeType,
-                TSerializeEnumerable,
-                TSerializeDictionary>(_a, ref serializer);
+        void ISerialize.Serialize(ISerializer serializer)
+            => EnumerableHelpers.SerializeArray<T, TWrap>(_a, serializer);
     }
 
     public readonly struct ArrayWrap<T> : ISerialize, IWrap<T[], ArrayWrap<T>>
@@ -142,14 +98,8 @@ namespace Serde
         private readonly T[] _a;
         public ArrayWrap(T[] a) { _a = a; }
 
-        void ISerialize.Serialize<TSerializer, TSerializeType, TSerializeEnumerable, TSerializeDictionary>(ref TSerializer serializer)
-            => EnumerableHelpers.SerializeArray<
-                T,
-                IdWrap<T>,
-                TSerializer,
-                TSerializeType,
-                TSerializeEnumerable,
-                TSerializeDictionary>(_a, ref serializer);
+        void ISerialize.Serialize(ISerializer serializer)
+            => EnumerableHelpers.SerializeArray<T, IdWrap<T>>(_a, serializer);
     }
 
     public readonly struct ListWrap<T> : ISerialize, IWrap<List<T>, ListWrap<T>>
@@ -160,18 +110,12 @@ namespace Serde
         private readonly List<T> _a;
         public ListWrap(List<T> a) { _a = a; }
 
-        void ISerialize.Serialize<TSerializer, TSerializeType, TSerializeEnumerable, TSerializeDictionary>(ref TSerializer serializer)
-            => EnumerableHelpers.SerializeList<
-                T,
-                IdWrap<T>,
-                TSerializer,
-                TSerializeType,
-                TSerializeEnumerable,
-                TSerializeDictionary>(_a, ref serializer);
+        void ISerialize.Serialize(ISerializer serializer)
+            => EnumerableHelpers.SerializeList<T, IdWrap<T>>(_a, serializer);
     }
 
     public readonly struct ListWrap<T, TWrap> : ISerialize, IWrap<List<T>, ListWrap<T, TWrap>>
-        where TWrap : struct, ISerialize, IWrap<T, TWrap>
+        where TWrap : struct, IWrap<T, TWrap>, ISerialize
     {
         public ListWrap<T, TWrap> Create(List<T> t) => new ListWrap<T, TWrap>(t);
 
@@ -181,14 +125,8 @@ namespace Serde
             _a = a;
         }
 
-        void ISerialize.Serialize<TSerializer, TSerializeType, TSerializeEnumerable, TSerializeDictionary>(ref TSerializer serializer)
-            => EnumerableHelpers.SerializeList<
-                T,
-                TWrap,
-                TSerializer,
-                TSerializeType,
-                TSerializeEnumerable,
-                TSerializeDictionary>(_a, ref serializer);
+        void ISerialize.Serialize(ISerializer serializer)
+            => EnumerableHelpers.SerializeList<T, TWrap>(_a, serializer);
     }
 
     public readonly struct ImmutableArrayWrap<T> : ISerialize, IWrap<ImmutableArray<T>, ImmutableArrayWrap<T>>
@@ -199,18 +137,12 @@ namespace Serde
         private readonly ImmutableArray<T> _a;
         public ImmutableArrayWrap(ImmutableArray<T> a) { _a = a; }
 
-        void ISerialize.Serialize<TSerializer, TSerializeType, TSerializeEnumerable, TSerializeDictionary>(ref TSerializer serializer)
-            => EnumerableHelpers.SerializeImmutableArray<
-                T,
-                IdWrap<T>,
-                TSerializer,
-                TSerializeType,
-                TSerializeEnumerable,
-                TSerializeDictionary>(_a, ref serializer);
+        void ISerialize.Serialize(ISerializer serializer)
+            => EnumerableHelpers.SerializeImmutableArray<T, IdWrap<T>>(_a, serializer);
     }
 
     public readonly struct ImmutableArrayWrap<T, TWrap> : ISerialize, IWrap<ImmutableArray<T>, ImmutableArrayWrap<T, TWrap>>
-        where TWrap : struct, ISerialize, IWrap<T, TWrap>
+        where TWrap : struct, IWrap<T, TWrap>, ISerialize
     {
         public ImmutableArrayWrap<T, TWrap> Create(ImmutableArray<T> t) => new ImmutableArrayWrap<T, TWrap>(t);
 
@@ -220,13 +152,7 @@ namespace Serde
             _a = a;
         }
 
-        void ISerialize.Serialize<TSerializer, TSerializeType, TSerializeEnumerable, TSerializeDictionary>(ref TSerializer serializer)
-            => EnumerableHelpers.SerializeImmutableArray<
-                T,
-                TWrap,
-                TSerializer,
-                TSerializeType,
-                TSerializeEnumerable,
-                TSerializeDictionary>(_a, ref serializer);
+        void ISerialize.Serialize(ISerializer serializer)
+            => EnumerableHelpers.SerializeImmutableArray<T, TWrap>(_a, serializer);
     }
 }

--- a/src/serde-dn/Wrappers.cs
+++ b/src/serde-dn/Wrappers.cs
@@ -21,144 +21,199 @@ namespace Serde
         TWrap Create(T t); // Should be abstract static
     }
 
-    public readonly struct BoolWrap : ISerialize, IWrap<bool, BoolWrap>
+    public readonly struct BoolWrap : ISerialize, ISerializeStatic, IWrap<bool, BoolWrap>
     {
         public BoolWrap Create(bool t) => new BoolWrap(t);
 
         private readonly bool _b;
         public BoolWrap(bool b) { _b = b; }
 
-        void ISerialize.Serialize<TSerializer, _1, _2, _3>(ref TSerializer serializer)
+        void ISerializeStatic.Serialize<TSerializer, _1, _2, _3>(ref TSerializer serializer)
+        {
+            serializer.Serialize(_b);
+        }
+
+        void ISerialize.Serialize(ISerializer serializer)
         {
             serializer.Serialize(_b);
         }
     }
 
-    public readonly struct CharWrap : ISerialize, IWrap<char, CharWrap>
+    public readonly struct CharWrap : ISerialize, ISerializeStatic, IWrap<char, CharWrap>
     {
         public CharWrap Create(char c) => new CharWrap(c);
 
         private readonly char _c;
         public CharWrap(char c) { _c = c; }
 
-        void ISerialize.Serialize<TSerializer, _1, _2, _3>(ref TSerializer serializer)
+        void ISerializeStatic.Serialize<TSerializer, _1, _2, _3>(ref TSerializer serializer)
+        {
+            serializer.Serialize(_c);
+        }
+
+        void ISerialize.Serialize(ISerializer serializer)
         {
             serializer.Serialize(_c);
         }
     }
 
-    public readonly struct ByteWrap : ISerialize, IWrap<byte, ByteWrap>
+    public readonly struct ByteWrap : ISerialize, ISerializeStatic, IWrap<byte, ByteWrap>
     {
         public ByteWrap Create(byte b) => new ByteWrap(b);
 
         private readonly byte _b;
         public ByteWrap(byte b) { _b = b;}
 
-        void ISerialize.Serialize<TSerializer, _1, _2, _3>(ref TSerializer serializer)
+        void ISerializeStatic.Serialize<TSerializer, _1, _2, _3>(ref TSerializer serializer)
+        {
+            serializer.Serialize(_b);
+        }
+
+        void ISerialize.Serialize(ISerializer serializer)
         {
             serializer.Serialize(_b);
         }
     }
 
-    public readonly struct UInt16Wrap : ISerialize, IWrap<ushort, UInt16Wrap>
+    public readonly struct UInt16Wrap : ISerialize, ISerializeStatic, IWrap<ushort, UInt16Wrap>
     {
         public UInt16Wrap Create(ushort i) => new UInt16Wrap(i);
 
         private readonly ushort _i;
         public UInt16Wrap(ushort i) { _i = i; }
 
-        void ISerialize.Serialize<TSerializer, _1, _2, _3>(ref TSerializer serializer)
+        void ISerializeStatic.Serialize<TSerializer, _1, _2, _3>(ref TSerializer serializer)
+        {
+            serializer.Serialize(_i);
+        }
+
+        void ISerialize.Serialize(ISerializer serializer)
         {
             serializer.Serialize(_i);
         }
     }
 
-    public readonly struct UInt32Wrap : ISerialize, IWrap<uint, UInt32Wrap>
+    public readonly struct UInt32Wrap : ISerialize, ISerializeStatic, IWrap<uint, UInt32Wrap>
     {
         public UInt32Wrap Create(uint i) => new UInt32Wrap(i);
 
         private readonly uint _i;
         public UInt32Wrap(uint i) { _i = i; }
 
-        void ISerialize.Serialize<TSerializer, _1, _2, _3>(ref TSerializer serializer)
+        void ISerializeStatic.Serialize<TSerializer, _1, _2, _3>(ref TSerializer serializer)
+        {
+            serializer.Serialize(_i);
+        }
+
+        void ISerialize.Serialize(ISerializer serializer)
         {
             serializer.Serialize(_i);
         }
     }
 
-    public readonly struct UInt64Wrap : ISerialize, IWrap<ulong, UInt64Wrap>
+    public readonly struct UInt64Wrap : ISerialize, ISerializeStatic, IWrap<ulong, UInt64Wrap>
     {
         public UInt64Wrap Create(ulong i) => new UInt64Wrap(i);
 
         private readonly ulong _i;
         public UInt64Wrap(ulong i) { _i = i; }
 
-        void ISerialize.Serialize<TSerializer, _1, _2, _3>(ref TSerializer serializer)
+        void ISerializeStatic.Serialize<TSerializer, _1, _2, _3>(ref TSerializer serializer)
+        {
+            serializer.Serialize(_i);
+        }
+
+        void ISerialize.Serialize(ISerializer serializer)
         {
             serializer.Serialize(_i);
         }
     }
 
-    public readonly struct SByteWrap : ISerialize, IWrap<sbyte, SByteWrap>
+    public readonly struct SByteWrap : ISerialize, ISerializeStatic, IWrap<sbyte, SByteWrap>
     {
         public SByteWrap Create(sbyte i) => new SByteWrap(i);
 
         private readonly sbyte _i;
         public SByteWrap(sbyte i) { _i = i; }
 
-        void ISerialize.Serialize<TSerializer, _1, _2, _3>(ref TSerializer serializer)
+        void ISerializeStatic.Serialize<TSerializer, _1, _2, _3>(ref TSerializer serializer)
+        {
+            serializer.Serialize(_i);
+        }
+
+        void ISerialize.Serialize(ISerializer serializer)
         {
             serializer.Serialize(_i);
         }
     }
 
-    public readonly struct Int16Wrap : ISerialize, IWrap<short, Int16Wrap>
+    public readonly struct Int16Wrap : ISerialize, ISerializeStatic, IWrap<short, Int16Wrap>
     {
         public Int16Wrap Create(short i) => new Int16Wrap(i);
 
         private readonly short _i;
         public Int16Wrap(short i) { _i = i; }
 
-        void ISerialize.Serialize<TSerializer, _1, _2, _3>(ref TSerializer serializer)
+        void ISerializeStatic.Serialize<TSerializer, _1, _2, _3>(ref TSerializer serializer)
+        {
+            serializer.Serialize(_i);
+        }
+
+        void ISerialize.Serialize(ISerializer serializer)
         {
             serializer.Serialize(_i);
         }
     }
 
-    public readonly struct Int32Wrap : ISerialize, IWrap<int, Int32Wrap>
+    public readonly struct Int32Wrap : ISerialize, ISerializeStatic, IWrap<int, Int32Wrap>
     {
         public Int32Wrap Create(int i) => new Int32Wrap(i);
 
         private readonly int _i;
         public Int32Wrap(int i) { _i = i; }
 
-        void ISerialize.Serialize<TSerializer, _1, _2, _3>(ref TSerializer serializer)
+        void ISerializeStatic.Serialize<TSerializer, _1, _2, _3>(ref TSerializer serializer)
+        {
+            serializer.Serialize(_i);
+        }
+
+        void ISerialize.Serialize(ISerializer serializer)
         {
             serializer.Serialize(_i);
         }
     }
 
-    public readonly struct Int64Wrap : ISerialize, IWrap<long, Int64Wrap>
+    public readonly struct Int64Wrap : ISerialize, ISerializeStatic, IWrap<long, Int64Wrap>
     {
         public Int64Wrap Create(long i) => new Int64Wrap(i);
 
         private readonly long _i;
         public Int64Wrap(long i) { _i = i; }
 
-        void ISerialize.Serialize<TSerializer, _1, _2, _3>(ref TSerializer serializer)
+        void ISerializeStatic.Serialize<TSerializer, _1, _2, _3>(ref TSerializer serializer)
+        {
+            serializer.Serialize(_i);
+        }
+
+        void ISerialize.Serialize(ISerializer serializer)
         {
             serializer.Serialize(_i);
         }
     }
 
-    public readonly struct StringWrap : ISerialize, IWrap<string, StringWrap>
+    public readonly struct StringWrap : ISerialize, ISerializeStatic, IWrap<string, StringWrap>
     {
         public StringWrap Create(string s) => new StringWrap(s);
 
         private readonly string _s;
         public StringWrap(string s) { _s = s; }
 
-        void ISerialize.Serialize<TSerializer, _1, _2, _3>(ref TSerializer serializer)
+        void ISerializeStatic.Serialize<TSerializer, _1, _2, _3>(ref TSerializer serializer)
+        {
+            serializer.Serialize(_s);
+        }
+
+        void ISerialize.Serialize(ISerializer serializer)
         {
             serializer.Serialize(_s);
         }

--- a/test/AllInOneImpl.cs
+++ b/test/AllInOneImpl.cs
@@ -3,7 +3,7 @@ namespace Serde.Test
 {
     public partial class AllInOne : Serde.ISerialize
     {
-        void Serde.ISerialize.Serialize<TSerializer, TSerializeType, TSerializeEnumerable, TSerializeDictionary>(ref TSerializer serializer)
+        void ISerialize.Serialize(ISerializer serializer)
         {
             var type = serializer.SerializeType("AllInOne", 13);
             type.SerializeField("BoolField", new BoolWrap(BoolField));

--- a/test/AllInOneJsonTest.cs
+++ b/test/AllInOneJsonTest.cs
@@ -1,6 +1,7 @@
 using System.IO;
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
+using Serde.Json;
 using Xunit;
 
 namespace Serde.Test
@@ -23,7 +24,7 @@ namespace Serde.Test
 {
     public partial class AllInOne : Serde.ISerialize
     {
-        void Serde.ISerialize.Serialize<TSerializer, TSerializeType, TSerializeEnumerable, TSerializeDictionary>(ref TSerializer serializer)
+        void Serde.ISerialize.Serialize(ISerializer serializer)
         {
             var type = serializer.SerializeType(""AllInOne"", 14);
             type.SerializeField(""BoolField"", new BoolWrap(BoolField));

--- a/test/GeneratorTests.cs
+++ b/test/GeneratorTests.cs
@@ -29,7 +29,7 @@ using Serde;
 
 partial struct Rgb : Serde.ISerialize
 {
-    void Serde.ISerialize.Serialize<TSerializer, TSerializeType, TSerializeEnumerable, TSerializeDictionary>(ref TSerializer serializer)
+    void Serde.ISerialize.Serialize(ISerializer serializer)
     {
         var type = serializer.SerializeType(""Rgb"", 3);
         type.SerializeField(""Red"", new ByteWrap(Red));
@@ -88,7 +88,7 @@ using Serde;
 
 partial class C : Serde.ISerialize
 {
-    void Serde.ISerialize.Serialize<TSerializer, TSerializeType, TSerializeEnumerable, TSerializeDictionary>(ref TSerializer serializer)
+    void Serde.ISerialize.Serialize(ISerializer serializer)
     {
         var type = serializer.SerializeType(""C"", 1);
         type.SerializeField(""IntArr"", new ArrayWrap<int, Int32Wrap>(IntArr));
@@ -112,7 +112,7 @@ using Serde;
 
 partial class C : Serde.ISerialize
 {
-    void Serde.ISerialize.Serialize<TSerializer, TSerializeType, TSerializeEnumerable, TSerializeDictionary>(ref TSerializer serializer)
+    void Serde.ISerialize.Serialize(ISerializer serializer)
     {
         var type = serializer.SerializeType(""C"", 1);
         type.SerializeField(""NestedArr"", new ArrayWrap<int[], ArrayWrap<int, Int32Wrap>>(NestedArr));
@@ -136,7 +136,7 @@ using Serde;
 
 partial class C : Serde.ISerialize
 {
-    void Serde.ISerialize.Serialize<TSerializer, TSerializeType, TSerializeEnumerable, TSerializeDictionary>(ref TSerializer serializer)
+    void Serde.ISerialize.Serialize(ISerializer serializer)
     {
         var type = serializer.SerializeType(""C"", 1);
         type.SerializeField(""NestedArr"", new ArrayWrap<int[], ArrayWrap<int, Int32Wrap>>(NestedArr));
@@ -176,7 +176,7 @@ partial class TestCase15
 {
     public partial class Class0 : Serde.ISerialize
     {
-        void Serde.ISerialize.Serialize<TSerializer, TSerializeType, TSerializeEnumerable, TSerializeDictionary>(ref TSerializer serializer)
+        void Serde.ISerialize.Serialize(ISerializer serializer)
         {
             var type = serializer.SerializeType(""Class0"", 2);
             type.SerializeField(""Field0"", new ArrayWrap<TestCase15.Class1>(Field0));
@@ -192,7 +192,7 @@ partial class TestCase15
 {
     public partial class Class1 : Serde.ISerialize
     {
-        void Serde.ISerialize.Serialize<TSerializer, TSerializeType, TSerializeEnumerable, TSerializeDictionary>(ref TSerializer serializer)
+        void Serde.ISerialize.Serialize(ISerializer serializer)
         {
             var type = serializer.SerializeType(""Class1"", 2);
             type.SerializeField(""Field0"", new Int32Wrap(Field0));
@@ -226,7 +226,7 @@ using Serde;
 
 partial class C : Serde.ISerialize
 {
-    void Serde.ISerialize.Serialize<TSerializer, TSerializeType, TSerializeEnumerable, TSerializeDictionary>(ref TSerializer serializer)
+    void Serde.ISerialize.Serialize(ISerializer serializer)
     {
         var type = serializer.SerializeType(""C"", 1);
         type.SerializeField(""Map"", new DictWrap<string, StringWrap, int, Int32Wrap>(Map));
@@ -261,7 +261,7 @@ using Serde;
 
 partial record C : Serde.ISerialize
 {
-    void Serde.ISerialize.Serialize<TSerializer, TSerializeType, TSerializeEnumerable, TSerializeDictionary>(ref TSerializer serializer)
+    void Serde.ISerialize.Serialize(ISerializer serializer)
     {
         var type = serializer.SerializeType(""C"", 1);
         type.SerializeField(""X"", new Int32Wrap(X));
@@ -273,7 +273,7 @@ using Serde;
 
 partial class C2 : Serde.ISerialize
 {
-    void Serde.ISerialize.Serialize<TSerializer, TSerializeType, TSerializeEnumerable, TSerializeDictionary>(ref TSerializer serializer)
+    void Serde.ISerialize.Serialize(ISerializer serializer)
     {
         var type = serializer.SerializeType(""C2"", 1);
         type.SerializeField(""Map"", new DictWrap<string, StringWrap, C, IdWrap<C>>(Map));
@@ -369,7 +369,7 @@ using Serde;
 
 partial class C : Serde.ISerialize
 {
-    void Serde.ISerialize.Serialize<TSerializer, TSerializeType, TSerializeEnumerable, TSerializeDictionary>(ref TSerializer serializer)
+    void Serde.ISerialize.Serialize(ISerializer serializer)
     {
         var type = serializer.SerializeType(""C"", 1);
         type.SerializeField(""RDictionary"", new IDictWrap<string, StringWrap, int, Int32Wrap>(RDictionary));
@@ -401,7 +401,7 @@ public struct SWrap : ISerialize
     {
         _s = s;
     }
-    void ISerialize.Serialize<TSerializer, _1, _2, _3>(ref TSerializer serializer)
+    void ISerialize.Serialize(ISerializer serializer)
     {
         serializer.Serialize(_s.X);
         serializer.Serialize(_s.Y);
@@ -418,7 +418,7 @@ using Serde;
 
 partial class C : Serde.ISerialize
 {
-    void Serde.ISerialize.Serialize<TSerializer, TSerializeType, TSerializeEnumerable, TSerializeDictionary>(ref TSerializer serializer)
+    void Serde.ISerialize.Serialize(ISerializer serializer)
     {
         var type = serializer.SerializeType(""C"", 1);
         type.SerializeField(""S"", new SWrap(S));
@@ -450,7 +450,7 @@ public struct SWrap<T, TWrap> : ISerialize, IWrap<S<T>, SWrap<T, TWrap>>
     {
         _s = s;
     }
-    void ISerialize.Serialize<TSerializer, _1, _2, _3>(ref TSerializer serializer)
+    void ISerialize.Serialize(ISerializer serializer)
     {
         var type = serializer.SerializeType(""S"", 1);
         var d = default(TWrap);
@@ -469,7 +469,7 @@ using Serde;
 
 partial class C : Serde.ISerialize
 {
-    void Serde.ISerialize.Serialize<TSerializer, TSerializeType, TSerializeEnumerable, TSerializeDictionary>(ref TSerializer serializer)
+    void Serde.ISerialize.Serialize(ISerializer serializer)
     {
         var type = serializer.SerializeType(""C"", 1);
         type.SerializeField(""S"", new SWrap<int, Int32Wrap>(S));

--- a/test/JsonFsCheck.cs
+++ b/test/JsonFsCheck.cs
@@ -58,7 +58,7 @@ namespace Serde.Test
                 var localName = "t" + i;
                 serializeStatements.Add($"var {localName} = new TestCase{i}.Class0();");
                 serializeStatements.Add($@"results.Add(
-(Serde.JsonSerializer.Serialize({localName}),
+(Serde.Json.JsonSerializer.Serialize({localName}),
  System.Text.Json.JsonSerializer.Serialize({localName}, options)));");
             }
             serializeStatements.Add("return results;");

--- a/test/JsonSerializerTests.cs
+++ b/test/JsonSerializerTests.cs
@@ -3,6 +3,7 @@ using System.Collections.Immutable;
 using System.IO;
 using System.Text;
 using System.Text.Json;
+using Serde.Json;
 using Xunit;
 
 namespace Serde.Test
@@ -21,7 +22,7 @@ namespace Serde.Test
 
         private void VerifyJsonSource(JsonNode node, string expected)
         {
-            var actual = JsonSerializer.Serialize(node);
+            var actual = Serde.Json.JsonSerializer.Serialize(node);
             Assert.Equal(expected.Trim(), PrettyPrint(actual));
         }
 
@@ -86,19 +87,29 @@ namespace Serde.Test
 ]");
         }
 
-        private struct JsonDictionaryWrapper : ISerialize
+        private struct JsonDictionaryWrapper : ISerialize, ISerializeStatic
         {
             private readonly Dictionary<int, int> _d;
             public JsonDictionaryWrapper(Dictionary<int, int> d)
             {
                 _d = d;
             }
-
             public void Serialize<TSerializer, TSerializeType, TSerializeEnumerable, TSerializeDictionary>(ref TSerializer serializer)
-                where TSerializer : ISerializer<TSerializeType, TSerializeEnumerable, TSerializeDictionary>
-                where TSerializeType : ISerializeType
-                where TSerializeEnumerable : ISerializeEnumerable
-                where TSerializeDictionary : ISerializeDictionary
+                where TSerializer : ISerializerStatic<TSerializeType, TSerializeEnumerable, TSerializeDictionary>
+                where TSerializeType : ISerializeTypeStatic
+                where TSerializeEnumerable : ISerializeEnumerableStatic
+                where TSerializeDictionary : ISerializeDictionaryStatic
+            {
+                var sd = serializer.SerializeDictionary(_d.Count);
+                foreach (var (k,v) in _d)
+                {
+                    sd.SerializeKey(new StringWrap(k.ToString()));
+                    sd.SerializeValue(new Int32Wrap(v));
+                }
+                sd.End();
+            }
+
+            void ISerialize.Serialize(ISerializer serializer)
             {
                 var sd = serializer.SerializeDictionary(_d.Count);
                 foreach (var (k,v) in _d)
@@ -118,7 +129,7 @@ namespace Serde.Test
                 [3] = 5,
                 [1] = 10
             };
-            var js = JsonSerializer.Serialize(new JsonDictionaryWrapper(d));
+            var js = Serde.Json.JsonSerializer.Serialize(new JsonDictionaryWrapper(d));
             var resultDict = System.Text.Json.JsonSerializer.Deserialize<Dictionary<int, int>>(js)!;
             Assert.Equal(d.Count, resultDict.Count);
             foreach (var (k, v) in resultDict)


### PR DESCRIPTION
There are serious limitations in the readability of the generics used in
the existing Serde model. Using boxed interfaces and dynamic dispatch is
clearer, at the potential expense of performance.

The previous implementation has been moved to a new interface hierarchy, `ISerializeStatic`.
Source generator support for `ISerializeStatic` can be added back later.