### PR TITLE
Add support for automatically serializing and deserializing enums

### DIFF
--- a/src/generator/ConfigOptions.cs
+++ b/src/generator/ConfigOptions.cs
@@ -1,13 +1,13 @@
 
 namespace Serde;
 
-internal readonly record struct TypeOptions
+internal readonly record struct TypeOptions()
 {
     public bool DenyUnknownMembers { get; init; } = false;
     public MemberFormat MemberFormat { get; init; } = MemberFormat.None;
 }
 
-internal readonly record struct MemberOptions
+internal readonly record struct MemberOptions()
 {
     public bool NullIfMissing { get; init; } = false;
 }

--- a/src/generator/Diagnostics.cs
+++ b/src/generator/Diagnostics.cs
@@ -6,7 +6,7 @@ namespace Serde
 {
     internal enum DiagId
     {
-        ERR_DoesntImplementISerializable = 1,
+        ERR_DoesntImplementInterface = 1,
         ERR_TypeNotPartial = 2,
         ERR_CantWrapSpecialType = 3
     }
@@ -20,7 +20,7 @@ namespace Serde
     {
         public static string GetName(this DiagId id) => id switch
         {
-            ERR_DoesntImplementISerializable => nameof(ERR_DoesntImplementISerializable),
+            ERR_DoesntImplementInterface => nameof(ERR_DoesntImplementInterface),
             ERR_TypeNotPartial => nameof(ERR_TypeNotPartial),
             ERR_CantWrapSpecialType => nameof(ERR_CantWrapSpecialType),
             _ => throw ExceptionUtilities.Unreachable

--- a/src/generator/Generator.Impl.cs
+++ b/src/generator/Generator.Impl.cs
@@ -49,11 +49,6 @@ namespace Serde
             ExpressionSyntax receiverExpr,
             GeneratorExecutionContext context)
         {
-            if (receiverType.TypeKind == TypeKind.Enum)
-            {
-                return;
-            }
-
             var typeName = typeDeclContext.Name;
             string fullTypeName = string.Join(".", typeDeclContext.NamespaceNames
                 .Concat(typeDeclContext.ParentTypeInfo.Select(x => x.Name))

--- a/src/generator/Resources.resx
+++ b/src/generator/Resources.resx
@@ -117,8 +117,8 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="ERR_DoesntImplementISerializable" xml:space="preserve">
-    <value>The member '{0}'s return type '{1}' doesn't implement Serde.ISerializable. Either implement the interface, or use a wrapper.</value>
+  <data name="ERR_DoesntImplementInterface" xml:space="preserve">
+    <value>The member '{0}'s return type '{1}' doesn't implement {2}. Either implement the interface, or use a wrapper.</value>
   </data>
   <data name="ERR_TypeNotPartial" xml:space="preserve">
     <value>The type '{0}' has the `[GenerateSerializeAttribute]` applied, but the implementation can't be generated unless the type is marked 'partial'.</value>

--- a/src/generator/SerdeGenerator.csproj
+++ b/src/generator/SerdeGenerator.csproj
@@ -9,6 +9,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.0.0-6.final" PrivateAssets="all" />
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.2" PrivateAssets="all" />
+    <PackageReference Include="StaticCs" Version="0.1.0" />
   </ItemGroup>
 
   <!-- Include analyzer in NuGet package -->

--- a/src/generator/SymbolUtilities.cs
+++ b/src/generator/SymbolUtilities.cs
@@ -3,6 +3,8 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace Serde
 {
@@ -27,6 +29,8 @@ namespace Serde
                 })
                 .Select(m => new DataMemberSymbol(m, format)).ToList();
         }
+
+        public static TypeSyntax ToFqnSyntax(this INamedTypeSymbol t) => SyntaxFactory.ParseTypeName(t.ToDisplayString());
 
         internal static TypeOptions GetTypeOptions(ITypeSymbol type)
         {

--- a/src/serde-dn/ISerialize.cs
+++ b/src/serde-dn/ISerialize.cs
@@ -1,61 +1,61 @@
-﻿namespace Serde
+﻿namespace Serde;
+
+public interface ISerialize
 {
-    public interface ISerialize
-    {
-        void Serialize<TSerializer, TSerializeType, TSerializeEnumerable, TSerializeDictionary>(ref TSerializer serializer)
-            where TSerializeType : ISerializeType
-            where TSerializeEnumerable : ISerializeEnumerable
-            where TSerializeDictionary : ISerializeDictionary
-            where TSerializer : ISerializer<TSerializeType, TSerializeEnumerable, TSerializeDictionary>;
-    }
-
-    public interface ISerializeType
-    {
-        void SerializeField<T>(string name, T value) where T : ISerialize;
-        void End();
-        void SkipField(string name) { }
-    }
-
-    public interface ISerializeEnumerable
-    {
-        void SerializeElement<T>(T value) where T : ISerialize;
-        void End();
-    }
-
-    public interface ISerializeDictionary
-    {
-        void SerializeKey<T>(T key) where T : ISerialize;
-        void SerializeValue<T>(T value) where T : ISerialize;
-        void End();
-    }
-
-    public interface ISerializer<
-        out TSerializeType,
-        out TSerializeEnumerable,
-        out TSerializeDictionary
-        >
+    void Serialize<TSerializer, TSerializeType, TSerializeEnumerable, TSerializeDictionary>(ref TSerializer serializer)
         where TSerializeType : ISerializeType
         where TSerializeEnumerable : ISerializeEnumerable
         where TSerializeDictionary : ISerializeDictionary
-    {
-        void SerializeBool(bool b);
-        void SerializeChar(char c);
-        void SerializeByte(byte b);
-        void SerializeU16(ushort u16);
-        void SerializeU32(uint u32);
-        void SerializeU64(ulong u64);
-        void SerializeSByte(sbyte b);
-        void SerializeI16(short i16);
-        void SerializeI32(int i32);
-        void SerializeI64(long i64);
-        void SerializeFloat(float f);
-        void SerializeDouble(double d);
-        void SerializeString(string s);
-        void SerializeNull();
-        void SerializeNotNull<T>(T t) where T : notnull, ISerialize;
+        where TSerializer : ISerializer<TSerializeType, TSerializeEnumerable, TSerializeDictionary>;
+}
 
-        TSerializeType SerializeType(string name, int numFields);
-        TSerializeEnumerable SerializeEnumerable(int? length);
-        TSerializeDictionary SerializeDictionary(int? length);
-    }
+public interface ISerializeType
+{
+    void SerializeField<T>(string name, T value) where T : ISerialize;
+    void End();
+    void SkipField(string name) { }
+}
+
+public interface ISerializeEnumerable
+{
+    void SerializeElement<T>(T value) where T : ISerialize;
+    void End();
+}
+
+public interface ISerializeDictionary
+{
+    void SerializeKey<T>(T key) where T : ISerialize;
+    void SerializeValue<T>(T value) where T : ISerialize;
+    void End();
+}
+
+public interface ISerializer<
+    out TSerializeType,
+    out TSerializeEnumerable,
+    out TSerializeDictionary
+    >
+    where TSerializeType : ISerializeType
+    where TSerializeEnumerable : ISerializeEnumerable
+    where TSerializeDictionary : ISerializeDictionary
+{
+    void SerializeBool(bool b);
+    void SerializeChar(char c);
+    void SerializeByte(byte b);
+    void SerializeU16(ushort u16);
+    void SerializeU32(uint u32);
+    void SerializeU64(ulong u64);
+    void SerializeSByte(sbyte b);
+    void SerializeI16(short i16);
+    void SerializeI32(int i32);
+    void SerializeI64(long i64);
+    void SerializeFloat(float f);
+    void SerializeDouble(double d);
+    void SerializeString(string s);
+    void SerializeNull();
+    void SerializeNotNull<T>(T t) where T : notnull, ISerialize;
+    void SerializeEnumValue<T>(string enumName, string? valueName, T value) where T : notnull, ISerialize;
+
+    TSerializeType SerializeType(string name, int numFields);
+    TSerializeEnumerable SerializeEnumerable(int? length);
+    TSerializeDictionary SerializeDictionary(int? length);
 }

--- a/src/serde-dn/SerdeDn.csproj
+++ b/src/serde-dn/SerdeDn.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <EnablePreviewFeatures>true</EnablePreviewFeatures>
   </PropertyGroup>
@@ -21,6 +21,9 @@
   <ItemGroup>
     <ProjectReference Include="../generator/SerdeGenerator.csproj" ReferenceOutputAssembly="false" />
     <None Include="$(BaseOutputPath)/../SerdeGenerator/Release/netstandard2.0/SerdeGenerator.dll" Pack="true" PackagePath="analyzers/dotnet/cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="StaticCs" Version="0.1.0" />
   </ItemGroup>
 
 </Project>

--- a/src/serde-dn/json/JsonSerializerImpl.cs
+++ b/src/serde-dn/json/JsonSerializerImpl.cs
@@ -52,6 +52,15 @@ namespace Serde.Json
             t.Serialize<JsonSerializerImpl, SerializeType, SerializeEnumerable, SerializeDictionary>(ref this);
         }
 
+        public void SerializeEnumValue<T>(string enumName, string? valueName, T value) where T : notnull, ISerialize
+        {
+            if (valueName is null)
+            {
+                throw new InvalidOperationException($"Cannot serialize unnamed enum value '{value}' of enum '{enumName}'");
+            }
+            _writer.WriteStringValue(valueName);
+        }
+
         public SerializeType SerializeType(string name, int numFields)
         {
             _writer.WriteStartObject();
@@ -177,6 +186,9 @@ namespace Serde.Json
             {
                 StringResult = s;
             }
+
+            public void SerializeEnumValue<T>(string enumName, string? valueName, T value) where T : notnull, ISerialize
+                => throw new KeyNotStringException();
 
             public ISerializeDictionary SerializeDictionary(int? length) => throw new KeyNotStringException();
 

--- a/test/AllInOneJsonTest.cs
+++ b/test/AllInOneJsonTest.cs
@@ -16,7 +16,8 @@ namespace Serde.Test
             var allInOnePath = Path.Combine(Path.GetDirectoryName(curPath)!, "AllInOneSrc.cs");
 
             var src = File.ReadAllText(allInOnePath);
-            var serializeSrc = @"
+            var serializeSrc = """
+
 #nullable enable
 using Serde;
 
@@ -26,25 +27,27 @@ namespace Serde.Test
     {
         void Serde.ISerialize.Serialize<TSerializer, TSerializeType, TSerializeEnumerable, TSerializeDictionary>(ref TSerializer serializer)
         {
-            var type = serializer.SerializeType(""AllInOne"", 14);
-            type.SerializeField(""BoolField"", new BoolWrap(this.BoolField));
-            type.SerializeField(""CharField"", new CharWrap(this.CharField));
-            type.SerializeField(""ByteField"", new ByteWrap(this.ByteField));
-            type.SerializeField(""UShortField"", new UInt16Wrap(this.UShortField));
-            type.SerializeField(""UIntField"", new UInt32Wrap(this.UIntField));
-            type.SerializeField(""ULongField"", new UInt64Wrap(this.ULongField));
-            type.SerializeField(""SByteField"", new SByteWrap(this.SByteField));
-            type.SerializeField(""ShortField"", new Int16Wrap(this.ShortField));
-            type.SerializeField(""IntField"", new Int32Wrap(this.IntField));
-            type.SerializeField(""LongField"", new Int64Wrap(this.LongField));
-            type.SerializeField(""StringField"", new StringWrap(this.StringField));
-            type.SerializeField(""IntArr"", new ArrayWrap.SerializeImpl<int, Int32Wrap>(this.IntArr));
-            type.SerializeField(""NestedArr"", new ArrayWrap.SerializeImpl<int[], ArrayWrap.SerializeImpl<int, Int32Wrap>>(this.NestedArr));
-            type.SerializeField(""IntImm"", new ImmutableArrayWrap.SerializeImpl<int, Int32Wrap>(this.IntImm));
+            var type = serializer.SerializeType("AllInOne", 15);
+            type.SerializeField("BoolField", new BoolWrap(this.BoolField));
+            type.SerializeField("CharField", new CharWrap(this.CharField));
+            type.SerializeField("ByteField", new ByteWrap(this.ByteField));
+            type.SerializeField("UShortField", new UInt16Wrap(this.UShortField));
+            type.SerializeField("UIntField", new UInt32Wrap(this.UIntField));
+            type.SerializeField("ULongField", new UInt64Wrap(this.ULongField));
+            type.SerializeField("SByteField", new SByteWrap(this.SByteField));
+            type.SerializeField("ShortField", new Int16Wrap(this.ShortField));
+            type.SerializeField("IntField", new Int32Wrap(this.IntField));
+            type.SerializeField("LongField", new Int64Wrap(this.LongField));
+            type.SerializeField("StringField", new StringWrap(this.StringField));
+            type.SerializeField("IntArr", new ArrayWrap.SerializeImpl<int, Int32Wrap>(this.IntArr));
+            type.SerializeField("NestedArr", new ArrayWrap.SerializeImpl<int[], ArrayWrap.SerializeImpl<int, Int32Wrap>>(this.NestedArr));
+            type.SerializeField("IntImm", new ImmutableArrayWrap.SerializeImpl<int, Int32Wrap>(this.IntImm));
+            type.SerializeField("Color", new AllInOneColorEnumWrap(this.Color));
             type.End();
         }
     }
-}";
+}
+""";
             var deserializeSrc = @"
 #nullable enable
 using Serde;
@@ -56,7 +59,7 @@ namespace Serde.Test
         static Serde.Test.AllInOne Serde.IDeserialize<Serde.Test.AllInOne>.Deserialize<D>(ref D deserializer)
         {
             var visitor = new SerdeVisitor();
-            var fieldNames = new[]{""BoolField"", ""CharField"", ""ByteField"", ""UShortField"", ""UIntField"", ""ULongField"", ""SByteField"", ""ShortField"", ""IntField"", ""LongField"", ""StringField"", ""IntArr"", ""NestedArr"", ""IntImm""};
+            var fieldNames = new[]{""BoolField"", ""CharField"", ""ByteField"", ""UShortField"", ""UIntField"", ""ULongField"", ""SByteField"", ""ShortField"", ""IntField"", ""LongField"", ""StringField"", ""IntArr"", ""NestedArr"", ""IntImm"", ""Color""};
             return deserializer.DeserializeType<Serde.Test.AllInOne, SerdeVisitor>(""AllInOne"", fieldNames, visitor);
         }
 
@@ -79,6 +82,7 @@ namespace Serde.Test
                 Serde.Option<int[]> intarr = default;
                 Serde.Option<int[][]> nestedarr = default;
                 Serde.Option<System.Collections.Immutable.ImmutableArray<int>> intimm = default;
+                Serde.Option<Serde.Test.AllInOne.ColorEnum> color = default;
                 while (d.TryGetNextKey<string, StringWrap>(out string? key))
                 {
                     switch (key)
@@ -125,13 +129,16 @@ namespace Serde.Test
                         case ""IntImm"":
                             intimm = d.GetNextValue<System.Collections.Immutable.ImmutableArray<int>, ImmutableArrayWrap.DeserializeImpl<int, Int32Wrap>>();
                             break;
+                        case ""Color"":
+                            color = d.GetNextValue<Serde.Test.AllInOne.ColorEnum, AllInOneColorEnumWrap>();
+                            break;
                         default:
                             break;
                     }
                 }
 
                 Serde.Test.AllInOne newType = new Serde.Test.AllInOne()
-                {BoolField = boolfield.GetValueOrThrow(""BoolField""), CharField = charfield.GetValueOrThrow(""CharField""), ByteField = bytefield.GetValueOrThrow(""ByteField""), UShortField = ushortfield.GetValueOrThrow(""UShortField""), UIntField = uintfield.GetValueOrThrow(""UIntField""), ULongField = ulongfield.GetValueOrThrow(""ULongField""), SByteField = sbytefield.GetValueOrThrow(""SByteField""), ShortField = shortfield.GetValueOrThrow(""ShortField""), IntField = intfield.GetValueOrThrow(""IntField""), LongField = longfield.GetValueOrThrow(""LongField""), StringField = stringfield.GetValueOrThrow(""StringField""), IntArr = intarr.GetValueOrThrow(""IntArr""), NestedArr = nestedarr.GetValueOrThrow(""NestedArr""), IntImm = intimm.GetValueOrThrow(""IntImm""), };
+                {BoolField = boolfield.GetValueOrThrow(""BoolField""), CharField = charfield.GetValueOrThrow(""CharField""), ByteField = bytefield.GetValueOrThrow(""ByteField""), UShortField = ushortfield.GetValueOrThrow(""UShortField""), UIntField = uintfield.GetValueOrThrow(""UIntField""), ULongField = ulongfield.GetValueOrThrow(""ULongField""), SByteField = sbytefield.GetValueOrThrow(""SByteField""), ShortField = shortfield.GetValueOrThrow(""ShortField""), IntField = intfield.GetValueOrThrow(""IntField""), LongField = longfield.GetValueOrThrow(""LongField""), StringField = stringfield.GetValueOrThrow(""StringField""), IntArr = intarr.GetValueOrThrow(""IntArr""), NestedArr = nestedarr.GetValueOrThrow(""NestedArr""), IntImm = intimm.GetValueOrThrow(""IntImm""), Color = color.GetValueOrThrow(""Color""), };
                 return newType;
             }
         }
@@ -139,8 +146,80 @@ namespace Serde.Test
 }";
 
             return GeneratorTestUtils.VerifyGeneratedCode(src, new[] {
+                ("Serde.AllInOneColorEnumWrap", @"
+using ColorEnum = Serde.Test.AllInOne.ColorEnum;
+
+namespace Serde
+{
+    internal readonly partial record struct AllInOneColorEnumWrap(ColorEnum Value);
+}"),
+                ("Serde.AllInOneColorEnumWrap.ISerialize", """
+
+#nullable enable
+using Serde;
+
+namespace Serde
+{
+    partial record struct AllInOneColorEnumWrap : Serde.ISerialize
+    {
+        void Serde.ISerialize.Serialize<TSerializer, TSerializeType, TSerializeEnumerable, TSerializeDictionary>(ref TSerializer serializer)
+        {
+            var name = Value switch
+            {
+                Serde.Test.AllInOne.ColorEnum.Red => "Red",
+                Serde.Test.AllInOne.ColorEnum.Blue => "Blue",
+                Serde.Test.AllInOne.ColorEnum.Green => "Green",
+                _ => null
+            };
+            serializer.SerializeEnumValue("ColorEnum", name, new Int32Wrap((int)Value));
+        }
+    }
+}
+"""),
                 ("Serde.Test.AllInOne.ISerialize", serializeSrc),
-                ("Serde.Test.AllInOne.IDeserialize", deserializeSrc)
+                ("Serde.AllInOneColorEnumWrap.IDeserialize", """
+
+#nullable enable
+using Serde;
+
+namespace Serde
+{
+    partial record struct AllInOneColorEnumWrap : Serde.IDeserialize<Serde.Test.AllInOne.ColorEnum>
+    {
+        static Serde.Test.AllInOne.ColorEnum Serde.IDeserialize<Serde.Test.AllInOne.ColorEnum>.Deserialize<D>(ref D deserializer)
+        {
+            var visitor = new SerdeVisitor();
+            return deserializer.DeserializeString<Serde.Test.AllInOne.ColorEnum, SerdeVisitor>(visitor);
+        }
+
+        private sealed class SerdeVisitor : Serde.IDeserializeVisitor<Serde.Test.AllInOne.ColorEnum>
+        {
+            public string ExpectedTypeName => "Serde.Test.AllInOne.ColorEnum";
+            Serde.Test.AllInOne.ColorEnum Serde.IDeserializeVisitor<Serde.Test.AllInOne.ColorEnum>.VisitString(string s)
+            {
+                Serde.Test.AllInOne.ColorEnum enumValue;
+                switch (s)
+                {
+                    case "Red":
+                        enumValue = Serde.Test.AllInOne.ColorEnum.Red;
+                        break;
+                    case "Blue":
+                        enumValue = Serde.Test.AllInOne.ColorEnum.Blue;
+                        break;
+                    case "Green":
+                        enumValue = Serde.Test.AllInOne.ColorEnum.Green;
+                        break;
+                    default:
+                        throw new InvalidDeserializeValueException("Unexpected enum field name: " + s);
+                }
+
+                return enumValue;
+            }
+        }
+    }
+}
+"""),
+                ("Serde.Test.AllInOne.IDeserialize", deserializeSrc),
             });
 
             static string GetPath([CallerFilePath] string path = "") => path;
@@ -175,7 +254,8 @@ namespace Serde.Test
   ""IntImm"": [
     1,
     2
-  ]
+  ],
+  ""Color"": ""Blue""
 }";
         private static readonly AllInOne Deserialized = new AllInOne()
         {

--- a/test/AllInOneSrc.cs
+++ b/test/AllInOneSrc.cs
@@ -30,6 +30,15 @@ namespace Serde.Test
 
         public ImmutableArray<int> IntImm;
 
+        public ColorEnum Color = ColorEnum.Blue;
+
+        public enum ColorEnum
+        {
+            Red = 1,
+            Blue = 3,
+            Green = 5
+        }
+
         public bool Equals(AllInOne? other)
         {
             return other is not null &&
@@ -47,7 +56,8 @@ namespace Serde.Test
                 IntArr.AsSpan().SequenceEqual(other.IntArr.AsSpan()) &&
                 NestedArr.AsSpan().SequenceEqual(other.NestedArr.AsSpan(),
                     new Comparer()) &&
-                IntImm.AsSpan().SequenceEqual(other.IntImm.AsSpan());
+                IntImm.AsSpan().SequenceEqual(other.IntImm.AsSpan()); // &&
+                //Color == other.Color;
         }
         private sealed class Comparer : IEqualityComparer<int[]>
         {

--- a/test/Config.cs
+++ b/test/Config.cs
@@ -14,9 +14,9 @@ namespace Serde.Test
     {
         public static ReferenceAssemblies LatestTfRefs =>
 			new ReferenceAssemblies (
-				"net6.0",
-				new PackageIdentity ("Microsoft.NETCore.App.Ref", "6.0.0-preview.7.21368.2"),
-				Path.Combine ("ref", "net6.0"))
+				"net7.0",
+				new PackageIdentity ("Microsoft.NETCore.App.Ref", "7.0.0-preview.4.22229.4"),
+				Path.Combine ("ref", "net7.0"))
 			.WithNuGetConfigFilePath (Path.Combine (
                 GetDirectoryPath(),
                 "..",

--- a/test/GeneratorDeserializeTests.cs
+++ b/test/GeneratorDeserializeTests.cs
@@ -217,6 +217,267 @@ partial struct ArrayField : Serde.IDeserialize<ArrayField>
 }");
         }
 
+        [Fact]
+        public Task EnumMember()
+        {
+            var src = @"
+[Serde.GenerateDeserialize]
+partial class C
+{
+    public ColorInt ColorInt;
+    public ColorByte ColorByte;
+    public ColorLong ColorLong;
+    public ColorULong ColorULong;
+}
+public enum ColorInt { Red = 3, Green = 5, Blue = 7 }
+public enum ColorByte : byte { Red = 3, Green = 5, Blue = 7 }
+public enum ColorLong : long { Red = 3, Green = 5, Blue = 7 }
+public enum ColorULong : ulong { Red = 3, Green = 5, Blue = 7 }
+";
+
+            return VerifyGeneratedCode(src, new[] {
+                ("Serde.ColorIntWrap", @"
+namespace Serde
+{
+    internal readonly partial record struct ColorIntWrap(ColorInt Value);
+}"),
+                ("Serde.ColorIntWrap.IDeserialize", """
+
+#nullable enable
+using Serde;
+
+namespace Serde
+{
+    partial record struct ColorIntWrap : Serde.IDeserialize<ColorInt>
+    {
+        static ColorInt Serde.IDeserialize<ColorInt>.Deserialize<D>(ref D deserializer)
+        {
+            var visitor = new SerdeVisitor();
+            return deserializer.DeserializeString<ColorInt, SerdeVisitor>(visitor);
+        }
+
+        private sealed class SerdeVisitor : Serde.IDeserializeVisitor<ColorInt>
+        {
+            public string ExpectedTypeName => "ColorInt";
+            ColorInt Serde.IDeserializeVisitor<ColorInt>.VisitString(string s)
+            {
+                ColorInt enumValue;
+                switch (s)
+                {
+                    case "Red":
+                        enumValue = ColorInt.Red;
+                        break;
+                    case "Green":
+                        enumValue = ColorInt.Green;
+                        break;
+                    case "Blue":
+                        enumValue = ColorInt.Blue;
+                        break;
+                    default:
+                        throw new InvalidDeserializeValueException("Unexpected enum field name: " + s);
+                }
+
+                return enumValue;
+            }
+        }
+    }
+}
+"""),
+                ("Serde.ColorByteWrap", @"
+namespace Serde
+{
+    internal readonly partial record struct ColorByteWrap(ColorByte Value);
+}"),
+                ("Serde.ColorByteWrap.IDeserialize", """
+
+#nullable enable
+using Serde;
+
+namespace Serde
+{
+    partial record struct ColorByteWrap : Serde.IDeserialize<ColorByte>
+    {
+        static ColorByte Serde.IDeserialize<ColorByte>.Deserialize<D>(ref D deserializer)
+        {
+            var visitor = new SerdeVisitor();
+            return deserializer.DeserializeString<ColorByte, SerdeVisitor>(visitor);
+        }
+
+        private sealed class SerdeVisitor : Serde.IDeserializeVisitor<ColorByte>
+        {
+            public string ExpectedTypeName => "ColorByte";
+            ColorByte Serde.IDeserializeVisitor<ColorByte>.VisitString(string s)
+            {
+                ColorByte enumValue;
+                switch (s)
+                {
+                    case "Red":
+                        enumValue = ColorByte.Red;
+                        break;
+                    case "Green":
+                        enumValue = ColorByte.Green;
+                        break;
+                    case "Blue":
+                        enumValue = ColorByte.Blue;
+                        break;
+                    default:
+                        throw new InvalidDeserializeValueException("Unexpected enum field name: " + s);
+                }
+
+                return enumValue;
+            }
+        }
+    }
+}
+"""),
+                ("Serde.ColorLongWrap", @"
+namespace Serde
+{
+    internal readonly partial record struct ColorLongWrap(ColorLong Value);
+}"),
+                ("Serde.ColorLongWrap.IDeserialize", """
+
+#nullable enable
+using Serde;
+
+namespace Serde
+{
+    partial record struct ColorLongWrap : Serde.IDeserialize<ColorLong>
+    {
+        static ColorLong Serde.IDeserialize<ColorLong>.Deserialize<D>(ref D deserializer)
+        {
+            var visitor = new SerdeVisitor();
+            return deserializer.DeserializeString<ColorLong, SerdeVisitor>(visitor);
+        }
+
+        private sealed class SerdeVisitor : Serde.IDeserializeVisitor<ColorLong>
+        {
+            public string ExpectedTypeName => "ColorLong";
+            ColorLong Serde.IDeserializeVisitor<ColorLong>.VisitString(string s)
+            {
+                ColorLong enumValue;
+                switch (s)
+                {
+                    case "Red":
+                        enumValue = ColorLong.Red;
+                        break;
+                    case "Green":
+                        enumValue = ColorLong.Green;
+                        break;
+                    case "Blue":
+                        enumValue = ColorLong.Blue;
+                        break;
+                    default:
+                        throw new InvalidDeserializeValueException("Unexpected enum field name: " + s);
+                }
+
+                return enumValue;
+            }
+        }
+    }
+}
+"""),
+                ("Serde.ColorULongWrap", @"
+namespace Serde
+{
+    internal readonly partial record struct ColorULongWrap(ColorULong Value);
+}"),
+                ("Serde.ColorULongWrap.IDeserialize", """
+
+#nullable enable
+using Serde;
+
+namespace Serde
+{
+    partial record struct ColorULongWrap : Serde.IDeserialize<ColorULong>
+    {
+        static ColorULong Serde.IDeserialize<ColorULong>.Deserialize<D>(ref D deserializer)
+        {
+            var visitor = new SerdeVisitor();
+            return deserializer.DeserializeString<ColorULong, SerdeVisitor>(visitor);
+        }
+
+        private sealed class SerdeVisitor : Serde.IDeserializeVisitor<ColorULong>
+        {
+            public string ExpectedTypeName => "ColorULong";
+            ColorULong Serde.IDeserializeVisitor<ColorULong>.VisitString(string s)
+            {
+                ColorULong enumValue;
+                switch (s)
+                {
+                    case "Red":
+                        enumValue = ColorULong.Red;
+                        break;
+                    case "Green":
+                        enumValue = ColorULong.Green;
+                        break;
+                    case "Blue":
+                        enumValue = ColorULong.Blue;
+                        break;
+                    default:
+                        throw new InvalidDeserializeValueException("Unexpected enum field name: " + s);
+                }
+
+                return enumValue;
+            }
+        }
+    }
+}
+"""),
+                ("C.IDeserialize", """
+
+#nullable enable
+using Serde;
+
+partial class C : Serde.IDeserialize<C>
+{
+    static C Serde.IDeserialize<C>.Deserialize<D>(ref D deserializer)
+    {
+        var visitor = new SerdeVisitor();
+        var fieldNames = new[]{"ColorInt", "ColorByte", "ColorLong", "ColorULong"};
+        return deserializer.DeserializeType<C, SerdeVisitor>("C", fieldNames, visitor);
+    }
+
+    private sealed class SerdeVisitor : Serde.IDeserializeVisitor<C>
+    {
+        public string ExpectedTypeName => "C";
+        C Serde.IDeserializeVisitor<C>.VisitDictionary<D>(ref D d)
+        {
+            Serde.Option<ColorInt> colorint = default;
+            Serde.Option<ColorByte> colorbyte = default;
+            Serde.Option<ColorLong> colorlong = default;
+            Serde.Option<ColorULong> colorulong = default;
+            while (d.TryGetNextKey<string, StringWrap>(out string? key))
+            {
+                switch (key)
+                {
+                    case "ColorInt":
+                        colorint = d.GetNextValue<ColorInt, ColorIntWrap>();
+                        break;
+                    case "ColorByte":
+                        colorbyte = d.GetNextValue<ColorByte, ColorByteWrap>();
+                        break;
+                    case "ColorLong":
+                        colorlong = d.GetNextValue<ColorLong, ColorLongWrap>();
+                        break;
+                    case "ColorULong":
+                        colorulong = d.GetNextValue<ColorULong, ColorULongWrap>();
+                        break;
+                    default:
+                        break;
+                }
+            }
+
+            C newType = new C()
+            {ColorInt = colorint.GetValueOrThrow("ColorInt"), ColorByte = colorbyte.GetValueOrThrow("ColorByte"), ColorLong = colorlong.GetValueOrThrow("ColorLong"), ColorULong = colorulong.GetValueOrThrow("ColorULong"), };
+            return newType;
+        }
+    }
+}
+"""),
+            });
+        }
+
         private static Task VerifyDeserialize(
             string src,
             string typeName,

--- a/test/GeneratorWrapperTests.cs
+++ b/test/GeneratorWrapperTests.cs
@@ -134,6 +134,7 @@ partial class C
             return VerifyGeneratedCode(src, new[] {
                 ("Serde.BitVector32SectionWrap", @"
 using Section = System.Collections.Specialized.BitVector32.Section;
+
 namespace Serde
 {
     internal readonly partial record struct BitVector32SectionWrap(Section Value);
@@ -184,6 +185,7 @@ partial class C
             return VerifyGeneratedCode(src, new[] {
                 ("Serde.BitVector32SectionWrap", @"
 using Section = System.Collections.Specialized.BitVector32.Section;
+
 namespace Serde
 {
     internal readonly partial record struct BitVector32SectionWrap(Section Value);

--- a/test/Serde.Test.csproj
+++ b/test/Serde.Test.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
     <EnablePreviewFeatures>true</EnablePreviewFeatures>
@@ -19,7 +19,7 @@
   <ItemGroup>
     <PackageReference Include="FsCheck" Version="2.15.3" />
     <PackageReference Include="FsCheck.Xunit" Version="2.15.3" />
-    <PackageReference Include="Microsoft.NETCore.App.Ref" Version="5.0.0">
+    <PackageReference Include="Microsoft.NETCore.App.Ref" Version="7.0.0-preview.4.22229.4">
       <ExcludeAssets>all</ExcludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/test/generated/SerdeGenerator/Serde.Generator/Serde.AllInOneColorEnumWrap.IDeserialize.cs
+++ b/test/generated/SerdeGenerator/Serde.Generator/Serde.AllInOneColorEnumWrap.IDeserialize.cs
@@ -1,0 +1,40 @@
+﻿
+#nullable enable
+using Serde;
+
+namespace Serde
+{
+    partial record struct AllInOneColorEnumWrap : Serde.IDeserialize<Serde.Test.AllInOne.ColorEnum>
+    {
+        static Serde.Test.AllInOne.ColorEnum Serde.IDeserialize<Serde.Test.AllInOne.ColorEnum>.Deserialize<D>(ref D deserializer)
+        {
+            var visitor = new SerdeVisitor();
+            return deserializer.DeserializeString<Serde.Test.AllInOne.ColorEnum, SerdeVisitor>(visitor);
+        }
+
+        private sealed class SerdeVisitor : Serde.IDeserializeVisitor<Serde.Test.AllInOne.ColorEnum>
+        {
+            public string ExpectedTypeName => "Serde.Test.AllInOne.ColorEnum";
+            Serde.Test.AllInOne.ColorEnum Serde.IDeserializeVisitor<Serde.Test.AllInOne.ColorEnum>.VisitString(string s)
+            {
+                Serde.Test.AllInOne.ColorEnum enumValue;
+                switch (s)
+                {
+                    case "Red":
+                        enumValue = Serde.Test.AllInOne.ColorEnum.Red;
+                        break;
+                    case "Blue":
+                        enumValue = Serde.Test.AllInOne.ColorEnum.Blue;
+                        break;
+                    case "Green":
+                        enumValue = Serde.Test.AllInOne.ColorEnum.Green;
+                        break;
+                    default:
+                        throw new InvalidDeserializeValueException("Unexpected enum field name: " + s);
+                }
+
+                return enumValue;
+            }
+        }
+    }
+}

--- a/test/generated/SerdeGenerator/Serde.Generator/Serde.AllInOneColorEnumWrap.ISerialize.cs
+++ b/test/generated/SerdeGenerator/Serde.Generator/Serde.AllInOneColorEnumWrap.ISerialize.cs
@@ -1,0 +1,21 @@
+﻿
+#nullable enable
+using Serde;
+
+namespace Serde
+{
+    partial record struct AllInOneColorEnumWrap : Serde.ISerialize
+    {
+        void Serde.ISerialize.Serialize<TSerializer, TSerializeType, TSerializeEnumerable, TSerializeDictionary>(ref TSerializer serializer)
+        {
+            var name = Value switch
+            {
+                Serde.Test.AllInOne.ColorEnum.Red => "Red",
+                Serde.Test.AllInOne.ColorEnum.Blue => "Blue",
+                Serde.Test.AllInOne.ColorEnum.Green => "Green",
+                _ => null
+            };
+            serializer.SerializeEnumValue("ColorEnum", name, new Int32Wrap((int)Value));
+        }
+    }
+}

--- a/test/generated/SerdeGenerator/Serde.Generator/Serde.AllInOneColorEnumWrap.cs
+++ b/test/generated/SerdeGenerator/Serde.Generator/Serde.AllInOneColorEnumWrap.cs
@@ -1,0 +1,7 @@
+﻿
+using ColorEnum = Serde.Test.AllInOne.ColorEnum;
+
+namespace Serde
+{
+    internal readonly partial record struct AllInOneColorEnumWrap(ColorEnum Value);
+}

--- a/test/generated/SerdeGenerator/Serde.Generator/Serde.Test.AllInOne.IDeserialize.cs
+++ b/test/generated/SerdeGenerator/Serde.Generator/Serde.Test.AllInOne.IDeserialize.cs
@@ -9,7 +9,7 @@ namespace Serde.Test
         static Serde.Test.AllInOne Serde.IDeserialize<Serde.Test.AllInOne>.Deserialize<D>(ref D deserializer)
         {
             var visitor = new SerdeVisitor();
-            var fieldNames = new[]{"BoolField", "CharField", "ByteField", "UShortField", "UIntField", "ULongField", "SByteField", "ShortField", "IntField", "LongField", "StringField", "IntArr", "NestedArr", "IntImm"};
+            var fieldNames = new[]{"BoolField", "CharField", "ByteField", "UShortField", "UIntField", "ULongField", "SByteField", "ShortField", "IntField", "LongField", "StringField", "IntArr", "NestedArr", "IntImm", "Color"};
             return deserializer.DeserializeType<Serde.Test.AllInOne, SerdeVisitor>("AllInOne", fieldNames, visitor);
         }
 
@@ -32,6 +32,7 @@ namespace Serde.Test
                 Serde.Option<int[]> intarr = default;
                 Serde.Option<int[][]> nestedarr = default;
                 Serde.Option<System.Collections.Immutable.ImmutableArray<int>> intimm = default;
+                Serde.Option<Serde.Test.AllInOne.ColorEnum> color = default;
                 while (d.TryGetNextKey<string, StringWrap>(out string? key))
                 {
                     switch (key)
@@ -78,13 +79,16 @@ namespace Serde.Test
                         case "IntImm":
                             intimm = d.GetNextValue<System.Collections.Immutable.ImmutableArray<int>, ImmutableArrayWrap.DeserializeImpl<int, Int32Wrap>>();
                             break;
+                        case "Color":
+                            color = d.GetNextValue<Serde.Test.AllInOne.ColorEnum, AllInOneColorEnumWrap>();
+                            break;
                         default:
                             break;
                     }
                 }
 
                 Serde.Test.AllInOne newType = new Serde.Test.AllInOne()
-                {BoolField = boolfield.GetValueOrThrow("BoolField"), CharField = charfield.GetValueOrThrow("CharField"), ByteField = bytefield.GetValueOrThrow("ByteField"), UShortField = ushortfield.GetValueOrThrow("UShortField"), UIntField = uintfield.GetValueOrThrow("UIntField"), ULongField = ulongfield.GetValueOrThrow("ULongField"), SByteField = sbytefield.GetValueOrThrow("SByteField"), ShortField = shortfield.GetValueOrThrow("ShortField"), IntField = intfield.GetValueOrThrow("IntField"), LongField = longfield.GetValueOrThrow("LongField"), StringField = stringfield.GetValueOrThrow("StringField"), IntArr = intarr.GetValueOrThrow("IntArr"), NestedArr = nestedarr.GetValueOrThrow("NestedArr"), IntImm = intimm.GetValueOrThrow("IntImm"), };
+                {BoolField = boolfield.GetValueOrThrow("BoolField"), CharField = charfield.GetValueOrThrow("CharField"), ByteField = bytefield.GetValueOrThrow("ByteField"), UShortField = ushortfield.GetValueOrThrow("UShortField"), UIntField = uintfield.GetValueOrThrow("UIntField"), ULongField = ulongfield.GetValueOrThrow("ULongField"), SByteField = sbytefield.GetValueOrThrow("SByteField"), ShortField = shortfield.GetValueOrThrow("ShortField"), IntField = intfield.GetValueOrThrow("IntField"), LongField = longfield.GetValueOrThrow("LongField"), StringField = stringfield.GetValueOrThrow("StringField"), IntArr = intarr.GetValueOrThrow("IntArr"), NestedArr = nestedarr.GetValueOrThrow("NestedArr"), IntImm = intimm.GetValueOrThrow("IntImm"), Color = color.GetValueOrThrow("Color"), };
                 return newType;
             }
         }

--- a/test/generated/SerdeGenerator/Serde.Generator/Serde.Test.AllInOne.ISerialize.cs
+++ b/test/generated/SerdeGenerator/Serde.Generator/Serde.Test.AllInOne.ISerialize.cs
@@ -8,7 +8,7 @@ namespace Serde.Test
     {
         void Serde.ISerialize.Serialize<TSerializer, TSerializeType, TSerializeEnumerable, TSerializeDictionary>(ref TSerializer serializer)
         {
-            var type = serializer.SerializeType("AllInOne", 14);
+            var type = serializer.SerializeType("AllInOne", 15);
             type.SerializeField("BoolField", new BoolWrap(this.BoolField));
             type.SerializeField("CharField", new CharWrap(this.CharField));
             type.SerializeField("ByteField", new ByteWrap(this.ByteField));
@@ -23,6 +23,7 @@ namespace Serde.Test
             type.SerializeField("IntArr", new ArrayWrap.SerializeImpl<int, Int32Wrap>(this.IntArr));
             type.SerializeField("NestedArr", new ArrayWrap.SerializeImpl<int[], ArrayWrap.SerializeImpl<int, Int32Wrap>>(this.NestedArr));
             type.SerializeField("IntImm", new ImmutableArrayWrap.SerializeImpl<int, Int32Wrap>(this.IntImm));
+            type.SerializeField("Color", new AllInOneColorEnumWrap(this.Color));
             type.End();
         }
     }


### PR DESCRIPTION
Default behavior for the source generator is to use the string value.
Using the numeric value can be supported later.