### PR TITLE
Remove generic parameters from ISerializer

### DIFF
--- a/src/generator/Generator.Serialize.cs
+++ b/src/generator/Generator.Serialize.cs
@@ -123,13 +123,8 @@ namespace Serde
                 explicitInterfaceSpecifier: ExplicitInterfaceSpecifier(
                     QualifiedName(IdentifierName("Serde"), IdentifierName("ISerialize"))),
                 identifier: Identifier("Serialize"),
-                typeParameterList: TypeParameterList(SeparatedList(new[] {
-                    TypeParameter("TSerializer"),
-                    TypeParameter("TSerializeType"),
-                    TypeParameter("TSerializeEnumerable"),
-                    TypeParameter("TSerializeDictionary")
-                    })),
-                parameterList: ParameterList(SeparatedList(new[] { Parameter("TSerializer", "serializer", byRef: true) })),
+                typeParameterList: null,
+                parameterList: ParameterList(SeparatedList(new[] { Parameter("ISerializer", "serializer") })),
                 constraintClauses: default,
                 body: Block(statements),
                 expressionBody: null)

--- a/src/serde-dn/ISerialize.cs
+++ b/src/serde-dn/ISerialize.cs
@@ -2,11 +2,7 @@
 
 public interface ISerialize
 {
-    void Serialize<TSerializer, TSerializeType, TSerializeEnumerable, TSerializeDictionary>(ref TSerializer serializer)
-        where TSerializeType : ISerializeType
-        where TSerializeEnumerable : ISerializeEnumerable
-        where TSerializeDictionary : ISerializeDictionary
-        where TSerializer : ISerializer<TSerializeType, TSerializeEnumerable, TSerializeDictionary>;
+    void Serialize(ISerializer serializer);
 }
 
 public interface ISerializeType
@@ -29,14 +25,7 @@ public interface ISerializeDictionary
     void End();
 }
 
-public interface ISerializer<
-    out TSerializeType,
-    out TSerializeEnumerable,
-    out TSerializeDictionary
-    >
-    where TSerializeType : ISerializeType
-    where TSerializeEnumerable : ISerializeEnumerable
-    where TSerializeDictionary : ISerializeDictionary
+public interface ISerializer
 {
     void SerializeBool(bool b);
     void SerializeChar(char c);
@@ -55,7 +44,7 @@ public interface ISerializer<
     void SerializeNotNull<T>(T t) where T : notnull, ISerialize;
     void SerializeEnumValue<T>(string enumName, string? valueName, T value) where T : notnull, ISerialize;
 
-    TSerializeType SerializeType(string name, int numFields);
-    TSerializeEnumerable SerializeEnumerable(int? length);
-    TSerializeDictionary SerializeDictionary(int? length);
+    ISerializeType SerializeType(string name, int numFields);
+    ISerializeEnumerable SerializeEnumerable(int? length);
+    ISerializeDictionary SerializeDictionary(int? length);
 }

--- a/src/serde-dn/Wrappers.Dictionary.cs
+++ b/src/serde-dn/Wrappers.Dictionary.cs
@@ -19,7 +19,7 @@ namespace Serde
                 _dict = dict;
             }
 
-            void ISerialize.Serialize<TSerializer, TSerializeType, TSerializeEnumerable, TSerializeDictionary>(ref TSerializer serializer)
+            void ISerialize.Serialize(ISerializer serializer)
             {
                 var sd = serializer.SerializeDictionary(_dict.Count);
                 foreach (var (k, v) in _dict)
@@ -81,7 +81,7 @@ namespace Serde
             public static SerializeImpl<TKey, TKeyWrap, TValue, TValueWrap> Create(IDictionary<TKey, TValue> t)
                 => new SerializeImpl<TKey, TKeyWrap, TValue, TValueWrap>(t);
 
-            void ISerialize.Serialize<TSerializer, TSerializeType, TSerializeEnumerable, TSerializeDictionary>(ref TSerializer serializer)
+            void ISerialize.Serialize(ISerializer serializer)
             {
                 var sd = serializer.SerializeDictionary(Value.Count);
                 foreach (var (k, v) in Value)
@@ -106,7 +106,7 @@ namespace Serde
             public static SerializeImpl<TKey, TKeyWrap, TValue, TValueWrap> Create(IReadOnlyDictionary<TKey, TValue> t)
                 => new SerializeImpl<TKey, TKeyWrap, TValue, TValueWrap>(t);
 
-            void ISerialize.Serialize<TSerializer, TSerializeType, TSerializeEnumerable, TSerializeDictionary>(ref TSerializer serializer)
+            void ISerialize.Serialize(ISerializer serializer)
             {
                 var sd = serializer.SerializeDictionary(Value.Count);
                 foreach (var (k, v) in Value)

--- a/src/serde-dn/Wrappers.List.cs
+++ b/src/serde-dn/Wrappers.List.cs
@@ -9,19 +9,8 @@ namespace Serde
 {
     internal static class EnumerableHelpers
     {
-        public static void SerializeSpan<
-            T,
-            TWrap,
-            TSerializer,
-            TSerializeType,
-            TSerializeEnumerable,
-            TSerializeDictionary
-            >(ReadOnlySpan<T> arr, ref TSerializer serializer)
+        public static void SerializeSpan<T, TWrap>(ReadOnlySpan<T> arr, ISerializer serializer)
             where TWrap : struct, ISerializeWrap<T, TWrap>, ISerialize
-            where TSerializer : ISerializer<TSerializeType, TSerializeEnumerable, TSerializeDictionary>
-            where TSerializeType : ISerializeType
-            where TSerializeEnumerable : ISerializeEnumerable
-            where TSerializeDictionary : ISerializeDictionary
         {
             var enumerable = serializer.SerializeEnumerable(arr.Length);
             foreach (var item in arr)
@@ -32,18 +21,8 @@ namespace Serde
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void SerializeList<
-            T,
-            TWrap,
-            TSerializer,
-            TSerializeType,
-            TSerializeEnumerable,
-            TSerializeDictionary>(List<T> list, ref TSerializer serializer)
+        public static void SerializeList<T, TWrap>(List<T> list, ISerializer serializer)
             where TWrap : struct, ISerializeWrap<T, TWrap>, ISerialize
-            where TSerializer : ISerializer<TSerializeType, TSerializeEnumerable, TSerializeDictionary>
-            where TSerializeType : ISerializeType
-            where TSerializeEnumerable : ISerializeEnumerable
-            where TSerializeDictionary : ISerializeDictionary
         {
             var enumerable = serializer.SerializeEnumerable(list.Count);
             foreach (var item in list)
@@ -55,18 +34,8 @@ namespace Serde
 
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void SerializeIList<
-            T,
-            TWrap,
-            TSerializer,
-            TSerializeType,
-            TSerializeEnumerable,
-            TSerializeDictionary>(IList<T> list, ref TSerializer serializer)
+        public static void SerializeIList<T, TWrap>(IList<T> list, ISerializer serializer)
             where TWrap : struct, ISerializeWrap<T, TWrap>, ISerialize
-            where TSerializer : ISerializer<TSerializeType, TSerializeEnumerable, TSerializeDictionary>
-            where TSerializeType : ISerializeType
-            where TSerializeEnumerable : ISerializeEnumerable
-            where TSerializeDictionary : ISerializeDictionary
         {
             var enumerable = serializer.SerializeEnumerable(list.Count);
             foreach (var item in list)
@@ -82,8 +51,7 @@ namespace Serde
     {
         public static IdWrap<T> Create(T t) => new IdWrap<T>(t);
 
-        void ISerialize.Serialize<TSerializer, Type, Enumerable, Dictionary>(ref TSerializer serializer)
-            => Value.Serialize<TSerializer, Type, Enumerable, Dictionary>(ref serializer);
+        void ISerialize.Serialize(ISerializer serializer) => Value.Serialize(serializer);
     }
 
     public static class ArrayWrap
@@ -94,8 +62,8 @@ namespace Serde
         {
             public static SerializeImpl<T, TWrap> Create(T[] t) => new SerializeImpl<T, TWrap>(t);
 
-            void ISerialize.Serialize<TSerializer, Type, Enumerable, Dictionary>(ref TSerializer serializer)
-                => EnumerableHelpers.SerializeSpan<T, TWrap, TSerializer, Type, Enumerable, Dictionary>(Value, ref serializer);
+            void ISerialize.Serialize(ISerializer serializer)
+                => EnumerableHelpers.SerializeSpan<T, TWrap>(Value, serializer);
         }
 
         public readonly struct DeserializeImpl<T, TWrap> : IDeserialize<T[]>
@@ -146,8 +114,8 @@ namespace Serde
         {
             public static SerializeImpl<T, TWrap> Create(List<T> t) => new SerializeImpl<T, TWrap>(t);
 
-            void ISerialize.Serialize<TSerializer, Type, Enumerable, Dictionary>(ref TSerializer serializer)
-                => EnumerableHelpers.SerializeList<T, TWrap, TSerializer, Type, Enumerable, Dictionary>(Value, ref serializer);
+            void ISerialize.Serialize(ISerializer serializer)
+                => EnumerableHelpers.SerializeList<T, TWrap>(Value, serializer);
         }
 
         public readonly struct DeserializeImpl<T, TWrap> : IDeserialize<List<T>>
@@ -195,8 +163,8 @@ namespace Serde
         {
             public static SerializeImpl<T, TWrap> Create(ImmutableArray<T> t) => new SerializeImpl<T, TWrap>(t);
 
-            void ISerialize.Serialize<TSerializer, Type, Enumerable, Dictionary>(ref TSerializer serializer)
-                => EnumerableHelpers.SerializeSpan<T, TWrap, TSerializer, Type, Enumerable, Dictionary>(Value.AsSpan(), ref serializer);
+            void ISerialize.Serialize(ISerializer serializer)
+                => EnumerableHelpers.SerializeSpan<T, TWrap>(Value.AsSpan(), serializer);
         }
 
         public readonly struct DeserializeImpl<T, TWrap> : IDeserialize<ImmutableArray<T>>

--- a/src/serde-dn/Wrappers.cs
+++ b/src/serde-dn/Wrappers.cs
@@ -25,7 +25,7 @@ namespace Serde
         : ISerializeWrap<bool, BoolWrap>, ISerialize, IDeserialize<bool>
     {
         public static BoolWrap Create(bool t) => new BoolWrap(t);
-        void Serde.ISerialize.Serialize<TSerializer, TSerializeType, TSerializeEnumerable, TSerializeDictionary>(ref TSerializer serializer)
+        void Serde.ISerialize.Serialize(ISerializer serializer)
         {
             serializer.SerializeBool(Value);
         }
@@ -46,7 +46,7 @@ namespace Serde
         : ISerializeWrap<char, CharWrap>, ISerialize, IDeserialize<char>
     {
         public static CharWrap Create(char c) => new CharWrap(c);
-        void Serde.ISerialize.Serialize<TSerializer, TSerializeType, TSerializeEnumerable, TSerializeDictionary>(ref TSerializer serializer)
+        void Serde.ISerialize.Serialize(ISerializer serializer)
         {
             serializer.SerializeChar(Value);
         }
@@ -75,7 +75,7 @@ namespace Serde
         : ISerializeWrap<byte, ByteWrap>, ISerialize, IDeserialize<byte>
     {
         public static ByteWrap Create(byte b) => new ByteWrap(b);
-        void Serde.ISerialize.Serialize<TSerializer, TSerializeType, TSerializeEnumerable, TSerializeDictionary>(ref TSerializer serializer)
+        void Serde.ISerialize.Serialize(ISerializer serializer)
         {
             serializer.SerializeByte(Value);
         }
@@ -103,7 +103,7 @@ namespace Serde
         : ISerializeWrap<ushort, UInt16Wrap>, ISerialize, IDeserialize<ushort>
     {
         public static UInt16Wrap Create(ushort i) => new UInt16Wrap(i);
-        void Serde.ISerialize.Serialize<TSerializer, TSerializeType, TSerializeEnumerable, TSerializeDictionary>(ref TSerializer serializer)
+        void Serde.ISerialize.Serialize(ISerializer serializer)
         {
             serializer.SerializeU16(Value);
         }
@@ -131,7 +131,7 @@ namespace Serde
         : ISerializeWrap<uint, UInt32Wrap>, ISerialize, IDeserialize<uint>
     {
         public static UInt32Wrap Create(uint i) => new UInt32Wrap(i);
-        void Serde.ISerialize.Serialize<TSerializer, TSerializeType, TSerializeEnumerable, TSerializeDictionary>(ref TSerializer serializer)
+        void Serde.ISerialize.Serialize(ISerializer serializer)
         {
             serializer.SerializeU32(Value);
         }
@@ -159,7 +159,7 @@ namespace Serde
         : ISerializeWrap<ulong, UInt64Wrap>, ISerialize, IDeserialize<ulong>
     {
         public static UInt64Wrap Create(ulong i) => new UInt64Wrap(i);
-        void Serde.ISerialize.Serialize<TSerializer, TSerializeType, TSerializeEnumerable, TSerializeDictionary>(ref TSerializer serializer)
+        void Serde.ISerialize.Serialize(ISerializer serializer)
         {
             serializer.SerializeU64(Value);
         }
@@ -187,7 +187,7 @@ namespace Serde
         : ISerializeWrap<sbyte, SByteWrap>, ISerialize, IDeserialize<sbyte>
     {
         public static SByteWrap Create(sbyte i) => new SByteWrap(i);
-        void Serde.ISerialize.Serialize<TSerializer, TSerializeType, TSerializeEnumerable, TSerializeDictionary>(ref TSerializer serializer)
+        void Serde.ISerialize.Serialize(ISerializer serializer)
         {
             serializer.SerializeSByte(Value);
         }
@@ -215,7 +215,7 @@ namespace Serde
         : ISerializeWrap<short, Int16Wrap>, ISerialize, IDeserialize<short>
     {
         public static Int16Wrap Create(short i) => new Int16Wrap(i);
-        void Serde.ISerialize.Serialize<TSerializer, TSerializeType, TSerializeEnumerable, TSerializeDictionary>(ref TSerializer serializer)
+        void Serde.ISerialize.Serialize(ISerializer serializer)
         {
             serializer.SerializeI16(Value);
         }
@@ -243,7 +243,7 @@ namespace Serde
         : ISerializeWrap<int, Int32Wrap>, ISerialize, IDeserialize<int>
     {
         public static Int32Wrap Create(int i) => new Int32Wrap(i);
-        void Serde.ISerialize.Serialize<TSerializer, TSerializeType, TSerializeEnumerable, TSerializeDictionary>(ref TSerializer serializer)
+        void Serde.ISerialize.Serialize(ISerializer serializer)
         {
             serializer.SerializeI32(Value);
         }
@@ -271,7 +271,7 @@ namespace Serde
         : ISerializeWrap<long, Int64Wrap>, ISerialize, IDeserialize<long>
     {
         public static Int64Wrap Create(long i) => new Int64Wrap(i);
-        void Serde.ISerialize.Serialize<TSerializer, TSerializeType, TSerializeEnumerable, TSerializeDictionary>(ref TSerializer serializer)
+        void Serde.ISerialize.Serialize(ISerializer serializer)
         {
             serializer.SerializeI64(Value);
         }
@@ -299,7 +299,7 @@ namespace Serde
         : ISerializeWrap<string, StringWrap>, ISerialize, IDeserialize<string>
     {
         public static StringWrap Create(string s) => new StringWrap(s);
-        void Serde.ISerialize.Serialize<TSerializer, TSerializeType, TSerializeEnumerable, TSerializeDictionary>(ref TSerializer serializer)
+        void Serde.ISerialize.Serialize(ISerializer serializer)
         {
             serializer.SerializeString(Value);
         }
@@ -327,7 +327,7 @@ namespace Serde
         {
             public static SerializeImpl<T, TWrap> Create(T? t) => new SerializeImpl<T, TWrap>(t);
 
-            void ISerialize.Serialize<TSerializer, TSerializeType, TSerializeEnumerable, TSerializeDictionary>(ref TSerializer serializer)
+            void ISerialize.Serialize(ISerializer serializer)
             {
                 if (Value is null)
                 {

--- a/src/serde-dn/json/JsonSerializer.cs
+++ b/src/serde-dn/json/JsonSerializer.cs
@@ -8,7 +8,7 @@ namespace Serde.Json
 {
     public sealed class KeyNotStringException : Exception { }
 
-    public sealed partial class JsonSerializer
+    public sealed partial class JsonSerializer : ISerializer
     {
         /// <summary>
         /// Serialize the given type to a string.
@@ -17,8 +17,8 @@ namespace Serde.Json
         {
             using var bufferWriter = new PooledByteBufferWriter(16 * 1024);
             using var writer = new Utf8JsonWriter(bufferWriter);
-            var serializer = new JsonSerializerImpl(writer);
-            s.Serialize<JsonSerializerImpl, SerializeType, SerializeEnumerable, SerializeDictionary>(ref serializer);
+            var serializer = new JsonSerializer(writer);
+            s.Serialize(serializer);
             writer.Flush();
             return Encoding.UTF8.GetString(bufferWriter.WrittenMemory.Span);
         }

--- a/src/serde-dn/json/JsonValue.Serialize.cs
+++ b/src/serde-dn/json/JsonValue.Serialize.cs
@@ -8,16 +8,12 @@ namespace Serde.Json
 {
     partial record JsonValue : ISerialize
     {
-        public abstract void Serialize<TSerializer, TSerializeType, TSerializeEnumerable, TSerializeDictionary>(ref TSerializer serializer)
-            where TSerializer : ISerializer<TSerializeType, TSerializeEnumerable, TSerializeDictionary>
-            where TSerializeType : ISerializeType
-            where TSerializeEnumerable : ISerializeEnumerable
-            where TSerializeDictionary : ISerializeDictionary;
+        public abstract void Serialize(ISerializer serializer);
 
 
         partial record Number
         {
-            public override void Serialize<TSerializer, TSerializeType, TSerializeEnumerable, TSerializeDictionary>(ref TSerializer serializer)
+            public override void Serialize(ISerializer serializer)
             {
                 serializer.SerializeDouble(Value);
             }
@@ -25,7 +21,7 @@ namespace Serde.Json
 
         partial record Bool
         {
-            public override void Serialize<TSerializer, TSerializeType, TSerializeEnumerable, TSerializeDictionary>(ref TSerializer serializer)
+            public override void Serialize(ISerializer serializer)
             {
                 serializer.SerializeBool(Value);
             }
@@ -33,7 +29,7 @@ namespace Serde.Json
 
         partial record String
         {
-            public override void Serialize<TSerializer, TSerializeType, TSerializeEnumerable, TSerializeDictionary>(ref TSerializer serializer)
+            public override void Serialize(ISerializer serializer)
             {
                 serializer.SerializeString(Value);
             }
@@ -49,7 +45,7 @@ namespace Serde.Json
                 : this(members.ToImmutableDictionary(t => t.FieldName, t => t.Value))
             { }
 
-            public override void Serialize<TSerializer, TSerializeType, TSerializeEnumerable, TSerializeDictionary>(ref TSerializer serializer)
+            public override void Serialize(ISerializer serializer)
             {
                 var type = serializer.SerializeType("", Members.Count);
                 foreach (var (name, node) in Members.OrderBy(kvp => kvp.Key))
@@ -66,7 +62,7 @@ namespace Serde.Json
                 : this(elements.ToImmutableArray())
             { }
 
-            public override void Serialize<TSerializer, TSerializeType, TSerializeEnumerable, TSerializeDictionary>(ref TSerializer serializer)
+            public override void Serialize(ISerializer serializer)
             {
                 var enumerable = serializer.SerializeEnumerable(Elements.Length);
                 foreach (var element in Elements)
@@ -79,7 +75,7 @@ namespace Serde.Json
 
         partial record Null
         {
-            public override void Serialize<TSerializer, TSerializeType, TSerializeEnumerable, TSerializeDictionary>(ref TSerializer serializer)
+            public override void Serialize(ISerializer serializer)
             {
                 serializer.SerializeNull();
             }

--- a/test/AllInOneJsonTest.cs
+++ b/test/AllInOneJsonTest.cs
@@ -25,7 +25,7 @@ namespace Serde.Test
 {
     partial record AllInOne : Serde.ISerialize
     {
-        void Serde.ISerialize.Serialize<TSerializer, TSerializeType, TSerializeEnumerable, TSerializeDictionary>(ref TSerializer serializer)
+        void Serde.ISerialize.Serialize(ISerializer serializer)
         {
             var type = serializer.SerializeType("AllInOne", 15);
             type.SerializeField("BoolField", new BoolWrap(this.BoolField));
@@ -162,7 +162,7 @@ namespace Serde
 {
     partial record struct AllInOneColorEnumWrap : Serde.ISerialize
     {
-        void Serde.ISerialize.Serialize<TSerializer, TSerializeType, TSerializeEnumerable, TSerializeDictionary>(ref TSerializer serializer)
+        void Serde.ISerialize.Serialize(ISerializer serializer)
         {
             var name = Value switch
             {

--- a/test/GeneratorSerializeTests.cs
+++ b/test/GeneratorSerializeTests.cs
@@ -25,7 +25,7 @@ using Serde;
 
 partial struct Rgb : Serde.ISerialize
 {
-    void Serde.ISerialize.Serialize<TSerializer, TSerializeType, TSerializeEnumerable, TSerializeDictionary>(ref TSerializer serializer)
+    void Serde.ISerialize.Serialize(ISerializer serializer)
     {
         var type = serializer.SerializeType(""Rgb"", 3);
         type.SerializeField(""Red"", new ByteWrap(this.Red));
@@ -51,7 +51,7 @@ using Serde;
 
 partial struct S : Serde.ISerialize
 {
-    void Serde.ISerialize.Serialize<TSerializer, TSerializeType, TSerializeEnumerable, TSerializeDictionary>(ref TSerializer serializer)
+    void Serde.ISerialize.Serialize(ISerializer serializer)
     {
         var type = serializer.SerializeType(""S"", 1);
         type.SerializeField(""F"", new NullableRefWrap.SerializeImpl<string, StringWrap>(this.F));
@@ -79,7 +79,7 @@ using Serde;
 
 partial struct S1 : Serde.ISerialize
 {
-    void Serde.ISerialize.Serialize<TSerializer, TSerializeType, TSerializeEnumerable, TSerializeDictionary>(ref TSerializer serializer)
+    void Serde.ISerialize.Serialize(ISerializer serializer)
     {
         var type = serializer.SerializeType(""S1"", 1);
         type.End();
@@ -122,7 +122,7 @@ using Serde;
 
 partial class C : Serde.ISerialize
 {
-    void Serde.ISerialize.Serialize<TSerializer, TSerializeType, TSerializeEnumerable, TSerializeDictionary>(ref TSerializer serializer)
+    void Serde.ISerialize.Serialize(ISerializer serializer)
     {
         var type = serializer.SerializeType(""C"", 1);
         type.SerializeField(""IntArr"", new ArrayWrap.SerializeImpl<int, Int32Wrap>(this.IntArr));
@@ -147,7 +147,7 @@ using Serde;
 
 partial class C : Serde.ISerialize
 {
-    void Serde.ISerialize.Serialize<TSerializer, TSerializeType, TSerializeEnumerable, TSerializeDictionary>(ref TSerializer serializer)
+    void Serde.ISerialize.Serialize(ISerializer serializer)
     {
         var type = serializer.SerializeType(""C"", 1);
         type.SerializeField(""NestedArr"", new ArrayWrap.SerializeImpl<int[], ArrayWrap.SerializeImpl<int, Int32Wrap>>(this.NestedArr));
@@ -172,7 +172,7 @@ using Serde;
 
 partial class C : Serde.ISerialize
 {
-    void Serde.ISerialize.Serialize<TSerializer, TSerializeType, TSerializeEnumerable, TSerializeDictionary>(ref TSerializer serializer)
+    void Serde.ISerialize.Serialize(ISerializer serializer)
     {
         var type = serializer.SerializeType(""C"", 1);
         type.SerializeField(""NestedArr"", new ArrayWrap.SerializeImpl<int[], ArrayWrap.SerializeImpl<int, Int32Wrap>>(this.NestedArr));
@@ -213,7 +213,7 @@ partial class TestCase15
 {
     partial class Class0 : Serde.ISerialize
     {
-        void Serde.ISerialize.Serialize<TSerializer, TSerializeType, TSerializeEnumerable, TSerializeDictionary>(ref TSerializer serializer)
+        void Serde.ISerialize.Serialize(ISerializer serializer)
         {
             var type = serializer.SerializeType(""Class0"", 2);
             type.SerializeField(""Field0"", new ArrayWrap.SerializeImpl<TestCase15.Class1, IdWrap<TestCase15.Class1>>(this.Field0));
@@ -230,7 +230,7 @@ partial class TestCase15
 {
     partial class Class1 : Serde.ISerialize
     {
-        void Serde.ISerialize.Serialize<TSerializer, TSerializeType, TSerializeEnumerable, TSerializeDictionary>(ref TSerializer serializer)
+        void Serde.ISerialize.Serialize(ISerializer serializer)
         {
             var type = serializer.SerializeType(""Class1"", 2);
             type.SerializeField(""Field0"", new Int32Wrap(this.Field0));
@@ -265,7 +265,7 @@ using Serde;
 
 partial class C : Serde.ISerialize
 {
-    void Serde.ISerialize.Serialize<TSerializer, TSerializeType, TSerializeEnumerable, TSerializeDictionary>(ref TSerializer serializer)
+    void Serde.ISerialize.Serialize(ISerializer serializer)
     {
         var type = serializer.SerializeType(""C"", 1);
         type.SerializeField(""Map"", new DictWrap.SerializeImpl<string, StringWrap, int, Int32Wrap>(this.Map));
@@ -301,7 +301,7 @@ using Serde;
 
 partial record C : Serde.ISerialize
 {
-    void Serde.ISerialize.Serialize<TSerializer, TSerializeType, TSerializeEnumerable, TSerializeDictionary>(ref TSerializer serializer)
+    void Serde.ISerialize.Serialize(ISerializer serializer)
     {
         var type = serializer.SerializeType(""C"", 1);
         type.SerializeField(""X"", new Int32Wrap(this.X));
@@ -314,7 +314,7 @@ using Serde;
 
 partial class C2 : Serde.ISerialize
 {
-    void Serde.ISerialize.Serialize<TSerializer, TSerializeType, TSerializeEnumerable, TSerializeDictionary>(ref TSerializer serializer)
+    void Serde.ISerialize.Serialize(ISerializer serializer)
     {
         var type = serializer.SerializeType(""C2"", 1);
         type.SerializeField(""Map"", new DictWrap.SerializeImpl<string, StringWrap, C, IdWrap<C>>(this.Map));
@@ -411,7 +411,7 @@ using Serde;
 
 partial class C : Serde.ISerialize
 {
-    void Serde.ISerialize.Serialize<TSerializer, TSerializeType, TSerializeEnumerable, TSerializeDictionary>(ref TSerializer serializer)
+    void Serde.ISerialize.Serialize(ISerializer serializer)
     {
         var type = serializer.SerializeType(""C"", 1);
         type.SerializeField(""RDictionary"", new IDictWrap.SerializeImpl<string, StringWrap, int, Int32Wrap>(this.RDictionary));
@@ -443,7 +443,7 @@ public struct SWrap : ISerialize
     {
         _s = s;
     }
-    void ISerialize.Serialize<TSerializer, TSerializeType, TSerializeEnumerable, TSerializeDictionary>(ref TSerializer serializer)
+    void ISerialize.Serialize(ISerializer serializer)
     {
         serializer.SerializeI32(_s.X);
         serializer.SerializeI32(_s.Y);
@@ -461,7 +461,7 @@ using Serde;
 
 partial class C : Serde.ISerialize
 {
-    void Serde.ISerialize.Serialize<TSerializer, TSerializeType, TSerializeEnumerable, TSerializeDictionary>(ref TSerializer serializer)
+    void Serde.ISerialize.Serialize(ISerializer serializer)
     {
         var type = serializer.SerializeType(""C"", 1);
         type.SerializeField(""S"", new SWrap(this.S));
@@ -493,7 +493,7 @@ public struct SWrap<T, TWrap> : ISerialize, ISerializeWrap<S<T>, SWrap<T, TWrap>
     {
         _s = s;
     }
-    void ISerialize.Serialize<TSerializer, TSerializeType, TSerializeEnumerable, TSerializeDictionary>(ref TSerializer serializer)
+    void ISerialize.Serialize(ISerializer serializer)
     {
         var type = serializer.SerializeType(""S"", 1);
         type.SerializeField(""S"", TWrap.Create(_s.Field));
@@ -512,7 +512,7 @@ using Serde;
 
 partial class C : Serde.ISerialize
 {
-    void Serde.ISerialize.Serialize<TSerializer, TSerializeType, TSerializeEnumerable, TSerializeDictionary>(ref TSerializer serializer)
+    void Serde.ISerialize.Serialize(ISerializer serializer)
     {
         var type = serializer.SerializeType(""C"", 1);
         type.SerializeField(""S"", new SWrap<int, Int32Wrap>(this.S));
@@ -554,7 +554,7 @@ namespace Serde
 {
     partial record struct ColorIntWrap : Serde.ISerialize
     {
-        void Serde.ISerialize.Serialize<TSerializer, TSerializeType, TSerializeEnumerable, TSerializeDictionary>(ref TSerializer serializer)
+        void Serde.ISerialize.Serialize(ISerializer serializer)
         {
             var name = Value switch
             {
@@ -582,7 +582,7 @@ namespace Serde
 {
     partial record struct ColorByteWrap : Serde.ISerialize
     {
-        void Serde.ISerialize.Serialize<TSerializer, TSerializeType, TSerializeEnumerable, TSerializeDictionary>(ref TSerializer serializer)
+        void Serde.ISerialize.Serialize(ISerializer serializer)
         {
             var name = Value switch
             {
@@ -610,7 +610,7 @@ namespace Serde
 {
     partial record struct ColorLongWrap : Serde.ISerialize
     {
-        void Serde.ISerialize.Serialize<TSerializer, TSerializeType, TSerializeEnumerable, TSerializeDictionary>(ref TSerializer serializer)
+        void Serde.ISerialize.Serialize(ISerializer serializer)
         {
             var name = Value switch
             {
@@ -638,7 +638,7 @@ namespace Serde
 {
     partial record struct ColorULongWrap : Serde.ISerialize
     {
-        void Serde.ISerialize.Serialize<TSerializer, TSerializeType, TSerializeEnumerable, TSerializeDictionary>(ref TSerializer serializer)
+        void Serde.ISerialize.Serialize(ISerializer serializer)
         {
             var name = Value switch
             {
@@ -659,7 +659,7 @@ using Serde;
 
 partial class C : Serde.ISerialize
 {
-    void Serde.ISerialize.Serialize<TSerializer, TSerializeType, TSerializeEnumerable, TSerializeDictionary>(ref TSerializer serializer)
+    void Serde.ISerialize.Serialize(ISerializer serializer)
     {
         var type = serializer.SerializeType("C", 4);
         type.SerializeField("ColorInt", new ColorIntWrap(this.ColorInt));

--- a/test/GeneratorWrapperTests.cs
+++ b/test/GeneratorWrapperTests.cs
@@ -69,7 +69,7 @@ using Serde;
 
 partial struct PointWrap : Serde.ISerialize
 {
-    void Serde.ISerialize.Serialize<TSerializer, TSerializeType, TSerializeEnumerable, TSerializeDictionary>(ref TSerializer serializer)
+    void Serde.ISerialize.Serialize(ISerializer serializer)
     {
         var type = serializer.SerializeType(""Point"", 2);
         type.SerializeField(""X"", new Int32Wrap(_point.X));
@@ -147,7 +147,7 @@ namespace Serde
 {
     partial record struct BitVector32SectionWrap : Serde.ISerialize
     {
-        void Serde.ISerialize.Serialize<TSerializer, TSerializeType, TSerializeEnumerable, TSerializeDictionary>(ref TSerializer serializer)
+        void Serde.ISerialize.Serialize(ISerializer serializer)
         {
             var type = serializer.SerializeType(""Section"", 2);
             type.SerializeField(""Mask"", new Int16Wrap(Value.Mask));
@@ -162,7 +162,7 @@ using Serde;
 
 partial class C : Serde.ISerialize
 {
-    void Serde.ISerialize.Serialize<TSerializer, TSerializeType, TSerializeEnumerable, TSerializeDictionary>(ref TSerializer serializer)
+    void Serde.ISerialize.Serialize(ISerializer serializer)
     {
         var type = serializer.SerializeType(""C"", 1);
         type.SerializeField(""S"", new BitVector32SectionWrap(this.S));

--- a/test/JsonSerializerTests.cs
+++ b/test/JsonSerializerTests.cs
@@ -97,11 +97,7 @@ namespace Serde.Test
             {
                 _d = d;
             }
-            public void Serialize<TSerializer, TSerializeType, TSerializeEnumerable, TSerializeDictionary>(ref TSerializer serializer)
-                where TSerializer : ISerializer<TSerializeType, TSerializeEnumerable, TSerializeDictionary>
-                where TSerializeType : ISerializeType
-                where TSerializeEnumerable : ISerializeEnumerable
-                where TSerializeDictionary : ISerializeDictionary
+            public void Serialize(ISerializer serializer)
             {
                 var sd = serializer.SerializeDictionary(_d.Count);
                 foreach (var (k,v) in _d)

--- a/test/MemberFormatTests.cs
+++ b/test/MemberFormatTests.cs
@@ -26,7 +26,7 @@ using Serde;
 
 partial struct S : Serde.ISerialize
 {
-    void Serde.ISerialize.Serialize<TSerializer, TSerializeType, TSerializeEnumerable, TSerializeDictionary>(ref TSerializer serializer)
+    void Serde.ISerialize.Serialize(ISerializer serializer)
     {
         var type = serializer.SerializeType(""S"", 2);
         type.SerializeField(""one"", new Int32Wrap(this.One));

--- a/test/generated/SerdeGenerator/Serde.Generator/Serde.AllInOneColorEnumWrap.ISerialize.cs
+++ b/test/generated/SerdeGenerator/Serde.Generator/Serde.AllInOneColorEnumWrap.ISerialize.cs
@@ -6,7 +6,7 @@ namespace Serde
 {
     partial record struct AllInOneColorEnumWrap : Serde.ISerialize
     {
-        void Serde.ISerialize.Serialize<TSerializer, TSerializeType, TSerializeEnumerable, TSerializeDictionary>(ref TSerializer serializer)
+        void Serde.ISerialize.Serialize(ISerializer serializer)
         {
             var name = Value switch
             {

--- a/test/generated/SerdeGenerator/Serde.Generator/Serde.Test.AllInOne.ISerialize.cs
+++ b/test/generated/SerdeGenerator/Serde.Generator/Serde.Test.AllInOne.ISerialize.cs
@@ -6,7 +6,7 @@ namespace Serde.Test
 {
     partial record AllInOne : Serde.ISerialize
     {
-        void Serde.ISerialize.Serialize<TSerializer, TSerializeType, TSerializeEnumerable, TSerializeDictionary>(ref TSerializer serializer)
+        void Serde.ISerialize.Serialize(ISerializer serializer)
         {
             var type = serializer.SerializeType("AllInOne", 15);
             type.SerializeField("BoolField", new BoolWrap(this.BoolField));

--- a/test/generated/SerdeGenerator/Serde.Generator/Serde.Test.JsonSerializerTests.NullableFields.ISerialize.cs
+++ b/test/generated/SerdeGenerator/Serde.Generator/Serde.Test.JsonSerializerTests.NullableFields.ISerialize.cs
@@ -8,7 +8,7 @@ namespace Serde.Test
     {
         partial class NullableFields : Serde.ISerialize
         {
-            void Serde.ISerialize.Serialize<TSerializer, TSerializeType, TSerializeEnumerable, TSerializeDictionary>(ref TSerializer serializer)
+            void Serde.ISerialize.Serialize(ISerializer serializer)
             {
                 var type = serializer.SerializeType("NullableFields", 2);
                 type.SerializeField("S", new NullableRefWrap.SerializeImpl<string, StringWrap>(this.S));


### PR DESCRIPTION
The performance difference between the approach with generics and
interface dispatch is small, but the complexity penalty
right now is high. If C# adds existential types, this would be a
more viable approach.