### PR TITLE
Change enumerable serialization to take a type name

### DIFF
--- a/src/serde-dn/ISerialize.cs
+++ b/src/serde-dn/ISerialize.cs
@@ -45,6 +45,6 @@ public interface ISerializer
     void SerializeEnumValue<T>(string enumName, string? valueName, T value) where T : notnull, ISerialize;
 
     ISerializeType SerializeType(string name, int numFields);
-    ISerializeEnumerable SerializeEnumerable(int? length);
+    ISerializeEnumerable SerializeEnumerable(string typeName, int? length);
     ISerializeDictionary SerializeDictionary(int? length);
 }

--- a/src/serde-dn/Wrappers.List.cs
+++ b/src/serde-dn/Wrappers.List.cs
@@ -9,10 +9,10 @@ namespace Serde
 {
     internal static class EnumerableHelpers
     {
-        public static void SerializeSpan<T, TWrap>(ReadOnlySpan<T> arr, ISerializer serializer)
+        public static void SerializeSpan<T, TWrap>(string typeName, ReadOnlySpan<T> arr, ISerializer serializer)
             where TWrap : struct, ISerializeWrap<T, TWrap>, ISerialize
         {
-            var enumerable = serializer.SerializeEnumerable(arr.Length);
+            var enumerable = serializer.SerializeEnumerable(typeName, arr.Length);
             foreach (var item in arr)
             {
                 enumerable.SerializeElement(TWrap.Create(item));
@@ -21,10 +21,10 @@ namespace Serde
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void SerializeList<T, TWrap>(List<T> list, ISerializer serializer)
+        public static void SerializeList<T, TWrap>(string typeName, List<T> list, ISerializer serializer)
             where TWrap : struct, ISerializeWrap<T, TWrap>, ISerialize
         {
-            var enumerable = serializer.SerializeEnumerable(list.Count);
+            var enumerable = serializer.SerializeEnumerable(typeName, list.Count);
             foreach (var item in list)
             {
                 enumerable.SerializeElement(TWrap.Create(item));
@@ -34,10 +34,10 @@ namespace Serde
 
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void SerializeIList<T, TWrap>(IList<T> list, ISerializer serializer)
+        public static void SerializeIList<T, TWrap>(string typeName, IList<T> list, ISerializer serializer)
             where TWrap : struct, ISerializeWrap<T, TWrap>, ISerialize
         {
-            var enumerable = serializer.SerializeEnumerable(list.Count);
+            var enumerable = serializer.SerializeEnumerable(typeName, list.Count);
             foreach (var item in list)
             {
                 enumerable.SerializeElement(TWrap.Create(item));
@@ -63,7 +63,7 @@ namespace Serde
             public static SerializeImpl<T, TWrap> Create(T[] t) => new SerializeImpl<T, TWrap>(t);
 
             void ISerialize.Serialize(ISerializer serializer)
-                => EnumerableHelpers.SerializeSpan<T, TWrap>(Value, serializer);
+                => EnumerableHelpers.SerializeSpan<T, TWrap>(typeof(T).Name, Value, serializer);
         }
 
         public readonly struct DeserializeImpl<T, TWrap> : IDeserialize<T[]>
@@ -115,7 +115,7 @@ namespace Serde
             public static SerializeImpl<T, TWrap> Create(List<T> t) => new SerializeImpl<T, TWrap>(t);
 
             void ISerialize.Serialize(ISerializer serializer)
-                => EnumerableHelpers.SerializeList<T, TWrap>(Value, serializer);
+                => EnumerableHelpers.SerializeList<T, TWrap>(typeof(T).Name, Value, serializer);
         }
 
         public readonly struct DeserializeImpl<T, TWrap> : IDeserialize<List<T>>
@@ -164,7 +164,7 @@ namespace Serde
             public static SerializeImpl<T, TWrap> Create(ImmutableArray<T> t) => new SerializeImpl<T, TWrap>(t);
 
             void ISerialize.Serialize(ISerializer serializer)
-                => EnumerableHelpers.SerializeSpan<T, TWrap>(Value.AsSpan(), serializer);
+                => EnumerableHelpers.SerializeSpan<T, TWrap>(typeof(T).Name, Value.AsSpan(), serializer);
         }
 
         public readonly struct DeserializeImpl<T, TWrap> : IDeserialize<ImmutableArray<T>>

--- a/src/serde-dn/json/JsonSerializerImpl.cs
+++ b/src/serde-dn/json/JsonSerializerImpl.cs
@@ -67,10 +67,25 @@ namespace Serde.Json
             return this;
         }
 
-        public ISerializeEnumerable SerializeEnumerable(int? count)
+        public ISerializeEnumerable SerializeEnumerable(string typeName, int? count)
         {
             _writer.WriteStartArray();
-            return this;
+            return new SerializeEnumerableImpl(this);
+        }
+
+        private sealed class SerializeEnumerableImpl : ISerializeEnumerable
+        {
+            private readonly JsonSerializer _s;
+            public SerializeEnumerableImpl(JsonSerializer s) { _s = s; }
+            void ISerializeEnumerable.SerializeElement<T>(T value)
+            {
+                value.Serialize(_s);
+            }
+
+            void ISerializeEnumerable.End()
+            {
+                _s._writer.WriteEndArray();
+            }
         }
 
         public ISerializeDictionary SerializeDictionary(int? count)
@@ -91,19 +106,6 @@ namespace Serde.Json
         void ISerializeType.End()
         {
             _writer.WriteEndObject();
-        }
-    }
-
-    partial class JsonSerializer : ISerializeEnumerable
-    {
-        void ISerializeEnumerable.SerializeElement<T>(T value)
-        {
-            value.Serialize(this);
-        }
-
-        void ISerializeEnumerable.End()
-        {
-            _writer.WriteEndArray();
         }
     }
 
@@ -161,7 +163,7 @@ namespace Serde.Json
 
             public ISerializeDictionary SerializeDictionary(int? length) => throw new KeyNotStringException();
 
-            public ISerializeEnumerable SerializeEnumerable(int? length) => throw new KeyNotStringException();
+            public ISerializeEnumerable SerializeEnumerable(string typeName, int? length) => throw new KeyNotStringException();
 
             public ISerializeType SerializeType(string name, int numFields) => throw new KeyNotStringException();
 

--- a/src/serde-dn/json/JsonValue.Serialize.cs
+++ b/src/serde-dn/json/JsonValue.Serialize.cs
@@ -64,7 +64,7 @@ namespace Serde.Json
 
             public override void Serialize(ISerializer serializer)
             {
-                var enumerable = serializer.SerializeEnumerable(Elements.Length);
+                var enumerable = serializer.SerializeEnumerable("JsonValue", Elements.Length);
                 foreach (var element in Elements)
                 {
                     enumerable.SerializeElement(element);


### PR DESCRIPTION
The structure for ISerialize.ISerializeEnumerable implies that the type can vary between elements, but this should not be legal for C# enumerables. The documentation should make it clear that `T` is expected to be the same in each invocation of SerializeElement, and there should be a single type name passed to SerializeEnumerable.