### PR TITLE
Bump versions and publish on release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,6 +3,9 @@ name: publish
 on:
   push:
     branches: [ release ]
+  release:
+    types: [ published ]
+
 jobs:
   pack:
     runs-on: ubuntu-latest

--- a/src/pack/Serde.Pkg.proj
+++ b/src/pack/Serde.Pkg.proj
@@ -5,7 +5,7 @@
     <TargetFramework>net7.0</TargetFramework>
 
     <PackageId>Serde</PackageId>
-    <Version>0.3.3</Version>
+    <Version>0.3.4</Version>
     <IsPackable>true</IsPackable>
     <PackageOutputPath>$(ArtifactsPath)pack</PackageOutputPath>
     <PackageLicenseExpression>BSD-3-Clause</PackageLicenseExpression>

--- a/src/pack/Serde.Xml.Pkg.proj
+++ b/src/pack/Serde.Xml.Pkg.proj
@@ -5,7 +5,7 @@
     <TargetFramework>net7.0</TargetFramework>
 
     <PackageId>Serde.Xml</PackageId>
-    <Version>0.1.0</Version>
+    <Version>0.1.1</Version>
     <IsPackable>true</IsPackable>
     <PackageOutputPath>$(ArtifactsPath)pack</PackageOutputPath>
     <PackageLicenseExpression>BSD-3-Clause</PackageLicenseExpression>


### PR DESCRIPTION
Creating a GH release will now automatically publish NuGet packages, just like pushing to the release branch