### PR TITLE
Change default field format to camelCase

### DIFF
--- a/src/generator/ConfigOptions.cs
+++ b/src/generator/ConfigOptions.cs
@@ -7,34 +7,22 @@ namespace Serde;
 internal readonly record struct TypeOptions()
 {
     public bool DenyUnknownMembers { get; init; } = false;
-    public MemberFormat MemberFormat { get; init; } = MemberFormat.None;
+    public MemberFormat MemberFormat { get; init; } = MemberFormat.CamelCase;
     public ITypeSymbol? ConstructorSignature { get; init; } = null;
     public bool SerializeNull { get; init; } = false;
 }
 
 internal readonly record struct MemberOptions()
 {
+    /// <see cref="SerdeMemberOptions.ThrowIfMissing" />
     public bool ThrowIfMissing { get; init; } = false;
 
+    /// <see cref="SerdeMemberOptions.Rename" />
     public string? Rename { get; init; } = null;
 
+    /// <see cref="SerdeMemberOptions.ProvideAttributes" />
     public bool ProvideAttributes { get; init; } = false;
-    public bool? SerializeNull { get; init; } = null;
-}
 
-// Keep in sync with copy in serde
-internal enum MemberFormat : byte
-{
-    /// <summary>
-    /// Use the original name of the member.
-    /// </summary>
-    None,
-    /// <summary>
-    /// "PascalCase"
-    /// </summary>
-    PascalCase,
-    /// <summary>
-    /// "camelCase"
-    /// </summary>
-    CamelCase
+    /// <see cref="SerdeMemberOptions.ProvideAttributes" />
+    public bool? SerializeNull { get; init; } = null;
 }

--- a/src/generator/DataMemberSymbol.cs
+++ b/src/generator/DataMemberSymbol.cs
@@ -154,7 +154,6 @@ namespace Serde
         {
             var resultBuilder = ImmutableArray.CreateBuilder<string>();
             var wordBuilder = new StringBuilder();
-            bool wasLowercase = false;
             foreach (var c in name)
             {
                 if (c == '_')
@@ -164,14 +163,7 @@ namespace Serde
                 }
                 if (char.IsUpper(c))
                 {
-                    if (wasLowercase)
-                    {
-                        AddWordAndClear();
-                    }
-                }
-                else
-                {
-                    wasLowercase = true;
+                    AddWordAndClear();
                 }
                 wordBuilder.Append(c);
             }

--- a/src/generator/Generator.Deserialize.cs
+++ b/src/generator/Generator.Deserialize.cs
@@ -204,7 +204,7 @@ namespace Serde
                 foreach (var m in SymbolUtilities.GetPublicDataMembers(type))
                 {
                     cases.Append(@$"
-        case ""{m.Name}"":
+        case ""{m.GetFormattedName()}"":
             enumValue = {typeName}.{m.Name};
             break;");
                 }

--- a/src/generator/Generator.Serialize.cs
+++ b/src/generator/Generator.Serialize.cs
@@ -39,7 +39,7 @@ namespace Serde
                 var cases = fieldsAndProps.Select(m => SwitchExpressionArm(
                         ConstantPattern(QualifiedName((NameSyntax)typeSyntax, IdentifierName(m.Name))),
                         whenClause: null,
-                        expression: StringLiteral(m.Name)));
+                        expression: StringLiteral(m.GetFormattedName())));
                 cases = cases.Concat(new[] { SwitchExpressionArm(
                     DiscardPattern(),
                     whenClause: null,

--- a/src/generator/Generator.cs
+++ b/src/generator/Generator.cs
@@ -43,8 +43,10 @@ namespace Serde
     {
         private static readonly GeneratorRegistry _registry = new GeneratorRegistry();
 
+        /// <inheritdoc/>
         public void Initialize(GeneratorInitializationContext context) { }
 
+        /// <inheritdoc/>
         public void Execute(GeneratorExecutionContext context)
         {
             var walker = new TypeWalker(this, context);

--- a/src/generator/SerdeGenerator.csproj
+++ b/src/generator/SerdeGenerator.csproj
@@ -8,6 +8,8 @@
 
     <PackFolder>analyzers/dotnet/cs</PackFolder>
     <PackSymbols>false</PackSymbols>
+    <DefineConstants>$(DefineConstants);SRCGEN</DefineConstants>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 
   <ItemGroup>
@@ -24,6 +26,8 @@
     <PackageReference Include="StaticCs" Version="0.2.0">
       <Pack>false</Pack>
     </PackageReference>
+
+    <Compile Include="../serde/Attributes.cs" />
   </ItemGroup>
 
 </Project>

--- a/src/generator/TypeDeclContext.cs
+++ b/src/generator/TypeDeclContext.cs
@@ -44,8 +44,6 @@ namespace Serde
             TypeParameterList = typeDecl.TypeParameterList;
         }
 
-        /// <summary>
-        /// Given a type, wraps it in the
         public MemberDeclarationSyntax WrapNewType(MemberDeclarationSyntax newType)
         {
             // If the original type was in a namespace or type, put this decl in the same one

--- a/src/pack/Serde.Pkg.proj
+++ b/src/pack/Serde.Pkg.proj
@@ -5,7 +5,7 @@
     <TargetFramework>net7.0</TargetFramework>
 
     <PackageId>Serde</PackageId>
-    <Version>0.3.4</Version>
+    <Version>0.4.0</Version>
     <IsPackable>true</IsPackable>
     <PackageOutputPath>$(ArtifactsPath)pack</PackageOutputPath>
     <PackageLicenseExpression>BSD-3-Clause</PackageLicenseExpression>

--- a/src/pack/Serde.Xml.Pkg.proj
+++ b/src/pack/Serde.Xml.Pkg.proj
@@ -5,7 +5,7 @@
     <TargetFramework>net7.0</TargetFramework>
 
     <PackageId>Serde.Xml</PackageId>
-    <Version>0.1.1</Version>
+    <Version>0.2.0</Version>
     <IsPackable>true</IsPackable>
     <PackageOutputPath>$(ArtifactsPath)pack</PackageOutputPath>
     <PackageLicenseExpression>BSD-3-Clause</PackageLicenseExpression>

--- a/src/serde/Attributes.cs
+++ b/src/serde/Attributes.cs
@@ -4,36 +4,98 @@ using System.Diagnostics;
 
 namespace Serde;
 
+// Silence warnings about references to Serde types that aren't referenced by the generator
+#pragma warning disable CS1574
+
+/// <summary>
+/// Generates an implementation of <see cref="Serde.ISerialize" />.
+/// </summary>
 [AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct, AllowMultiple = false, Inherited = false)]
 [Conditional("EMIT_GENERATE_SERDE_ATTRIBUTE")]
-public sealed class GenerateSerialize : Attribute
+#if !SRCGEN
+public
+#else
+internal
+#endif
+sealed class GenerateSerialize : Attribute
 { }
 
+/// <summary>
+/// Generates an implementation of <see cref="Serde.IDeserialize" />.
+/// </summary>
 [AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct, AllowMultiple = false, Inherited = false)]
 [Conditional("EMIT_GENERATE_SERDE_ATTRIBUTE")]
-public sealed class GenerateDeserialize : Attribute
+#if !SRCGEN
+public
+#else
+internal
+#endif
+sealed class GenerateDeserialize : Attribute
 { }
 
+/// <summary>
+/// Generates an implementation of both <see cref="Serde.ISerialize" /> and <see cref="Serde.IDeserialize" />.
+/// </summary>
 [AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct, AllowMultiple = false, Inherited = false)]
 [Conditional("EMIT_GENERATE_SERDE_ATTRIBUTE")]
-public sealed class GenerateSerde : Attribute
+#if !SRCGEN
+public
+#else
+internal
+#endif
+sealed class GenerateSerde : Attribute
 { }
 
+/// <summary>
+/// Generates the equivalent of <see cref="GenerateSerde" />, but delegated to a member of the name
+/// passed in as a parameter.
+/// </summary>
 [AttributeUsage(AttributeTargets.Struct, AllowMultiple = false, Inherited = false)]
 [Conditional("EMIT_GENERATE_SERDE_ATTRIBUTE")]
-public sealed class GenerateWrapper : Attribute
+#if !SRCGEN
+public
+#else
+internal
+#endif
+sealed class GenerateWrapper : Attribute
 {
-    public GenerateWrapper(string memberName) { }
-}
+    /// <summary>
+    /// The name of the member used for delegation.
+    /// </summary>
+    public string MemberName { get; }
 
+    /// <summary>
+    /// Constructor for GenerateWrapper.
+    /// </summary>
+    public GenerateWrapper(string memberName)
+    {
+        MemberName = memberName;
+    }
+}
+#pragma warning restore CS1574
+
+/// <summary>
+/// Set options for the Serde source generator for the current type.
+/// </summary>
 [AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct, AllowMultiple = false, Inherited = false)]
-public sealed class SerdeTypeOptions : Attribute
+#if !SRCGEN
+public
+#else
+internal
+#endif
+sealed class SerdeTypeOptions : Attribute
 {
+    /// <summary>
+    /// Throw an exception during deserialization if any members not expected by the current
+    /// type are present.
+    /// </summary>
     public bool DenyUnknownMembers { get; init; } = false;
+
     /// <summary>
     /// Override the formatting for members.
     /// </summary>
-    public MemberFormat MemberFormat { get; init; } = MemberFormat.None;
+    public MemberFormat MemberFormat { get; init; } = MemberFormat.CamelCase;
+
     /// <summary>
     /// Pick the constructor used for deserialization. Expects a tuple with the same types as
     /// the desired parameter list of the desired constructor.
@@ -46,8 +108,16 @@ public sealed class SerdeTypeOptions : Attribute
     public bool SerializeNull { get; init; } = false;
 }
 
+/// <summary>
+/// Set options for the Serde source generator specific to the current member.
+/// </summary>
 [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property, AllowMultiple = false, Inherited = false)]
-public sealed class SerdeMemberOptions : Attribute
+#if !SRCGEN
+public
+#else
+internal
+#endif
+sealed class SerdeMemberOptions : Attribute
 {
     /// <summary>
     /// Throw an exception if the target field is not present when deserializing.  This is the
@@ -74,8 +144,21 @@ public sealed class SerdeMemberOptions : Attribute
     public bool SerializeNull { get; init; } = false;
 }
 
-public enum MemberFormat : byte
+/// <summary>
+/// A enumeration of all possible types of name formatting that the source generator
+/// can generate.
+/// </summary>
+#if !SRCGEN
+public
+#else
+internal
+#endif
+enum MemberFormat : byte
 {
+    /// <summary>
+    /// "camelCase"
+    /// </summary>
+    CamelCase,
     /// <summary>
     /// Use the original name of the member.
     /// </summary>
@@ -85,7 +168,7 @@ public enum MemberFormat : byte
     /// </summary>
     PascalCase,
     /// <summary>
-    /// "camelCase"
+    /// "kebab-case"
     /// </summary>
-    CamelCase
+    KebabCase,
 }

--- a/test/Serde.Test/AllInOneJsonTest.cs
+++ b/test/Serde.Test/AllInOneJsonTest.cs
@@ -28,22 +28,22 @@ namespace Serde.Test
         void Serde.ISerialize.Serialize(ISerializer serializer)
         {
             var type = serializer.SerializeType("AllInOne", 16);
-            type.SerializeField("BoolField", new BoolWrap(this.BoolField));
-            type.SerializeField("CharField", new CharWrap(this.CharField));
-            type.SerializeField("ByteField", new ByteWrap(this.ByteField));
-            type.SerializeField("UShortField", new UInt16Wrap(this.UShortField));
-            type.SerializeField("UIntField", new UInt32Wrap(this.UIntField));
-            type.SerializeField("ULongField", new UInt64Wrap(this.ULongField));
-            type.SerializeField("SByteField", new SByteWrap(this.SByteField));
-            type.SerializeField("ShortField", new Int16Wrap(this.ShortField));
-            type.SerializeField("IntField", new Int32Wrap(this.IntField));
-            type.SerializeField("LongField", new Int64Wrap(this.LongField));
-            type.SerializeField("StringField", new StringWrap(this.StringField));
-            type.SerializeFieldIfNotNull("NullStringField", new NullableRefWrap.SerializeImpl<string, StringWrap>(this.NullStringField), this.NullStringField);
-            type.SerializeField("UIntArr", new ArrayWrap.SerializeImpl<uint, UInt32Wrap>(this.UIntArr));
-            type.SerializeField("NestedArr", new ArrayWrap.SerializeImpl<int[], ArrayWrap.SerializeImpl<int, Int32Wrap>>(this.NestedArr));
-            type.SerializeField("IntImm", new ImmutableArrayWrap.SerializeImpl<int, Int32Wrap>(this.IntImm));
-            type.SerializeField("Color", new AllInOneColorEnumWrap(this.Color));
+            type.SerializeField("boolField", new BoolWrap(this.BoolField));
+            type.SerializeField("charField", new CharWrap(this.CharField));
+            type.SerializeField("byteField", new ByteWrap(this.ByteField));
+            type.SerializeField("uShortField", new UInt16Wrap(this.UShortField));
+            type.SerializeField("uIntField", new UInt32Wrap(this.UIntField));
+            type.SerializeField("uLongField", new UInt64Wrap(this.ULongField));
+            type.SerializeField("sByteField", new SByteWrap(this.SByteField));
+            type.SerializeField("shortField", new Int16Wrap(this.ShortField));
+            type.SerializeField("intField", new Int32Wrap(this.IntField));
+            type.SerializeField("longField", new Int64Wrap(this.LongField));
+            type.SerializeField("stringField", new StringWrap(this.StringField));
+            type.SerializeFieldIfNotNull("nullStringField", new NullableRefWrap.SerializeImpl<string, StringWrap>(this.NullStringField), this.NullStringField);
+            type.SerializeField("uIntArr", new ArrayWrap.SerializeImpl<uint, UInt32Wrap>(this.UIntArr));
+            type.SerializeField("nestedArr", new ArrayWrap.SerializeImpl<int[], ArrayWrap.SerializeImpl<int, Int32Wrap>>(this.NestedArr));
+            type.SerializeField("intImm", new ImmutableArrayWrap.SerializeImpl<int, Int32Wrap>(this.IntImm));
+            type.SerializeField("color", new AllInOneColorEnumWrap(this.Color));
             type.End();
         }
     }
@@ -89,52 +89,52 @@ namespace Serde.Test
                 {
                     switch (key)
                     {
-                        case ""BoolField"":
+                        case ""boolField"":
                             boolfield = d.GetNextValue<bool, BoolWrap>();
                             break;
-                        case ""CharField"":
+                        case ""charField"":
                             charfield = d.GetNextValue<char, CharWrap>();
                             break;
-                        case ""ByteField"":
+                        case ""byteField"":
                             bytefield = d.GetNextValue<byte, ByteWrap>();
                             break;
-                        case ""UShortField"":
+                        case ""uShortField"":
                             ushortfield = d.GetNextValue<ushort, UInt16Wrap>();
                             break;
-                        case ""UIntField"":
+                        case ""uIntField"":
                             uintfield = d.GetNextValue<uint, UInt32Wrap>();
                             break;
-                        case ""ULongField"":
+                        case ""uLongField"":
                             ulongfield = d.GetNextValue<ulong, UInt64Wrap>();
                             break;
-                        case ""SByteField"":
+                        case ""sByteField"":
                             sbytefield = d.GetNextValue<sbyte, SByteWrap>();
                             break;
-                        case ""ShortField"":
+                        case ""shortField"":
                             shortfield = d.GetNextValue<short, Int16Wrap>();
                             break;
-                        case ""IntField"":
+                        case ""intField"":
                             intfield = d.GetNextValue<int, Int32Wrap>();
                             break;
-                        case ""LongField"":
+                        case ""longField"":
                             longfield = d.GetNextValue<long, Int64Wrap>();
                             break;
-                        case ""StringField"":
+                        case ""stringField"":
                             stringfield = d.GetNextValue<string, StringWrap>();
                             break;
-                        case ""NullStringField"":
+                        case ""nullStringField"":
                             nullstringfield = d.GetNextValue<string?, NullableRefWrap.DeserializeImpl<string, StringWrap>>();
                             break;
-                        case ""UIntArr"":
+                        case ""uIntArr"":
                             uintarr = d.GetNextValue<uint[], ArrayWrap.DeserializeImpl<uint, UInt32Wrap>>();
                             break;
-                        case ""NestedArr"":
+                        case ""nestedArr"":
                             nestedarr = d.GetNextValue<int[][], ArrayWrap.DeserializeImpl<int[], ArrayWrap.DeserializeImpl<int, Int32Wrap>>>();
                             break;
-                        case ""IntImm"":
+                        case ""intImm"":
                             intimm = d.GetNextValue<System.Collections.Immutable.ImmutableArray<int>, ImmutableArrayWrap.DeserializeImpl<int, Int32Wrap>>();
                             break;
-                        case ""Color"":
+                        case ""color"":
                             color = d.GetNextValue<Serde.Test.AllInOne.ColorEnum, AllInOneColorEnumWrap>();
                             break;
                         default:
@@ -169,9 +169,9 @@ namespace Serde
         {
             var name = Value switch
             {
-                Serde.Test.AllInOne.ColorEnum.Red => "Red",
-                Serde.Test.AllInOne.ColorEnum.Blue => "Blue",
-                Serde.Test.AllInOne.ColorEnum.Green => "Green",
+                Serde.Test.AllInOne.ColorEnum.Red => "red",
+                Serde.Test.AllInOne.ColorEnum.Blue => "blue",
+                Serde.Test.AllInOne.ColorEnum.Green => "green",
                 _ => null
             };
             serializer.SerializeEnumValue("ColorEnum", name, new Int32Wrap((int)Value));
@@ -203,13 +203,13 @@ namespace Serde
                 Serde.Test.AllInOne.ColorEnum enumValue;
                 switch (s)
                 {
-                    case "Red":
+                    case "red":
                         enumValue = Serde.Test.AllInOne.ColorEnum.Red;
                         break;
-                    case "Blue":
+                    case "blue":
                         enumValue = Serde.Test.AllInOne.ColorEnum.Blue;
                         break;
-                    case "Green":
+                    case "green":
                         enumValue = Serde.Test.AllInOne.ColorEnum.Green;
                         break;
                     default:
@@ -230,23 +230,23 @@ namespace Serde
 
         private const string Serialized = """
 {
-  "BoolField": true,
-  "CharField": "#",
-  "ByteField": 255,
-  "UShortField": 65535,
-  "UIntField": 4294967295,
-  "ULongField": 18446744073709551615,
-  "SByteField": 127,
-  "ShortField": 32767,
-  "IntField": 2147483647,
-  "LongField": 9223372036854775807,
-  "StringField": "StringValue",
-  "UIntArr": [
+  "boolField": true,
+  "charField": "#",
+  "byteField": 255,
+  "uShortField": 65535,
+  "uIntField": 4294967295,
+  "uLongField": 18446744073709551615,
+  "sByteField": 127,
+  "shortField": 32767,
+  "intField": 2147483647,
+  "longField": 9223372036854775807,
+  "stringField": "StringValue",
+  "uIntArr": [
     1,
     2,
     3
   ],
-  "NestedArr": [
+  "nestedArr": [
     [
       1
     ],
@@ -254,11 +254,11 @@ namespace Serde
       2
     ]
   ],
-  "IntImm": [
+  "intImm": [
     1,
     2
   ],
-  "Color": "Blue"
+  "color": "blue"
 }
 """;
 

--- a/test/Serde.Test/AllInOneSrc.cs
+++ b/test/Serde.Test/AllInOneSrc.cs
@@ -37,7 +37,7 @@ namespace Serde.Test
 
         public ImmutableArray<int> IntImm;
 
-        public ColorEnum Color = ColorEnum.Blue;
+        public ColorEnum Color;
 
         public enum ColorEnum
         {
@@ -65,8 +65,8 @@ namespace Serde.Test
                 UIntArr.AsSpan().SequenceEqual(other.UIntArr.AsSpan()) &&
                 NestedArr.AsSpan().SequenceEqual(other.NestedArr.AsSpan(),
                     new Comparer()) &&
-                IntImm.AsSpan().SequenceEqual(other.IntImm.AsSpan()); // &&
-                //Color == other.Color;
+                IntImm.AsSpan().SequenceEqual(other.IntImm.AsSpan()) &&
+                Color == other.Color;
         }
         private sealed class Comparer : IEqualityComparer<int[]>
         {
@@ -105,7 +105,9 @@ namespace Serde.Test
             UIntArr = new uint[] { 1, 2, 3 },
             NestedArr = new[] { new[] { 1 }, new[] { 2 } },
 
-            IntImm = ImmutableArray.Create<int>(1, 2)
+            IntImm = ImmutableArray.Create<int>(1, 2),
+
+            Color = ColorEnum.Blue
         };
     }
 }

--- a/test/Serde.Test/GeneratorDeserializeTests.cs
+++ b/test/Serde.Test/GeneratorDeserializeTests.cs
@@ -43,13 +43,13 @@ partial struct Rgb : Serde.IDeserialize<Rgb>
             {
                 switch (key)
                 {
-                    case ""Red"":
+                    case ""red"":
                         red = d.GetNextValue<byte, ByteWrap>();
                         break;
-                    case ""Green"":
+                    case ""green"":
                         green = d.GetNextValue<byte, ByteWrap>();
                         break;
-                    case ""Blue"":
+                    case ""blue"":
                         blue = d.GetNextValue<byte, ByteWrap>();
                         break;
                     default:
@@ -97,7 +97,7 @@ partial struct S : Serde.IDeserialize<S>
             {
                 switch (key)
                 {
-                    case ""F"":
+                    case ""f"":
                         f = d.GetNextValue<string?, NullableRefWrap.DeserializeImpl<string, StringWrap>>();
                         break;
                     default:
@@ -152,13 +152,13 @@ partial record struct SetToNull : Serde.IDeserialize<SetToNull>
             {
                 switch (key)
                 {
-                    case "Present":
+                    case "present":
                         present = d.GetNextValue<string, StringWrap>();
                         break;
-                    case "Missing":
+                    case "missing":
                         missing = d.GetNextValue<string?, NullableRefWrap.DeserializeImpl<string, StringWrap>>();
                         break;
-                    case "ThrowMissing":
+                    case "throwMissing":
                         throwmissing = d.GetNextValue<string?, NullableRefWrap.DeserializeImpl<string, StringWrap>>();
                         break;
                     default:
@@ -208,7 +208,7 @@ partial struct ArrayField : Serde.IDeserialize<ArrayField>
             {
                 switch (key)
                 {
-                    case ""IntArr"":
+                    case ""intArr"":
                         intarr = d.GetNextValue<int[], ArrayWrap.DeserializeImpl<int, Int32Wrap>>();
                         break;
                     default:
@@ -271,13 +271,13 @@ namespace Serde
                 ColorInt enumValue;
                 switch (s)
                 {
-                    case "Red":
+                    case "red":
                         enumValue = ColorInt.Red;
                         break;
-                    case "Green":
+                    case "green":
                         enumValue = ColorInt.Green;
                         break;
-                    case "Blue":
+                    case "blue":
                         enumValue = ColorInt.Blue;
                         break;
                     default:
@@ -318,13 +318,13 @@ namespace Serde
                 ColorByte enumValue;
                 switch (s)
                 {
-                    case "Red":
+                    case "red":
                         enumValue = ColorByte.Red;
                         break;
-                    case "Green":
+                    case "green":
                         enumValue = ColorByte.Green;
                         break;
-                    case "Blue":
+                    case "blue":
                         enumValue = ColorByte.Blue;
                         break;
                     default:
@@ -365,13 +365,13 @@ namespace Serde
                 ColorLong enumValue;
                 switch (s)
                 {
-                    case "Red":
+                    case "red":
                         enumValue = ColorLong.Red;
                         break;
-                    case "Green":
+                    case "green":
                         enumValue = ColorLong.Green;
                         break;
-                    case "Blue":
+                    case "blue":
                         enumValue = ColorLong.Blue;
                         break;
                     default:
@@ -412,13 +412,13 @@ namespace Serde
                 ColorULong enumValue;
                 switch (s)
                 {
-                    case "Red":
+                    case "red":
                         enumValue = ColorULong.Red;
                         break;
-                    case "Green":
+                    case "green":
                         enumValue = ColorULong.Green;
                         break;
-                    case "Blue":
+                    case "blue":
                         enumValue = ColorULong.Blue;
                         break;
                     default:
@@ -458,16 +458,16 @@ partial class C : Serde.IDeserialize<C>
             {
                 switch (key)
                 {
-                    case "ColorInt":
+                    case "colorInt":
                         colorint = d.GetNextValue<ColorInt, ColorIntWrap>();
                         break;
-                    case "ColorByte":
+                    case "colorByte":
                         colorbyte = d.GetNextValue<ColorByte, ColorByteWrap>();
                         break;
-                    case "ColorLong":
+                    case "colorLong":
                         colorlong = d.GetNextValue<ColorLong, ColorLongWrap>();
                         break;
-                    case "ColorULong":
+                    case "colorULong":
                         colorulong = d.GetNextValue<ColorULong, ColorULongWrap>();
                         break;
                     default:

--- a/test/Serde.Test/GeneratorSerializeTests.cs
+++ b/test/Serde.Test/GeneratorSerializeTests.cs
@@ -28,9 +28,9 @@ partial struct Rgb : Serde.ISerialize
     void Serde.ISerialize.Serialize(ISerializer serializer)
     {
         var type = serializer.SerializeType(""Rgb"", 3);
-        type.SerializeField(""Red"", new ByteWrap(this.Red));
-        type.SerializeField(""Green"", new ByteWrap(this.Green));
-        type.SerializeField(""Blue"", new ByteWrap(this.Blue));
+        type.SerializeField(""red"", new ByteWrap(this.Red));
+        type.SerializeField(""green"", new ByteWrap(this.Green));
+        type.SerializeField(""blue"", new ByteWrap(this.Blue));
         type.End();
     }
 }");
@@ -66,11 +66,11 @@ partial struct S<T1, T2, T3, T4, T5> : Serde.ISerialize
     void Serde.ISerialize.Serialize(ISerializer serializer)
     {
         var type = serializer.SerializeType("S", 5);
-        type.SerializeFieldIfNotNull("FS", new NullableRefWrap.SerializeImpl<string, StringWrap>(this.FS), this.FS);
-        type.SerializeField("F1", this.F1);
-        type.SerializeFieldIfNotNull("F2", this.F2, this.F2);
-        type.SerializeFieldIfNotNull("F3", new NullableRefWrap.SerializeImpl<T3, IdWrap<T3>>(this.F3), this.F3);
-        type.SerializeFieldIfNotNull("F4", this.F4, this.F4);
+        type.SerializeFieldIfNotNull("fS", new NullableRefWrap.SerializeImpl<string, StringWrap>(this.FS), this.FS);
+        type.SerializeField("f1", this.F1);
+        type.SerializeFieldIfNotNull("f2", this.F2, this.F2);
+        type.SerializeFieldIfNotNull("f3", new NullableRefWrap.SerializeImpl<T3, IdWrap<T3>>(this.F3), this.F3);
+        type.SerializeFieldIfNotNull("f4", this.F4, this.F4);
         type.End();
     }
 }
@@ -115,8 +115,8 @@ partial struct S<T1, T2, TSerialize> : Serde.ISerialize
     void Serde.ISerialize.Serialize(ISerializer serializer)
     {
         var type = serializer.SerializeType("S", 4);
-        type.SerializeFieldIfNotNull("FI", new NullableWrap.SerializeImpl<int, Int32Wrap>(this.FI), this.FI);
-        type.SerializeFieldIfNotNull("F3", new NullableWrap.SerializeImpl<TSerialize, IdWrap<TSerialize>>(this.F3), this.F3);
+        type.SerializeFieldIfNotNull("fI", new NullableWrap.SerializeImpl<int, Int32Wrap>(this.FI), this.FI);
+        type.SerializeFieldIfNotNull("f3", new NullableWrap.SerializeImpl<TSerialize, IdWrap<TSerialize>>(this.F3), this.F3);
         type.End();
     }
 }
@@ -188,7 +188,7 @@ partial class C : Serde.ISerialize
     void Serde.ISerialize.Serialize(ISerializer serializer)
     {
         var type = serializer.SerializeType(""C"", 1);
-        type.SerializeField(""IntArr"", new ArrayWrap.SerializeImpl<int, Int32Wrap>(this.IntArr));
+        type.SerializeField(""intArr"", new ArrayWrap.SerializeImpl<int, Int32Wrap>(this.IntArr));
         type.End();
     }
 }");
@@ -213,7 +213,7 @@ partial class C : Serde.ISerialize
     void Serde.ISerialize.Serialize(ISerializer serializer)
     {
         var type = serializer.SerializeType(""C"", 1);
-        type.SerializeField(""NestedArr"", new ArrayWrap.SerializeImpl<int[], ArrayWrap.SerializeImpl<int, Int32Wrap>>(this.NestedArr));
+        type.SerializeField(""nestedArr"", new ArrayWrap.SerializeImpl<int[], ArrayWrap.SerializeImpl<int, Int32Wrap>>(this.NestedArr));
         type.End();
     }
 }");
@@ -238,7 +238,7 @@ partial class C : Serde.ISerialize
     void Serde.ISerialize.Serialize(ISerializer serializer)
     {
         var type = serializer.SerializeType(""C"", 1);
-        type.SerializeField(""NestedArr"", new ArrayWrap.SerializeImpl<int[], ArrayWrap.SerializeImpl<int, Int32Wrap>>(this.NestedArr));
+        type.SerializeField(""nestedArr"", new ArrayWrap.SerializeImpl<int[], ArrayWrap.SerializeImpl<int, Int32Wrap>>(this.NestedArr));
         type.End();
     }
 }");
@@ -279,8 +279,8 @@ partial class TestCase15
         void Serde.ISerialize.Serialize(ISerializer serializer)
         {
             var type = serializer.SerializeType(""Class0"", 2);
-            type.SerializeField(""Field0"", new ArrayWrap.SerializeImpl<TestCase15.Class1, IdWrap<TestCase15.Class1>>(this.Field0));
-            type.SerializeField(""Field1"", new ArrayWrap.SerializeImpl<bool, BoolWrap>(this.Field1));
+            type.SerializeField(""field0"", new ArrayWrap.SerializeImpl<TestCase15.Class1, IdWrap<TestCase15.Class1>>(this.Field0));
+            type.SerializeField(""field1"", new ArrayWrap.SerializeImpl<bool, BoolWrap>(this.Field1));
             type.End();
         }
     }
@@ -296,8 +296,8 @@ partial class TestCase15
         void Serde.ISerialize.Serialize(ISerializer serializer)
         {
             var type = serializer.SerializeType(""Class1"", 2);
-            type.SerializeField(""Field0"", new Int32Wrap(this.Field0));
-            type.SerializeField(""Field1"", new ByteWrap(this.Field1));
+            type.SerializeField(""field0"", new Int32Wrap(this.Field0));
+            type.SerializeField(""field1"", new ByteWrap(this.Field1));
             type.End();
         }
     }
@@ -331,7 +331,7 @@ partial class C : Serde.ISerialize
     void Serde.ISerialize.Serialize(ISerializer serializer)
     {
         var type = serializer.SerializeType(""C"", 1);
-        type.SerializeField(""Map"", new DictWrap.SerializeImpl<string, StringWrap, int, Int32Wrap>(this.Map));
+        type.SerializeField(""map"", new DictWrap.SerializeImpl<string, StringWrap, int, Int32Wrap>(this.Map));
         type.End();
     }
 }");
@@ -367,7 +367,7 @@ partial record C : Serde.ISerialize
     void Serde.ISerialize.Serialize(ISerializer serializer)
     {
         var type = serializer.SerializeType(""C"", 1);
-        type.SerializeField(""X"", new Int32Wrap(this.X));
+        type.SerializeField(""x"", new Int32Wrap(this.X));
         type.End();
     }
 }"),
@@ -380,7 +380,7 @@ partial class C2 : Serde.ISerialize
     void Serde.ISerialize.Serialize(ISerializer serializer)
     {
         var type = serializer.SerializeType(""C2"", 1);
-        type.SerializeField(""Map"", new DictWrap.SerializeImpl<string, StringWrap, C, IdWrap<C>>(this.Map));
+        type.SerializeField(""map"", new DictWrap.SerializeImpl<string, StringWrap, C, IdWrap<C>>(this.Map));
         type.End();
     }
 }")
@@ -477,7 +477,7 @@ partial class C : Serde.ISerialize
     void Serde.ISerialize.Serialize(ISerializer serializer)
     {
         var type = serializer.SerializeType(""C"", 1);
-        type.SerializeField(""RDictionary"", new IDictWrap.SerializeImpl<string, StringWrap, int, Int32Wrap>(this.RDictionary));
+        type.SerializeField(""rDictionary"", new IDictWrap.SerializeImpl<string, StringWrap, int, Int32Wrap>(this.RDictionary));
         type.End();
     }
 }");
@@ -527,7 +527,7 @@ partial class C : Serde.ISerialize
     void Serde.ISerialize.Serialize(ISerializer serializer)
     {
         var type = serializer.SerializeType(""C"", 1);
-        type.SerializeField(""S"", new SWrap(this.S));
+        type.SerializeField(""s"", new SWrap(this.S));
         type.End();
     }
 }");
@@ -559,7 +559,7 @@ public struct SWrap<T, TWrap> : ISerialize, ISerializeWrap<S<T>, SWrap<T, TWrap>
     void ISerialize.Serialize(ISerializer serializer)
     {
         var type = serializer.SerializeType(""S"", 1);
-        type.SerializeField(""S"", TWrap.Create(_s.Field));
+        type.SerializeField(""s"", TWrap.Create(_s.Field));
         type.End();
     }
 }
@@ -578,7 +578,7 @@ partial class C : Serde.ISerialize
     void Serde.ISerialize.Serialize(ISerializer serializer)
     {
         var type = serializer.SerializeType(""C"", 1);
-        type.SerializeField(""S"", new SWrap<int, Int32Wrap>(this.S));
+        type.SerializeField(""s"", new SWrap<int, Int32Wrap>(this.S));
         type.End();
     }
 }");
@@ -623,9 +623,9 @@ namespace Serde
         {
             var name = Value switch
             {
-                Some.Nested.Namespace.ColorInt.Red => "Red",
-                Some.Nested.Namespace.ColorInt.Green => "Green",
-                Some.Nested.Namespace.ColorInt.Blue => "Blue",
+                Some.Nested.Namespace.ColorInt.Red => "red",
+                Some.Nested.Namespace.ColorInt.Green => "green",
+                Some.Nested.Namespace.ColorInt.Blue => "blue",
                 _ => null
             };
             serializer.SerializeEnumValue("ColorInt", name, new Int32Wrap((int)Value));
@@ -651,9 +651,9 @@ namespace Serde
         {
             var name = Value switch
             {
-                Some.Nested.Namespace.ColorByte.Red => "Red",
-                Some.Nested.Namespace.ColorByte.Green => "Green",
-                Some.Nested.Namespace.ColorByte.Blue => "Blue",
+                Some.Nested.Namespace.ColorByte.Red => "red",
+                Some.Nested.Namespace.ColorByte.Green => "green",
+                Some.Nested.Namespace.ColorByte.Blue => "blue",
                 _ => null
             };
             serializer.SerializeEnumValue("ColorByte", name, new ByteWrap((byte)Value));
@@ -679,9 +679,9 @@ namespace Serde
         {
             var name = Value switch
             {
-                Some.Nested.Namespace.ColorLong.Red => "Red",
-                Some.Nested.Namespace.ColorLong.Green => "Green",
-                Some.Nested.Namespace.ColorLong.Blue => "Blue",
+                Some.Nested.Namespace.ColorLong.Red => "red",
+                Some.Nested.Namespace.ColorLong.Green => "green",
+                Some.Nested.Namespace.ColorLong.Blue => "blue",
                 _ => null
             };
             serializer.SerializeEnumValue("ColorLong", name, new Int64Wrap((long)Value));
@@ -707,9 +707,9 @@ namespace Serde
         {
             var name = Value switch
             {
-                Some.Nested.Namespace.ColorULong.Red => "Red",
-                Some.Nested.Namespace.ColorULong.Green => "Green",
-                Some.Nested.Namespace.ColorULong.Blue => "Blue",
+                Some.Nested.Namespace.ColorULong.Red => "red",
+                Some.Nested.Namespace.ColorULong.Green => "green",
+                Some.Nested.Namespace.ColorULong.Blue => "blue",
                 _ => null
             };
             serializer.SerializeEnumValue("ColorULong", name, new UInt64Wrap((ulong)Value));
@@ -729,10 +729,10 @@ namespace Some.Nested.Namespace
         void Serde.ISerialize.Serialize(ISerializer serializer)
         {
             var type = serializer.SerializeType("C", 4);
-            type.SerializeField("ColorInt", new ColorIntWrap(this.ColorInt));
-            type.SerializeField("ColorByte", new ColorByteWrap(this.ColorByte));
-            type.SerializeField("ColorLong", new ColorLongWrap(this.ColorLong));
-            type.SerializeField("ColorULong", new ColorULongWrap(this.ColorULong));
+            type.SerializeField("colorInt", new ColorIntWrap(this.ColorInt));
+            type.SerializeField("colorByte", new ColorByteWrap(this.ColorByte));
+            type.SerializeField("colorLong", new ColorLongWrap(this.ColorLong));
+            type.SerializeField("colorULong", new ColorULongWrap(this.ColorULong));
             type.End();
         }
     }

--- a/test/Serde.Test/GeneratorWrapperTests.cs
+++ b/test/Serde.Test/GeneratorWrapperTests.cs
@@ -72,8 +72,8 @@ partial struct PointWrap : Serde.ISerialize
     void Serde.ISerialize.Serialize(ISerializer serializer)
     {
         var type = serializer.SerializeType(""Point"", 2);
-        type.SerializeField(""X"", new Int32Wrap(_point.X));
-        type.SerializeField(""Y"", new Int32Wrap(_point.Y));
+        type.SerializeField(""x"", new Int32Wrap(_point.X));
+        type.SerializeField(""y"", new Int32Wrap(_point.Y));
         type.End();
     }
 }"),
@@ -101,10 +101,10 @@ partial struct PointWrap : Serde.IDeserialize<Point>
             {
                 switch (key)
                 {
-                    case ""X"":
+                    case ""x"":
                         x = d.GetNextValue<int, Int32Wrap>();
                         break;
-                    case ""Y"":
+                    case ""y"":
                         y = d.GetNextValue<int, Int32Wrap>();
                         break;
                     default:
@@ -148,8 +148,8 @@ namespace Serde
         void Serde.ISerialize.Serialize(ISerializer serializer)
         {
             var type = serializer.SerializeType(""Section"", 2);
-            type.SerializeField(""Mask"", new Int16Wrap(Value.Mask));
-            type.SerializeField(""Offset"", new Int16Wrap(Value.Offset));
+            type.SerializeField(""mask"", new Int16Wrap(Value.Mask));
+            type.SerializeField(""offset"", new Int16Wrap(Value.Offset));
             type.End();
         }
     }
@@ -163,7 +163,7 @@ partial class C : Serde.ISerialize
     void Serde.ISerialize.Serialize(ISerializer serializer)
     {
         var type = serializer.SerializeType(""C"", 1);
-        type.SerializeField(""S"", new BitVector32SectionWrap(this.S));
+        type.SerializeField(""s"", new BitVector32SectionWrap(this.S));
         type.End();
     }
 }")
@@ -212,10 +212,10 @@ namespace Serde
                 {
                     switch (key)
                     {
-                        case ""Mask"":
+                        case ""mask"":
                             mask = d.GetNextValue<short, Int16Wrap>();
                             break;
-                        case ""Offset"":
+                        case ""offset"":
                             offset = d.GetNextValue<short, Int16Wrap>();
                             break;
                         default:
@@ -253,7 +253,7 @@ partial class C : Serde.IDeserialize<C>
             {
                 switch (key)
                 {
-                    case ""S"":
+                    case ""s"":
                         s = d.GetNextValue<System.Collections.Specialized.BitVector32.Section, BitVector32SectionWrap>();
                         break;
                     default:
@@ -309,10 +309,10 @@ partial record R : Serde.IDeserialize<R>
             {
                 switch (key)
                 {
-                    case "A":
+                    case "a":
                         a = d.GetNextValue<int, Int32Wrap>();
                         break;
-                    case "B":
+                    case "b":
                         b = d.GetNextValue<string, StringWrap>();
                         break;
                     default:
@@ -367,13 +367,13 @@ partial class Address : Serde.ISerialize
     void Serde.ISerialize.Serialize(ISerializer serializer)
     {
         var type = serializer.SerializeType("Address", 5);
-        type.SerializeField("Name", new StringWrap(this.Name), new System.Attribute[]{new System.Xml.Serialization.XmlAttributeAttribute()
+        type.SerializeField("name", new StringWrap(this.Name), new System.Attribute[]{new System.Xml.Serialization.XmlAttributeAttribute()
         {}, new Serde.SerdeMemberOptions()
         {ProvideAttributes = true}});
-        type.SerializeField("Line1", new StringWrap(this.Line1));
-        type.SerializeField("City", new StringWrap(this.City));
-        type.SerializeField("State", new StringWrap(this.State));
-        type.SerializeField("Zip", new StringWrap(this.Zip));
+        type.SerializeField("line1", new StringWrap(this.Line1));
+        type.SerializeField("city", new StringWrap(this.City));
+        type.SerializeField("state", new StringWrap(this.State));
+        type.SerializeField("zip", new StringWrap(this.Zip));
         type.End();
     }
 }

--- a/test/Serde.Test/JsonDeserializeTests.cs
+++ b/test/Serde.Test/JsonDeserializeTests.cs
@@ -188,8 +188,8 @@ namespace Serde.Test
         {
             var src = @"
 {
-    ""Present"": ""abc"",
-    ""Extra"": ""def""
+    ""present"": ""abc"",
+    ""extra"": ""def""
 }";
             var result = JsonSerializer.Deserialize<SetToNull>(src);
             Assert.Equal("abc", result.Present);
@@ -216,8 +216,8 @@ namespace Serde.Test
         {
             var src = @"
 {
-    ""Present"": ""abc"",
-    ""Extra"": ""def""
+    ""present"": ""abc"",
+    ""extra"": ""def""
 }";
             Assert.Throws<InvalidDeserializeValueException>(() => JsonSerializer.Deserialize<ThrowMissing>(src));
         }
@@ -238,7 +238,7 @@ namespace Serde.Test
         {
             var src = @"
 {
-    ""Dict"": {
+    ""dict"": {
         ""def"": ""def"",
         ""abc"": null
     }

--- a/test/Serde.Test/JsonFsCheck.cs
+++ b/test/Serde.Test/JsonFsCheck.cs
@@ -49,7 +49,10 @@ namespace Serde.Test
             }
 
             var serializeStatements = new List<string>();
-            serializeStatements.Add("var options = new System.Text.Json.JsonSerializerOptions() { IncludeFields = true };");
+            serializeStatements.Add(@"var options = new System.Text.Json.JsonSerializerOptions() {
+                IncludeFields = true,
+                PropertyNamingPolicy = System.Text.Json.JsonNamingPolicy.CamelCase
+            };");
             for (int i = 0; i < wrappers.Length; i++)
             {
                 var localName = "t" + i;

--- a/test/Serde.Test/MemberFormatTests.cs
+++ b/test/Serde.Test/MemberFormatTests.cs
@@ -8,6 +8,34 @@ namespace Serde.Test
     public class MemberFormatTests
     {
         [Fact]
+        public Task Default()
+        {
+            var src = @"
+using Serde;
+
+[GenerateSerialize]
+partial struct S
+{
+    public int One { get; set; }
+    public int TwoWord { get; set; }
+}";
+            return VerifyGeneratedCode(src, "S.ISerialize", @"
+#nullable enable
+using Serde;
+
+partial struct S : Serde.ISerialize
+{
+    void Serde.ISerialize.Serialize(ISerializer serializer)
+    {
+        var type = serializer.SerializeType(""S"", 2);
+        type.SerializeField(""one"", new Int32Wrap(this.One));
+        type.SerializeField(""twoWord"", new Int32Wrap(this.TwoWord));
+        type.End();
+    }
+}");
+        }
+
+        [Fact]
         public Task CamelCase()
         {
             var src = @"
@@ -34,6 +62,213 @@ partial struct S : Serde.ISerialize
         type.End();
     }
 }");
+        }
+
+        [Fact]
+        public Task EnumValues()
+        {
+            var src = """
+using Serde;
+[GenerateSerialize, GenerateDeserialize]
+partial struct S
+{
+    public ColorEnum E;
+}
+[GenerateSerialize, GenerateDeserialize]
+[SerdeTypeOptions(MemberFormat = MemberFormat.None)]
+partial struct S2
+{
+    public ColorEnum E;
+}
+enum ColorEnum
+{
+    Red,
+    Green,
+    Blue
+}
+""";
+            return VerifyGeneratedCode(src, new[] {
+                ("Serde.ColorEnumWrap", """
+
+namespace Serde
+{
+    internal readonly partial record struct ColorEnumWrap(ColorEnum Value);
+}
+"""),
+                ("Serde.ColorEnumWrap.ISerialize", """
+
+#nullable enable
+using Serde;
+
+namespace Serde
+{
+    partial record struct ColorEnumWrap : Serde.ISerialize
+    {
+        void Serde.ISerialize.Serialize(ISerializer serializer)
+        {
+            var name = Value switch
+            {
+                ColorEnum.Red => "red",
+                ColorEnum.Green => "green",
+                ColorEnum.Blue => "blue",
+                _ => null
+            };
+            serializer.SerializeEnumValue("ColorEnum", name, new Int32Wrap((int)Value));
+        }
+    }
+}
+"""),
+                ("S.ISerialize", """
+
+#nullable enable
+using Serde;
+
+partial struct S : Serde.ISerialize
+{
+    void Serde.ISerialize.Serialize(ISerializer serializer)
+    {
+        var type = serializer.SerializeType("S", 1);
+        type.SerializeField("e", new ColorEnumWrap(this.E));
+        type.End();
+    }
+}
+"""),
+                ("Serde.ColorEnumWrap.IDeserialize", """
+
+#nullable enable
+using Serde;
+
+namespace Serde
+{
+    partial record struct ColorEnumWrap : Serde.IDeserialize<ColorEnum>
+    {
+        static ColorEnum Serde.IDeserialize<ColorEnum>.Deserialize<D>(ref D deserializer)
+        {
+            var visitor = new SerdeVisitor();
+            return deserializer.DeserializeString<ColorEnum, SerdeVisitor>(visitor);
+        }
+
+        private sealed class SerdeVisitor : Serde.IDeserializeVisitor<ColorEnum>
+        {
+            public string ExpectedTypeName => "ColorEnum";
+            ColorEnum Serde.IDeserializeVisitor<ColorEnum>.VisitString(string s)
+            {
+                ColorEnum enumValue;
+                switch (s)
+                {
+                    case "red":
+                        enumValue = ColorEnum.Red;
+                        break;
+                    case "green":
+                        enumValue = ColorEnum.Green;
+                        break;
+                    case "blue":
+                        enumValue = ColorEnum.Blue;
+                        break;
+                    default:
+                        throw new InvalidDeserializeValueException("Unexpected enum field name: " + s);
+                }
+
+                return enumValue;
+            }
+        }
+    }
+}
+"""),
+                ("S.IDeserialize", """
+
+#nullable enable
+using Serde;
+
+partial struct S : Serde.IDeserialize<S>
+{
+    static S Serde.IDeserialize<S>.Deserialize<D>(ref D deserializer)
+    {
+        var visitor = new SerdeVisitor();
+        var fieldNames = new[]{"E"};
+        return deserializer.DeserializeType<S, SerdeVisitor>("S", fieldNames, visitor);
+    }
+
+    private sealed class SerdeVisitor : Serde.IDeserializeVisitor<S>
+    {
+        public string ExpectedTypeName => "S";
+        S Serde.IDeserializeVisitor<S>.VisitDictionary<D>(ref D d)
+        {
+            Serde.Option<ColorEnum> e = default;
+            while (d.TryGetNextKey<string, StringWrap>(out string? key))
+            {
+                switch (key)
+                {
+                    case "e":
+                        e = d.GetNextValue<ColorEnum, ColorEnumWrap>();
+                        break;
+                    default:
+                        break;
+                }
+            }
+
+            var newType = new S()
+            {E = e.GetValueOrThrow("E"), };
+            return newType;
+        }
+    }
+}
+"""),
+                ("S2.ISerialize", """
+
+#nullable enable
+using Serde;
+
+partial struct S2 : Serde.ISerialize
+{
+    void Serde.ISerialize.Serialize(ISerializer serializer)
+    {
+        var type = serializer.SerializeType("S2", 1);
+        type.SerializeField("E", new ColorEnumWrap(this.E));
+        type.End();
+    }
+}
+"""),
+                ("S2.IDeserialize", """
+
+#nullable enable
+using Serde;
+
+partial struct S2 : Serde.IDeserialize<S2>
+{
+    static S2 Serde.IDeserialize<S2>.Deserialize<D>(ref D deserializer)
+    {
+        var visitor = new SerdeVisitor();
+        var fieldNames = new[]{"E"};
+        return deserializer.DeserializeType<S2, SerdeVisitor>("S2", fieldNames, visitor);
+    }
+
+    private sealed class SerdeVisitor : Serde.IDeserializeVisitor<S2>
+    {
+        public string ExpectedTypeName => "S2";
+        S2 Serde.IDeserializeVisitor<S2>.VisitDictionary<D>(ref D d)
+        {
+            Serde.Option<ColorEnum> e = default;
+            while (d.TryGetNextKey<string, StringWrap>(out string? key))
+            {
+                switch (key)
+                {
+                    case "E":
+                        e = d.GetNextValue<ColorEnum, ColorEnumWrap>();
+                        break;
+                    default:
+                        break;
+                }
+            }
+
+            var newType = new S2()
+            {E = e.GetValueOrThrow("E"), };
+            return newType;
+        }
+    }
+}
+"""),
+            });
         }
     }
 }

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.Generator/Serde.AllInOneColorEnumWrap.IDeserialize.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.Generator/Serde.AllInOneColorEnumWrap.IDeserialize.cs
@@ -20,13 +20,13 @@ namespace Serde
                 Serde.Test.AllInOne.ColorEnum enumValue;
                 switch (s)
                 {
-                    case "Red":
+                    case "red":
                         enumValue = Serde.Test.AllInOne.ColorEnum.Red;
                         break;
-                    case "Blue":
+                    case "blue":
                         enumValue = Serde.Test.AllInOne.ColorEnum.Blue;
                         break;
-                    case "Green":
+                    case "green":
                         enumValue = Serde.Test.AllInOne.ColorEnum.Green;
                         break;
                     default:

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.Generator/Serde.AllInOneColorEnumWrap.ISerialize.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.Generator/Serde.AllInOneColorEnumWrap.ISerialize.cs
@@ -10,9 +10,9 @@ namespace Serde
         {
             var name = Value switch
             {
-                Serde.Test.AllInOne.ColorEnum.Red => "Red",
-                Serde.Test.AllInOne.ColorEnum.Blue => "Blue",
-                Serde.Test.AllInOne.ColorEnum.Green => "Green",
+                Serde.Test.AllInOne.ColorEnum.Red => "red",
+                Serde.Test.AllInOne.ColorEnum.Blue => "blue",
+                Serde.Test.AllInOne.ColorEnum.Green => "green",
                 _ => null
             };
             serializer.SerializeEnumValue("ColorEnum", name, new Int32Wrap((int)Value));

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.Generator/Serde.Test.AllInOne.IDeserialize.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.Generator/Serde.Test.AllInOne.IDeserialize.cs
@@ -38,52 +38,52 @@ namespace Serde.Test
                 {
                     switch (key)
                     {
-                        case "BoolField":
+                        case "boolField":
                             boolfield = d.GetNextValue<bool, BoolWrap>();
                             break;
-                        case "CharField":
+                        case "charField":
                             charfield = d.GetNextValue<char, CharWrap>();
                             break;
-                        case "ByteField":
+                        case "byteField":
                             bytefield = d.GetNextValue<byte, ByteWrap>();
                             break;
-                        case "UShortField":
+                        case "uShortField":
                             ushortfield = d.GetNextValue<ushort, UInt16Wrap>();
                             break;
-                        case "UIntField":
+                        case "uIntField":
                             uintfield = d.GetNextValue<uint, UInt32Wrap>();
                             break;
-                        case "ULongField":
+                        case "uLongField":
                             ulongfield = d.GetNextValue<ulong, UInt64Wrap>();
                             break;
-                        case "SByteField":
+                        case "sByteField":
                             sbytefield = d.GetNextValue<sbyte, SByteWrap>();
                             break;
-                        case "ShortField":
+                        case "shortField":
                             shortfield = d.GetNextValue<short, Int16Wrap>();
                             break;
-                        case "IntField":
+                        case "intField":
                             intfield = d.GetNextValue<int, Int32Wrap>();
                             break;
-                        case "LongField":
+                        case "longField":
                             longfield = d.GetNextValue<long, Int64Wrap>();
                             break;
-                        case "StringField":
+                        case "stringField":
                             stringfield = d.GetNextValue<string, StringWrap>();
                             break;
-                        case "NullStringField":
+                        case "nullStringField":
                             nullstringfield = d.GetNextValue<string?, NullableRefWrap.DeserializeImpl<string, StringWrap>>();
                             break;
-                        case "UIntArr":
+                        case "uIntArr":
                             uintarr = d.GetNextValue<uint[], ArrayWrap.DeserializeImpl<uint, UInt32Wrap>>();
                             break;
-                        case "NestedArr":
+                        case "nestedArr":
                             nestedarr = d.GetNextValue<int[][], ArrayWrap.DeserializeImpl<int[], ArrayWrap.DeserializeImpl<int, Int32Wrap>>>();
                             break;
-                        case "IntImm":
+                        case "intImm":
                             intimm = d.GetNextValue<System.Collections.Immutable.ImmutableArray<int>, ImmutableArrayWrap.DeserializeImpl<int, Int32Wrap>>();
                             break;
-                        case "Color":
+                        case "color":
                             color = d.GetNextValue<Serde.Test.AllInOne.ColorEnum, AllInOneColorEnumWrap>();
                             break;
                         default:

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.Generator/Serde.Test.AllInOne.ISerialize.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.Generator/Serde.Test.AllInOne.ISerialize.cs
@@ -9,22 +9,22 @@ namespace Serde.Test
         void Serde.ISerialize.Serialize(ISerializer serializer)
         {
             var type = serializer.SerializeType("AllInOne", 16);
-            type.SerializeField("BoolField", new BoolWrap(this.BoolField));
-            type.SerializeField("CharField", new CharWrap(this.CharField));
-            type.SerializeField("ByteField", new ByteWrap(this.ByteField));
-            type.SerializeField("UShortField", new UInt16Wrap(this.UShortField));
-            type.SerializeField("UIntField", new UInt32Wrap(this.UIntField));
-            type.SerializeField("ULongField", new UInt64Wrap(this.ULongField));
-            type.SerializeField("SByteField", new SByteWrap(this.SByteField));
-            type.SerializeField("ShortField", new Int16Wrap(this.ShortField));
-            type.SerializeField("IntField", new Int32Wrap(this.IntField));
-            type.SerializeField("LongField", new Int64Wrap(this.LongField));
-            type.SerializeField("StringField", new StringWrap(this.StringField));
-            type.SerializeFieldIfNotNull("NullStringField", new NullableRefWrap.SerializeImpl<string, StringWrap>(this.NullStringField), this.NullStringField);
-            type.SerializeField("UIntArr", new ArrayWrap.SerializeImpl<uint, UInt32Wrap>(this.UIntArr));
-            type.SerializeField("NestedArr", new ArrayWrap.SerializeImpl<int[], ArrayWrap.SerializeImpl<int, Int32Wrap>>(this.NestedArr));
-            type.SerializeField("IntImm", new ImmutableArrayWrap.SerializeImpl<int, Int32Wrap>(this.IntImm));
-            type.SerializeField("Color", new AllInOneColorEnumWrap(this.Color));
+            type.SerializeField("boolField", new BoolWrap(this.BoolField));
+            type.SerializeField("charField", new CharWrap(this.CharField));
+            type.SerializeField("byteField", new ByteWrap(this.ByteField));
+            type.SerializeField("uShortField", new UInt16Wrap(this.UShortField));
+            type.SerializeField("uIntField", new UInt32Wrap(this.UIntField));
+            type.SerializeField("uLongField", new UInt64Wrap(this.ULongField));
+            type.SerializeField("sByteField", new SByteWrap(this.SByteField));
+            type.SerializeField("shortField", new Int16Wrap(this.ShortField));
+            type.SerializeField("intField", new Int32Wrap(this.IntField));
+            type.SerializeField("longField", new Int64Wrap(this.LongField));
+            type.SerializeField("stringField", new StringWrap(this.StringField));
+            type.SerializeFieldIfNotNull("nullStringField", new NullableRefWrap.SerializeImpl<string, StringWrap>(this.NullStringField), this.NullStringField);
+            type.SerializeField("uIntArr", new ArrayWrap.SerializeImpl<uint, UInt32Wrap>(this.UIntArr));
+            type.SerializeField("nestedArr", new ArrayWrap.SerializeImpl<int[], ArrayWrap.SerializeImpl<int, Int32Wrap>>(this.NestedArr));
+            type.SerializeField("intImm", new ImmutableArrayWrap.SerializeImpl<int, Int32Wrap>(this.IntImm));
+            type.SerializeField("color", new AllInOneColorEnumWrap(this.Color));
             type.End();
         }
     }

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.Generator/Serde.Test.JsonDeserializeTests.NullableFields.IDeserialize.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.Generator/Serde.Test.JsonDeserializeTests.NullableFields.IDeserialize.cs
@@ -26,10 +26,10 @@ namespace Serde.Test
                     {
                         switch (key)
                         {
-                            case "S":
+                            case "s":
                                 s = d.GetNextValue<string?, NullableRefWrap.DeserializeImpl<string, StringWrap>>();
                                 break;
-                            case "Dict":
+                            case "dict":
                                 dict = d.GetNextValue<System.Collections.Generic.Dictionary<string, string?>, DictWrap.DeserializeImpl<string, StringWrap, string?, NullableRefWrap.DeserializeImpl<string, StringWrap>>>();
                                 break;
                             default:

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.Generator/Serde.Test.JsonDeserializeTests.SetToNull.IDeserialize.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.Generator/Serde.Test.JsonDeserializeTests.SetToNull.IDeserialize.cs
@@ -26,10 +26,10 @@ namespace Serde.Test
                     {
                         switch (key)
                         {
-                            case "Present":
+                            case "present":
                                 present = d.GetNextValue<string, StringWrap>();
                                 break;
-                            case "Missing":
+                            case "missing":
                                 missing = d.GetNextValue<string?, NullableRefWrap.DeserializeImpl<string, StringWrap>>();
                                 break;
                             default:

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.Generator/Serde.Test.JsonDeserializeTests.ThrowMissing.IDeserialize.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.Generator/Serde.Test.JsonDeserializeTests.ThrowMissing.IDeserialize.cs
@@ -26,10 +26,10 @@ namespace Serde.Test
                     {
                         switch (key)
                         {
-                            case "Present":
+                            case "present":
                                 present = d.GetNextValue<string, StringWrap>();
                                 break;
-                            case "Missing":
+                            case "missing":
                                 missing = d.GetNextValue<string?, NullableRefWrap.DeserializeImpl<string, StringWrap>>();
                                 break;
                             default:

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.Generator/Serde.Test.JsonSerializerTests.NullableFields.ISerialize.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.Generator/Serde.Test.JsonSerializerTests.NullableFields.ISerialize.cs
@@ -11,8 +11,8 @@ namespace Serde.Test
             void Serde.ISerialize.Serialize(ISerializer serializer)
             {
                 var type = serializer.SerializeType("NullableFields", 2);
-                type.SerializeFieldIfNotNull("S", new NullableRefWrap.SerializeImpl<string, StringWrap>(this.S), this.S);
-                type.SerializeField("D", new DictWrap.SerializeImpl<string, StringWrap, string?, NullableRefWrap.SerializeImpl<string, StringWrap>>(this.D));
+                type.SerializeFieldIfNotNull("s", new NullableRefWrap.SerializeImpl<string, StringWrap>(this.S), this.S);
+                type.SerializeField("d", new DictWrap.SerializeImpl<string, StringWrap, string?, NullableRefWrap.SerializeImpl<string, StringWrap>>(this.D));
                 type.End();
             }
         }

--- a/test/Serde.Xml.Test/SampleTest.cs
+++ b/test/Serde.Xml.Test/SampleTest.cs
@@ -18,6 +18,7 @@ public partial class SampleTest
        the xsi:null attribute appears if the class instance is set to
        a null reference. */
     [GenerateSerialize]
+    [SerdeTypeOptions(MemberFormat = MemberFormat.None)]
     //[XmlRoot("PurchaseOrder", IsNullable = false)]
     public partial record PurchaseOrder
     {
@@ -34,6 +35,7 @@ public partial class SampleTest
     }
 
     [GenerateSerialize]
+    [SerdeTypeOptions(MemberFormat = MemberFormat.None)]
     public partial record Address
     {
         /* The XmlAttribute instructs the XmlSerializer to serialize the Name
@@ -54,6 +56,7 @@ public partial class SampleTest
     }
 
     [GenerateSerialize]
+    [SerdeTypeOptions(MemberFormat = MemberFormat.None)]
     public partial record OrderedItem
     {
         public string ItemName = null!;

--- a/test/Serde.Xml.Test/XmlTests.cs
+++ b/test/Serde.Xml.Test/XmlTests.cs
@@ -11,23 +11,23 @@ namespace Serde.Test
         private const string AllInOneSerialized = """
 <?xml version="1.0" encoding="utf-16"?>
 <AllInOne>
-  <BoolField>true</BoolField>
-  <CharField>#</CharField>
-  <ByteField>255</ByteField>
-  <UShortField>65535</UShortField>
-  <UIntField>4294967295</UIntField>
-  <ULongField>18446744073709551615</ULongField>
-  <SByteField>127</SByteField>
-  <ShortField>32767</ShortField>
-  <IntField>2147483647</IntField>
-  <LongField>9223372036854775807</LongField>
-  <StringField>StringValue</StringField>
-  <UIntArr>
+  <boolField>true</boolField>
+  <charField>#</charField>
+  <byteField>255</byteField>
+  <uShortField>65535</uShortField>
+  <uIntField>4294967295</uIntField>
+  <uLongField>18446744073709551615</uLongField>
+  <sByteField>127</sByteField>
+  <shortField>32767</shortField>
+  <intField>2147483647</intField>
+  <longField>9223372036854775807</longField>
+  <stringField>StringValue</stringField>
+  <uIntArr>
     <int>1</int>
     <int>2</int>
     <int>3</int>
-  </UIntArr>
-  <NestedArr>
+  </uIntArr>
+  <nestedArr>
     <ArrayOfArrayOfInt32>
       <ArrayOfInt32>
         <int>1</int>
@@ -36,14 +36,14 @@ namespace Serde.Test
         <int>2</int>
       </ArrayOfInt32>
     </ArrayOfArrayOfInt32>
-  </NestedArr>
-  <IntImm>
+  </nestedArr>
+  <intImm>
     <ImmutableArrayOfInt32>
       <int>1</int>
       <int>2</int>
     </ImmutableArrayOfInt32>
-  </IntImm>
-  <Color />
+  </intImm>
+  <color />
 </AllInOne>
 """;
 
@@ -67,6 +67,7 @@ namespace Serde.Test
         }
 
         [GenerateSerialize]
+        [SerdeTypeOptions(MemberFormat = MemberFormat.None)]
         public partial class NestedArrays
         {
             public int[][][] A = new[] { new[] { new[] { 1, 2, 3 } } };
@@ -94,6 +95,7 @@ namespace Serde.Test
         }
 
         [GenerateSerialize]
+        [SerdeTypeOptions(MemberFormat = MemberFormat.None)]
         public partial class TypeWithArrayField
         {
             public StructWithIntField[] ArrayField = new[] {
@@ -104,6 +106,7 @@ namespace Serde.Test
         }
 
         [GenerateSerialize]
+        [SerdeTypeOptions(MemberFormat = MemberFormat.None)]
         public partial record StructWithIntField(int X)
         {
             public StructWithIntField() : this(11) { }
@@ -135,6 +138,7 @@ namespace Serde.Test
         }
 
         [GenerateSerialize]
+        [SerdeTypeOptions(MemberFormat = MemberFormat.None)]
         public partial struct BoolStruct
         {
             public bool BoolField;
@@ -155,6 +159,7 @@ namespace Serde.Test
         }
 
         [GenerateSerialize]
+        [SerdeTypeOptions(MemberFormat = MemberFormat.None)]
         public partial class MapTest1
         {
             public Dictionary<string, int> MapField = new Dictionary<string, int>()

--- a/test/Serde.Xml.Test/generated/SerdeGenerator/Serde.Generator/Serde.AllInOneColorEnumWrap.IDeserialize.cs
+++ b/test/Serde.Xml.Test/generated/SerdeGenerator/Serde.Generator/Serde.AllInOneColorEnumWrap.IDeserialize.cs
@@ -20,13 +20,13 @@ namespace Serde
                 Serde.Test.AllInOne.ColorEnum enumValue;
                 switch (s)
                 {
-                    case "Red":
+                    case "red":
                         enumValue = Serde.Test.AllInOne.ColorEnum.Red;
                         break;
-                    case "Blue":
+                    case "blue":
                         enumValue = Serde.Test.AllInOne.ColorEnum.Blue;
                         break;
-                    case "Green":
+                    case "green":
                         enumValue = Serde.Test.AllInOne.ColorEnum.Green;
                         break;
                     default:

--- a/test/Serde.Xml.Test/generated/SerdeGenerator/Serde.Generator/Serde.AllInOneColorEnumWrap.ISerialize.cs
+++ b/test/Serde.Xml.Test/generated/SerdeGenerator/Serde.Generator/Serde.AllInOneColorEnumWrap.ISerialize.cs
@@ -10,9 +10,9 @@ namespace Serde
         {
             var name = Value switch
             {
-                Serde.Test.AllInOne.ColorEnum.Red => "Red",
-                Serde.Test.AllInOne.ColorEnum.Blue => "Blue",
-                Serde.Test.AllInOne.ColorEnum.Green => "Green",
+                Serde.Test.AllInOne.ColorEnum.Red => "red",
+                Serde.Test.AllInOne.ColorEnum.Blue => "blue",
+                Serde.Test.AllInOne.ColorEnum.Green => "green",
                 _ => null
             };
             serializer.SerializeEnumValue("ColorEnum", name, new Int32Wrap((int)Value));

--- a/test/Serde.Xml.Test/generated/SerdeGenerator/Serde.Generator/Serde.Test.AllInOne.IDeserialize.cs
+++ b/test/Serde.Xml.Test/generated/SerdeGenerator/Serde.Generator/Serde.Test.AllInOne.IDeserialize.cs
@@ -38,52 +38,52 @@ namespace Serde.Test
                 {
                     switch (key)
                     {
-                        case "BoolField":
+                        case "boolField":
                             boolfield = d.GetNextValue<bool, BoolWrap>();
                             break;
-                        case "CharField":
+                        case "charField":
                             charfield = d.GetNextValue<char, CharWrap>();
                             break;
-                        case "ByteField":
+                        case "byteField":
                             bytefield = d.GetNextValue<byte, ByteWrap>();
                             break;
-                        case "UShortField":
+                        case "uShortField":
                             ushortfield = d.GetNextValue<ushort, UInt16Wrap>();
                             break;
-                        case "UIntField":
+                        case "uIntField":
                             uintfield = d.GetNextValue<uint, UInt32Wrap>();
                             break;
-                        case "ULongField":
+                        case "uLongField":
                             ulongfield = d.GetNextValue<ulong, UInt64Wrap>();
                             break;
-                        case "SByteField":
+                        case "sByteField":
                             sbytefield = d.GetNextValue<sbyte, SByteWrap>();
                             break;
-                        case "ShortField":
+                        case "shortField":
                             shortfield = d.GetNextValue<short, Int16Wrap>();
                             break;
-                        case "IntField":
+                        case "intField":
                             intfield = d.GetNextValue<int, Int32Wrap>();
                             break;
-                        case "LongField":
+                        case "longField":
                             longfield = d.GetNextValue<long, Int64Wrap>();
                             break;
-                        case "StringField":
+                        case "stringField":
                             stringfield = d.GetNextValue<string, StringWrap>();
                             break;
-                        case "NullStringField":
+                        case "nullStringField":
                             nullstringfield = d.GetNextValue<string?, NullableRefWrap.DeserializeImpl<string, StringWrap>>();
                             break;
-                        case "UIntArr":
+                        case "uIntArr":
                             uintarr = d.GetNextValue<uint[], ArrayWrap.DeserializeImpl<uint, UInt32Wrap>>();
                             break;
-                        case "NestedArr":
+                        case "nestedArr":
                             nestedarr = d.GetNextValue<int[][], ArrayWrap.DeserializeImpl<int[], ArrayWrap.DeserializeImpl<int, Int32Wrap>>>();
                             break;
-                        case "IntImm":
+                        case "intImm":
                             intimm = d.GetNextValue<System.Collections.Immutable.ImmutableArray<int>, ImmutableArrayWrap.DeserializeImpl<int, Int32Wrap>>();
                             break;
-                        case "Color":
+                        case "color":
                             color = d.GetNextValue<Serde.Test.AllInOne.ColorEnum, AllInOneColorEnumWrap>();
                             break;
                         default:

--- a/test/Serde.Xml.Test/generated/SerdeGenerator/Serde.Generator/Serde.Test.AllInOne.ISerialize.cs
+++ b/test/Serde.Xml.Test/generated/SerdeGenerator/Serde.Generator/Serde.Test.AllInOne.ISerialize.cs
@@ -9,22 +9,22 @@ namespace Serde.Test
         void Serde.ISerialize.Serialize(ISerializer serializer)
         {
             var type = serializer.SerializeType("AllInOne", 16);
-            type.SerializeField("BoolField", new BoolWrap(this.BoolField));
-            type.SerializeField("CharField", new CharWrap(this.CharField));
-            type.SerializeField("ByteField", new ByteWrap(this.ByteField));
-            type.SerializeField("UShortField", new UInt16Wrap(this.UShortField));
-            type.SerializeField("UIntField", new UInt32Wrap(this.UIntField));
-            type.SerializeField("ULongField", new UInt64Wrap(this.ULongField));
-            type.SerializeField("SByteField", new SByteWrap(this.SByteField));
-            type.SerializeField("ShortField", new Int16Wrap(this.ShortField));
-            type.SerializeField("IntField", new Int32Wrap(this.IntField));
-            type.SerializeField("LongField", new Int64Wrap(this.LongField));
-            type.SerializeField("StringField", new StringWrap(this.StringField));
-            type.SerializeFieldIfNotNull("NullStringField", new NullableRefWrap.SerializeImpl<string, StringWrap>(this.NullStringField), this.NullStringField);
-            type.SerializeField("UIntArr", new ArrayWrap.SerializeImpl<uint, UInt32Wrap>(this.UIntArr));
-            type.SerializeField("NestedArr", new ArrayWrap.SerializeImpl<int[], ArrayWrap.SerializeImpl<int, Int32Wrap>>(this.NestedArr));
-            type.SerializeField("IntImm", new ImmutableArrayWrap.SerializeImpl<int, Int32Wrap>(this.IntImm));
-            type.SerializeField("Color", new AllInOneColorEnumWrap(this.Color));
+            type.SerializeField("boolField", new BoolWrap(this.BoolField));
+            type.SerializeField("charField", new CharWrap(this.CharField));
+            type.SerializeField("byteField", new ByteWrap(this.ByteField));
+            type.SerializeField("uShortField", new UInt16Wrap(this.UShortField));
+            type.SerializeField("uIntField", new UInt32Wrap(this.UIntField));
+            type.SerializeField("uLongField", new UInt64Wrap(this.ULongField));
+            type.SerializeField("sByteField", new SByteWrap(this.SByteField));
+            type.SerializeField("shortField", new Int16Wrap(this.ShortField));
+            type.SerializeField("intField", new Int32Wrap(this.IntField));
+            type.SerializeField("longField", new Int64Wrap(this.LongField));
+            type.SerializeField("stringField", new StringWrap(this.StringField));
+            type.SerializeFieldIfNotNull("nullStringField", new NullableRefWrap.SerializeImpl<string, StringWrap>(this.NullStringField), this.NullStringField);
+            type.SerializeField("uIntArr", new ArrayWrap.SerializeImpl<uint, UInt32Wrap>(this.UIntArr));
+            type.SerializeField("nestedArr", new ArrayWrap.SerializeImpl<int[], ArrayWrap.SerializeImpl<int, Int32Wrap>>(this.NestedArr));
+            type.SerializeField("intImm", new ImmutableArrayWrap.SerializeImpl<int, Int32Wrap>(this.IntImm));
+            type.SerializeField("color", new AllInOneColorEnumWrap(this.Color));
             type.End();
         }
     }


### PR DESCRIPTION
The current default formatting is to write fields with exactly the
same casing as they are in the source code. However, the vast majority
of JSON files are formatted with camelCase. Since JSON is the most popular
format, this means that the most common serialization format is camelCase.
Thus, it makes sense for Serde to write camelCase by default, especially
since it incurs no performance cost due to source generation.

To achieve the old behavior, users can pass MemberFormat.None.