### PR TITLE
Allow struct visitors and use them for compound deserialize

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,4 +19,4 @@ jobs:
     - name: Pack
       run: ./build.sh --pack
     - name: Publish package
-      run: dotnet nuget push -k ${{ secrets.NUGET_API_KEY }} -s https://api.nuget.org/v3/index.json artifacts/pack/*.nupkg
+      run: dotnet nuget push --skip-duplicate -k ${{ secrets.NUGET_API_KEY }} -s https://api.nuget.org/v3/index.json artifacts/pack/*.nupkg

--- a/src/pack/Serde.Pkg.proj
+++ b/src/pack/Serde.Pkg.proj
@@ -5,7 +5,7 @@
     <TargetFramework>net7.0</TargetFramework>
 
     <PackageId>Serde</PackageId>
-    <PackageVersion>0.4.2</PackageVersion>
+    <PackageVersion>0.4.3</PackageVersion>
     <IsPackable>true</IsPackable>
     <PackageOutputPath>$(ArtifactsPath)pack</PackageOutputPath>
     <PackageLicenseExpression>BSD-3-Clause</PackageLicenseExpression>

--- a/src/serde/IDeserialize.cs
+++ b/src/serde/IDeserialize.cs
@@ -80,25 +80,25 @@ namespace Serde
 
     public interface IDeserializer
     {
-        T DeserializeAny<T, V>(V v) where V : class, IDeserializeVisitor<T>;
-        T DeserializeBool<T, V>(V v) where V : class, IDeserializeVisitor<T>;
-        T DeserializeChar<T, V>(V v) where V : class, IDeserializeVisitor<T>;
-        T DeserializeByte<T, V>(V v) where V : class, IDeserializeVisitor<T>;
-        T DeserializeU16<T, V>(V v) where V : class, IDeserializeVisitor<T>;
-        T DeserializeU32<T, V>(V v) where V : class, IDeserializeVisitor<T>;
-        T DeserializeU64<T, V>(V v) where V : class, IDeserializeVisitor<T>;
-        T DeserializeSByte<T, V>(V v) where V : class, IDeserializeVisitor<T>;
-        T DeserializeI16<T, V>(V v) where V : class, IDeserializeVisitor<T>;
-        T DeserializeI32<T, V>(V v) where V : class, IDeserializeVisitor<T>;
-        T DeserializeI64<T, V>(V v) where V : class, IDeserializeVisitor<T>;
-        T DeserializeFloat<T, V>(V v) where V : class, IDeserializeVisitor<T>;
-        T DeserializeDouble<T, V>(V v) where V : class, IDeserializeVisitor<T>;
-        T DeserializeDecimal<T, V>(V v) where V : class, IDeserializeVisitor<T>;
-        T DeserializeString<T, V>(V v) where V : class, IDeserializeVisitor<T>;
-        T DeserializeIdentifier<T, V>(V v) where V : class, IDeserializeVisitor<T>;
-        T DeserializeType<T, V>(string typeName, ReadOnlySpan<string> fieldNames, V v) where V : class, IDeserializeVisitor<T>;
-        T DeserializeEnumerable<T, V>(V v) where V : class, IDeserializeVisitor<T>;
-        T DeserializeDictionary<T, V>(V v) where V : class, IDeserializeVisitor<T>;
-        T DeserializeNullableRef<T, V>(V v) where V : class, IDeserializeVisitor<T>;
+        T DeserializeAny<T, V>(V v) where V : IDeserializeVisitor<T>;
+        T DeserializeBool<T, V>(V v) where V : IDeserializeVisitor<T>;
+        T DeserializeChar<T, V>(V v) where V : IDeserializeVisitor<T>;
+        T DeserializeByte<T, V>(V v) where V : IDeserializeVisitor<T>;
+        T DeserializeU16<T, V>(V v) where V : IDeserializeVisitor<T>;
+        T DeserializeU32<T, V>(V v) where V : IDeserializeVisitor<T>;
+        T DeserializeU64<T, V>(V v) where V : IDeserializeVisitor<T>;
+        T DeserializeSByte<T, V>(V v) where V : IDeserializeVisitor<T>;
+        T DeserializeI16<T, V>(V v) where V : IDeserializeVisitor<T>;
+        T DeserializeI32<T, V>(V v) where V : IDeserializeVisitor<T>;
+        T DeserializeI64<T, V>(V v) where V : IDeserializeVisitor<T>;
+        T DeserializeFloat<T, V>(V v) where V : IDeserializeVisitor<T>;
+        T DeserializeDouble<T, V>(V v) where V : IDeserializeVisitor<T>;
+        T DeserializeDecimal<T, V>(V v) where V : IDeserializeVisitor<T>;
+        T DeserializeString<T, V>(V v) where V : IDeserializeVisitor<T>;
+        T DeserializeIdentifier<T, V>(V v) where V : IDeserializeVisitor<T>;
+        T DeserializeType<T, V>(string typeName, ReadOnlySpan<string> fieldNames, V v) where V : IDeserializeVisitor<T>;
+        T DeserializeEnumerable<T, V>(V v) where V : IDeserializeVisitor<T>;
+        T DeserializeDictionary<T, V>(V v) where V : IDeserializeVisitor<T>;
+        T DeserializeNullableRef<T, V>(V v) where V : IDeserializeVisitor<T>;
     }
 }

--- a/src/serde/Wrappers.Dictionary.cs
+++ b/src/serde/Wrappers.Dictionary.cs
@@ -40,7 +40,7 @@ namespace Serde
             {
                 return deserializer.DeserializeDictionary<Dictionary<TKey, TValue>, Visitor>(new Visitor());
             }
-            private sealed class Visitor : IDeserializeVisitor<Dictionary<TKey, TValue>>
+            private struct Visitor : IDeserializeVisitor<Dictionary<TKey, TValue>>
             {
                 public string ExpectedTypeName => "Dictionary<" + typeof(TKey).Name + ", " + typeof(TValue).Name + ">";
                 public Dictionary<TKey, TValue> VisitDictionary<D>(ref D d)

--- a/src/serde/Wrappers.List.cs
+++ b/src/serde/Wrappers.List.cs
@@ -73,7 +73,7 @@ namespace Serde
             {
                 return deserializer.DeserializeEnumerable<T[], SerdeVisitor>(new SerdeVisitor());
             }
-            private sealed class SerdeVisitor : IDeserializeVisitor<T[]>
+            private struct SerdeVisitor : IDeserializeVisitor<T[]>
             {
                 string IDeserializeVisitor<T[]>.ExpectedTypeName => typeof(T[]).ToString();
 
@@ -125,7 +125,7 @@ namespace Serde
             {
                 return deserializer.DeserializeEnumerable<List<T>, SerdeVisitor>(new SerdeVisitor());
             }
-            private sealed class SerdeVisitor : IDeserializeVisitor<List<T>>
+            private struct SerdeVisitor : IDeserializeVisitor<List<T>>
             {
                 string IDeserializeVisitor<List<T>>.ExpectedTypeName => typeof(T[]).ToString();
 
@@ -177,7 +177,7 @@ namespace Serde
                     Visitor>(new Visitor());
             }
 
-            private sealed class Visitor : IDeserializeVisitor<ImmutableArray<T>>
+            private struct Visitor : IDeserializeVisitor<ImmutableArray<T>>
             {
                 public string ExpectedTypeName => typeof(ImmutableArray<T>).ToString();
                 ImmutableArray<T> IDeserializeVisitor<ImmutableArray<T>>.VisitEnumerable<D>(ref D d)

--- a/src/serde/Wrappers.cs
+++ b/src/serde/Wrappers.cs
@@ -469,7 +469,7 @@ namespace Serde
                 return deserializer.DeserializeNullableRef<T?, Visitor>(new Visitor());
             }
 
-            private sealed class Visitor : IDeserializeVisitor<T?>
+            private struct Visitor : IDeserializeVisitor<T?>
             {
                 public string ExpectedTypeName => typeof(T).ToString() + "?";
 

--- a/src/serde/json/JsonDeserializer.cs
+++ b/src/serde/json/JsonDeserializer.cs
@@ -48,7 +48,7 @@ namespace Serde.Json
                 _state.ReaderState);
         }
 
-        public T DeserializeAny<T, V>(V v) where V : class, IDeserializeVisitor<T>
+        public T DeserializeAny<T, V>(V v) where V : IDeserializeVisitor<T>
         {
             var reader = GetReader();
             reader.ReadOrThrow();
@@ -82,7 +82,7 @@ namespace Serde.Json
             return result;
         }
 
-        public T DeserializeBool<T, V>(V v) where V : class, IDeserializeVisitor<T>
+        public T DeserializeBool<T, V>(V v) where V : IDeserializeVisitor<T>
         {
             var reader = GetReader();
             reader.ReadOrThrow();
@@ -91,7 +91,7 @@ namespace Serde.Json
             return v.VisitBool(b);
         }
 
-        public T DeserializeDictionary<T, V>(V v) where V : class, IDeserializeVisitor<T>
+        public T DeserializeDictionary<T, V>(V v) where V : IDeserializeVisitor<T>
         {
             var reader = GetReader();
             reader.ReadOrThrow();
@@ -106,10 +106,10 @@ namespace Serde.Json
             return v.VisitDictionary(ref map);
         }
 
-        public T DeserializeFloat<T, V>(V v) where V : class, IDeserializeVisitor<T>
+        public T DeserializeFloat<T, V>(V v) where V : IDeserializeVisitor<T>
             => DeserializeDouble<T, V>(v);
 
-        public T DeserializeDouble<T, V>(V v) where V : class, IDeserializeVisitor<T>
+        public T DeserializeDouble<T, V>(V v) where V : IDeserializeVisitor<T>
         {
             var reader = GetReader();
             var d = reader.GetDouble();
@@ -117,7 +117,7 @@ namespace Serde.Json
             return v.VisitDouble(d);
         }
 
-        public T DeserializeDecimal<T, V>(V v) where V : class, IDeserializeVisitor<T>
+        public T DeserializeDecimal<T, V>(V v) where V : IDeserializeVisitor<T>
         {
             var reader = GetReader();
             var d = reader.GetDecimal();
@@ -125,7 +125,7 @@ namespace Serde.Json
             return v.VisitDecimal(d);
         }
 
-        public T DeserializeEnumerable<T, V>(V v) where V : class, IDeserializeVisitor<T>
+        public T DeserializeEnumerable<T, V>(V v) where V : IDeserializeVisitor<T>
         {
             var reader = GetReader();
             reader.ReadOrThrow();
@@ -226,17 +226,17 @@ namespace Serde.Json
             }
         }
 
-        public T DeserializeSByte<T, V>(V v) where V : class, IDeserializeVisitor<T>
+        public T DeserializeSByte<T, V>(V v) where V : IDeserializeVisitor<T>
             => DeserializeI64<T, V>(v);
 
-        public T DeserializeI16<T, V>(V v) where V : class, IDeserializeVisitor<T>
+        public T DeserializeI16<T, V>(V v) where V : IDeserializeVisitor<T>
             => DeserializeI64<T, V>(v);
 
 
-        public T DeserializeI32<T, V>(V v) where V : class, IDeserializeVisitor<T>
+        public T DeserializeI32<T, V>(V v) where V : IDeserializeVisitor<T>
             => DeserializeI64<T, V>(v);
 
-        public T DeserializeI64<T, V>(V v) where V : class, IDeserializeVisitor<T>
+        public T DeserializeI64<T, V>(V v) where V : IDeserializeVisitor<T>
         {
             var reader = GetReader();
             reader.ReadOrThrow();
@@ -245,7 +245,7 @@ namespace Serde.Json
             return v.VisitI64(i64);
         }
 
-        public T DeserializeString<T, V>(V v) where V : class, IDeserializeVisitor<T>
+        public T DeserializeString<T, V>(V v) where V : IDeserializeVisitor<T>
         {
             var reader = GetReader();
             reader.ReadOrThrow();
@@ -256,25 +256,25 @@ namespace Serde.Json
                 : v.VisitString(s);
         }
 
-        public T DeserializeIdentifier<T, V>(V v) where V : class, IDeserializeVisitor<T>
+        public T DeserializeIdentifier<T, V>(V v) where V : IDeserializeVisitor<T>
             => DeserializeString<T, V>(v);
 
-        public T DeserializeType<T, V>(string typeName, ReadOnlySpan<string> fieldNames, V v) where V : class, IDeserializeVisitor<T>
+        public T DeserializeType<T, V>(string typeName, ReadOnlySpan<string> fieldNames, V v) where V : IDeserializeVisitor<T>
         {
             // Types are identical to dictionaries
             return DeserializeDictionary<T, V>(v);
         }
 
-        public T DeserializeByte<T, V>(V v) where V : class, IDeserializeVisitor<T>
+        public T DeserializeByte<T, V>(V v) where V : IDeserializeVisitor<T>
             => DeserializeU64<T, V>(v);
 
-        public T DeserializeU16<T, V>(V v) where V : class, IDeserializeVisitor<T>
+        public T DeserializeU16<T, V>(V v) where V : IDeserializeVisitor<T>
             => DeserializeU64<T, V>(v);
 
-        public T DeserializeU32<T, V>(V v) where V : class, IDeserializeVisitor<T>
+        public T DeserializeU32<T, V>(V v) where V : IDeserializeVisitor<T>
             => DeserializeU64<T, V>(v);
 
-        public T DeserializeU64<T, V>(V v) where V : class, IDeserializeVisitor<T>
+        public T DeserializeU64<T, V>(V v) where V : IDeserializeVisitor<T>
         {
             var reader = GetReader();
             reader.ReadOrThrow();
@@ -283,11 +283,11 @@ namespace Serde.Json
             return v.VisitU64(u64);
         }
 
-        public T DeserializeChar<T, V>(V v) where V : class, IDeserializeVisitor<T>
+        public T DeserializeChar<T, V>(V v) where V : IDeserializeVisitor<T>
             => DeserializeString<T, V>(v);
 
         public T DeserializeNullableRef<T, V>(V v)
-            where V : class, IDeserializeVisitor<T>
+            where V : IDeserializeVisitor<T>
         {
             var reader = GetReader();
             reader.ReadOrThrow();


### PR DESCRIPTION
Struct visitors are useful (no allocations), but they're tricky, as side-effects may not be preserved when they are copied by the underlying deserializer.

Most importantly, a Native AOT bug
(https://github.com/dotnet/runtime/issues/77070) currently causes some static abstract interface calls to fail when they have to be loaded at runtime. Generic specialization can avoid this. By using a struct visitor for some compound calls (dictionaries, enumerables, nullables) the likelihood of hitting this is reduced.