### PR TITLE
Fix deserialization of enums as generic arguments

### DIFF
--- a/src/generator/Generator.Deserialize.cs
+++ b/src/generator/Generator.Deserialize.cs
@@ -256,15 +256,7 @@ namespace Serde
                 {
                     wrapperName = memberType;
                 }
-                else if (TryGetPrimitiveWrapper(m.Type, SerdeUsage.Deserialize) is { } primWrap)
-                {
-                    wrapperName = primWrap;
-                }
-                else if (TryGetCompoundWrapper(m.Type, context, SerdeUsage.Deserialize) is { } compound)
-                {
-                    wrapperName = compound.ToString();
-                }
-                else if (TryCreateWrapper(m, context, SerdeUsage.Deserialize) is { } wrap)
+                else if (TryGetAnyWrapper(m.Type, context, SerdeUsage.Deserialize) is {} wrap)
                 {
                     wrapperName = wrap.ToString();
                 }

--- a/src/pack/Serde.Pkg.proj
+++ b/src/pack/Serde.Pkg.proj
@@ -5,7 +5,7 @@
     <TargetFramework>net7.0</TargetFramework>
 
     <PackageId>Serde</PackageId>
-    <PackageVersion>0.4.3</PackageVersion>
+    <PackageVersion>0.4.4</PackageVersion>
     <IsPackable>true</IsPackable>
     <PackageOutputPath>$(ArtifactsPath)pack</PackageOutputPath>
     <PackageLicenseExpression>BSD-3-Clause</PackageLicenseExpression>

--- a/test/Serde.Test/GeneratorWrapperTests.cs
+++ b/test/Serde.Test/GeneratorWrapperTests.cs
@@ -379,5 +379,115 @@ partial class Address : Serde.ISerialize
 }
 """) });
         }
+
+        [Fact]
+        public Task ImmutableArrayEnumDeserialize()
+        {
+            var src = """
+using System.Collections.Immutable;
+namespace Test;
+
+public enum Channel { A, B, C }
+
+[Serde.GenerateDeserialize]
+internal partial record struct ChannelList
+{
+    public ImmutableArray<Channel> Channels { get; init; }
+}
+""";
+            return VerifyGeneratedCode(src, new[] {
+                ("Serde.ChannelWrap", """
+
+namespace Serde
+{
+    internal readonly partial record struct ChannelWrap(Test.Channel Value);
+}
+"""),
+                ("Serde.ChannelWrap.IDeserialize", """
+
+#nullable enable
+using Serde;
+
+namespace Serde
+{
+    partial record struct ChannelWrap : Serde.IDeserialize<Test.Channel>
+    {
+        static Test.Channel Serde.IDeserialize<Test.Channel>.Deserialize<D>(ref D deserializer)
+        {
+            var visitor = new SerdeVisitor();
+            return deserializer.DeserializeString<Test.Channel, SerdeVisitor>(visitor);
+        }
+
+        private sealed class SerdeVisitor : Serde.IDeserializeVisitor<Test.Channel>
+        {
+            public string ExpectedTypeName => "Test.Channel";
+            Test.Channel Serde.IDeserializeVisitor<Test.Channel>.VisitString(string s)
+            {
+                Test.Channel enumValue;
+                switch (s)
+                {
+                    case "a":
+                        enumValue = Test.Channel.A;
+                        break;
+                    case "b":
+                        enumValue = Test.Channel.B;
+                        break;
+                    case "c":
+                        enumValue = Test.Channel.C;
+                        break;
+                    default:
+                        throw new InvalidDeserializeValueException("Unexpected enum field name: " + s);
+                }
+
+                return enumValue;
+            }
+        }
+    }
+}
+"""),
+                ("Test.ChannelList.IDeserialize", """
+
+#nullable enable
+using Serde;
+
+namespace Test
+{
+    partial record struct ChannelList : Serde.IDeserialize<Test.ChannelList>
+    {
+        static Test.ChannelList Serde.IDeserialize<Test.ChannelList>.Deserialize<D>(ref D deserializer)
+        {
+            var visitor = new SerdeVisitor();
+            var fieldNames = new[]{"Channels"};
+            return deserializer.DeserializeType<Test.ChannelList, SerdeVisitor>("ChannelList", fieldNames, visitor);
+        }
+
+        private sealed class SerdeVisitor : Serde.IDeserializeVisitor<Test.ChannelList>
+        {
+            public string ExpectedTypeName => "Test.ChannelList";
+            Test.ChannelList Serde.IDeserializeVisitor<Test.ChannelList>.VisitDictionary<D>(ref D d)
+            {
+                Serde.Option<System.Collections.Immutable.ImmutableArray<Test.Channel>> channels = default;
+                while (d.TryGetNextKey<string, StringWrap>(out string? key))
+                {
+                    switch (key)
+                    {
+                        case "channels":
+                            channels = d.GetNextValue<System.Collections.Immutable.ImmutableArray<Test.Channel>, ImmutableArrayWrap.DeserializeImpl<Test.Channel, ChannelWrap>>();
+                            break;
+                        default:
+                            break;
+                    }
+                }
+
+                var newType = new Test.ChannelList()
+                {Channels = channels.GetValueOrThrow("Channels"), };
+                return newType;
+            }
+        }
+    }
+}
+"""),
+            });
+        }
     }
 }


### PR DESCRIPTION
In the case of compound types where wrappers are needed (e.g., lists), the generator code didn't attempt to create wrappers for enums. This resulted in bad codegen for deserializing compound types containing enums.

The code has been slightly refactored to make forgetting this harder, by introducing a new method to try to centralize wrapper fetching.