### PR TITLE
Add support for skipping members

### DIFF
--- a/src/generator/ConfigOptions.cs
+++ b/src/generator/ConfigOptions.cs
@@ -4,7 +4,7 @@ using Microsoft.CodeAnalysis;
 
 namespace Serde;
 
-internal readonly record struct TypeOptions()
+internal record TypeOptions
 {
     public bool DenyUnknownMembers { get; init; } = false;
     public MemberFormat MemberFormat { get; init; } = MemberFormat.CamelCase;
@@ -25,4 +25,13 @@ internal readonly record struct MemberOptions()
 
     /// <see cref="SerdeMemberOptions.ProvideAttributes" />
     public bool? SerializeNull { get; init; } = null;
+
+    /// <see cref="SerdeMemberOptions.Skip" />
+    public bool Skip { get; init; } = false;
+
+    /// <see cref="SerdeMemberOptions.SkipSerialize" />
+    public bool SkipSerialize { get; init; } = false;
+
+    /// <see cref="SerdeMemberOptions.SkipDeserialize" />
+    public bool SkipDeserialize { get; init; } = false;
 }

--- a/src/generator/Generator.Deserialize.cs
+++ b/src/generator/Generator.Deserialize.cs
@@ -113,7 +113,7 @@ namespace Serde
             else
             {
                 // 3. Custom type
-                var members = SymbolUtilities.GetPublicDataMembers(typeSymbol);
+                var members = SymbolUtilities.GetDataMembers(typeSymbol, SerdeUsage.Deserialize);
                 var namesArray = ImplicitArrayCreationExpression(InitializerExpression(
                     SyntaxKind.ArrayInitializerExpression,
                     SeparatedList(members.Select(d => (ExpressionSyntax)StringLiteral(d.Name)))));
@@ -201,7 +201,7 @@ namespace Serde
             else if (type.TypeKind == TypeKind.Enum)
             {
                 var cases = new StringBuilder();
-                foreach (var m in SymbolUtilities.GetPublicDataMembers(type))
+                foreach (var m in SymbolUtilities.GetDataMembers(type, SerdeUsage.Deserialize))
                 {
                     cases.Append(@$"
         case ""{m.GetFormattedName()}"":
@@ -247,7 +247,7 @@ namespace Serde
         {
             var cases = new StringBuilder();
             var locals = new StringBuilder();
-            var members = SymbolUtilities.GetPublicDataMembers(type);
+            var members = SymbolUtilities.GetDataMembers(type, SerdeUsage.Deserialize);
             foreach (var m in members)
             {
                 string wrapperName;

--- a/src/generator/Generator.Serialize.cs
+++ b/src/generator/Generator.Serialize.cs
@@ -21,7 +21,7 @@ namespace Serde
             ExpressionSyntax receiverExpr)
         {
             var statements = new List<StatementSyntax>();
-            var fieldsAndProps = SymbolUtilities.GetPublicDataMembers(receiverType);
+            var fieldsAndProps = SymbolUtilities.GetDataMembers(receiverType, SerdeUsage.Serialize);
 
             if (receiverType.TypeKind == TypeKind.Enum)
             {

--- a/src/pack/Serde.Pkg.proj
+++ b/src/pack/Serde.Pkg.proj
@@ -5,7 +5,7 @@
     <TargetFramework>net7.0</TargetFramework>
 
     <PackageId>Serde</PackageId>
-    <PackageVersion>0.4.4</PackageVersion>
+    <PackageVersion>0.4.5</PackageVersion>
     <IsPackable>true</IsPackable>
     <PackageOutputPath>$(ArtifactsPath)pack</PackageOutputPath>
     <PackageLicenseExpression>BSD-3-Clause</PackageLicenseExpression>

--- a/src/serde/Attributes.cs
+++ b/src/serde/Attributes.cs
@@ -143,6 +143,21 @@ sealed class SerdeMemberOptions : Attribute
     /// serialization.
     /// </summary>
     public bool SerializeNull { get; init; } = false;
+
+    /// <summary>
+    /// Skip both serialization and deserialization of this member.
+    /// </summary>
+    public bool Skip { get; init; } = false;
+
+    /// <summary>
+    /// Skip serialization of this member.
+    /// </summary>
+    public bool SkipSerialize { get; init; } = false;
+
+    /// <summary>
+    /// Skip deserialization of this member.
+    /// </summary>
+    public bool SkipDeserialize { get; init; } = false;
 }
 
 /// <summary>

--- a/test/Serde.Test/GeneratorDeserializeTests.cs
+++ b/test/Serde.Test/GeneratorDeserializeTests.cs
@@ -9,6 +9,186 @@ namespace Serde.Test
     public class GeneratorDeserializeTests
     {
         [Fact]
+        public Task MemberSkip()
+        {
+            var src = """
+using Serde;
+[GenerateDeserialize]
+partial struct Rgb
+{
+    public byte Red;
+    [SerdeMemberOptions(Skip = true)]
+    public byte Green;
+    public byte Blue;
+}
+""";
+            return VerifyDeserialize(src, "Rgb", """
+
+#nullable enable
+using Serde;
+
+partial struct Rgb : Serde.IDeserialize<Rgb>
+{
+    static Rgb Serde.IDeserialize<Rgb>.Deserialize<D>(ref D deserializer)
+    {
+        var visitor = new SerdeVisitor();
+        var fieldNames = new[]{"Red", "Blue"};
+        return deserializer.DeserializeType<Rgb, SerdeVisitor>("Rgb", fieldNames, visitor);
+    }
+
+    private sealed class SerdeVisitor : Serde.IDeserializeVisitor<Rgb>
+    {
+        public string ExpectedTypeName => "Rgb";
+        Rgb Serde.IDeserializeVisitor<Rgb>.VisitDictionary<D>(ref D d)
+        {
+            Serde.Option<byte> red = default;
+            Serde.Option<byte> blue = default;
+            while (d.TryGetNextKey<string, StringWrap>(out string? key))
+            {
+                switch (key)
+                {
+                    case "red":
+                        red = d.GetNextValue<byte, ByteWrap>();
+                        break;
+                    case "blue":
+                        blue = d.GetNextValue<byte, ByteWrap>();
+                        break;
+                    default:
+                        break;
+                }
+            }
+
+            var newType = new Rgb()
+            {Red = red.GetValueOrThrow("Red"), Blue = blue.GetValueOrThrow("Blue"), };
+            return newType;
+        }
+    }
+}
+""");
+        }
+
+        [Fact]
+        public Task MemberSkipSerialize()
+        {
+            var src = """
+using Serde;
+[GenerateDeserialize]
+partial struct Rgb
+{
+    public byte Red;
+    [SerdeMemberOptions(SkipDeserialize = true)]
+    public byte Green;
+    public byte Blue;
+}
+""";
+            return VerifyDeserialize(src, "Rgb", """
+
+#nullable enable
+using Serde;
+
+partial struct Rgb : Serde.IDeserialize<Rgb>
+{
+    static Rgb Serde.IDeserialize<Rgb>.Deserialize<D>(ref D deserializer)
+    {
+        var visitor = new SerdeVisitor();
+        var fieldNames = new[]{"Red", "Blue"};
+        return deserializer.DeserializeType<Rgb, SerdeVisitor>("Rgb", fieldNames, visitor);
+    }
+
+    private sealed class SerdeVisitor : Serde.IDeserializeVisitor<Rgb>
+    {
+        public string ExpectedTypeName => "Rgb";
+        Rgb Serde.IDeserializeVisitor<Rgb>.VisitDictionary<D>(ref D d)
+        {
+            Serde.Option<byte> red = default;
+            Serde.Option<byte> blue = default;
+            while (d.TryGetNextKey<string, StringWrap>(out string? key))
+            {
+                switch (key)
+                {
+                    case "red":
+                        red = d.GetNextValue<byte, ByteWrap>();
+                        break;
+                    case "blue":
+                        blue = d.GetNextValue<byte, ByteWrap>();
+                        break;
+                    default:
+                        break;
+                }
+            }
+
+            var newType = new Rgb()
+            {Red = red.GetValueOrThrow("Red"), Blue = blue.GetValueOrThrow("Blue"), };
+            return newType;
+        }
+    }
+}
+""");
+        }
+
+        [Fact]
+        public Task MemberSkipDeserialize()
+        {
+            var src = """
+using Serde;
+[GenerateDeserialize]
+partial struct Rgb
+{
+    public byte Red;
+    [SerdeMemberOptions(SkipSerialize = true)]
+    public byte Green;
+    public byte Blue;
+}
+""";
+            return VerifyDeserialize(src, "Rgb", """
+
+#nullable enable
+using Serde;
+
+partial struct Rgb : Serde.IDeserialize<Rgb>
+{
+    static Rgb Serde.IDeserialize<Rgb>.Deserialize<D>(ref D deserializer)
+    {
+        var visitor = new SerdeVisitor();
+        var fieldNames = new[]{"Red", "Green", "Blue"};
+        return deserializer.DeserializeType<Rgb, SerdeVisitor>("Rgb", fieldNames, visitor);
+    }
+
+    private sealed class SerdeVisitor : Serde.IDeserializeVisitor<Rgb>
+    {
+        public string ExpectedTypeName => "Rgb";
+        Rgb Serde.IDeserializeVisitor<Rgb>.VisitDictionary<D>(ref D d)
+        {
+            Serde.Option<byte> red = default;
+            Serde.Option<byte> green = default;
+            Serde.Option<byte> blue = default;
+            while (d.TryGetNextKey<string, StringWrap>(out string? key))
+            {
+                switch (key)
+                {
+                    case "red":
+                        red = d.GetNextValue<byte, ByteWrap>();
+                        break;
+                    case "green":
+                        green = d.GetNextValue<byte, ByteWrap>();
+                        break;
+                    case "blue":
+                        blue = d.GetNextValue<byte, ByteWrap>();
+                        break;
+                    default:
+                        break;
+                }
+            }
+
+            var newType = new Rgb()
+            {Red = red.GetValueOrThrow("Red"), Green = green.GetValueOrThrow("Green"), Blue = blue.GetValueOrThrow("Blue"), };
+            return newType;
+        }
+    }
+}
+""");
+        }
+        [Fact]
         public Task Rgb()
         {
             var src = @"

--- a/test/Serde.Test/GeneratorSerializeTests.cs
+++ b/test/Serde.Test/GeneratorSerializeTests.cs
@@ -10,6 +10,103 @@ namespace Serde.Test
     public class GeneratorSerializeTests
     {
         [Fact]
+        public Task MemberSkip()
+        {
+            var src = """
+using Serde;
+[GenerateSerialize]
+partial struct Rgb
+{
+    public byte Red;
+    [SerdeMemberOptions(Skip = true)]
+    public byte Green;
+    public byte Blue;
+}
+""";
+            return VerifySerialize(src, "Rgb", """
+
+#nullable enable
+using Serde;
+
+partial struct Rgb : Serde.ISerialize
+{
+    void Serde.ISerialize.Serialize(ISerializer serializer)
+    {
+        var type = serializer.SerializeType("Rgb", 2);
+        type.SerializeField("red", new ByteWrap(this.Red));
+        type.SerializeField("blue", new ByteWrap(this.Blue));
+        type.End();
+    }
+}
+""");
+        }
+
+        [Fact]
+        public Task MemberSkipSerialize()
+        {
+            var src = """
+using Serde;
+[GenerateSerialize]
+partial struct Rgb
+{
+    public byte Red;
+    [SerdeMemberOptions(SkipSerialize = true)]
+    public byte Green;
+    public byte Blue;
+}
+""";
+            return VerifySerialize(src, "Rgb", """
+
+#nullable enable
+using Serde;
+
+partial struct Rgb : Serde.ISerialize
+{
+    void Serde.ISerialize.Serialize(ISerializer serializer)
+    {
+        var type = serializer.SerializeType("Rgb", 2);
+        type.SerializeField("red", new ByteWrap(this.Red));
+        type.SerializeField("blue", new ByteWrap(this.Blue));
+        type.End();
+    }
+}
+""");
+        }
+
+        [Fact]
+        public Task MemberSkipDeserialize()
+        {
+            var src = """
+using Serde;
+[GenerateSerialize]
+partial struct Rgb
+{
+    public byte Red;
+    [SerdeMemberOptions(SkipDeserialize = true)]
+    public byte Green;
+    public byte Blue;
+}
+""";
+            return VerifySerialize(src, "Rgb", """
+
+#nullable enable
+using Serde;
+
+partial struct Rgb : Serde.ISerialize
+{
+    void Serde.ISerialize.Serialize(ISerializer serializer)
+    {
+        var type = serializer.SerializeType("Rgb", 3);
+        type.SerializeField("red", new ByteWrap(this.Red));
+        type.SerializeField("green", new ByteWrap(this.Green));
+        type.SerializeField("blue", new ByteWrap(this.Blue));
+        type.End();
+    }
+}
+""");
+        }
+
+        [Fact]
         public Task Rgb()
         {
             var src = @"


### PR DESCRIPTION
Adds three new switches to SerdeMemberOptions: Skip, SkipSerialize, and SkipDeserialize. When any of them are true and the usage matches the flag, that member will be skipped for serialization or deserialization respectively. These flags are used to opt-out members that normally would be included in (de)serialization.