### PR TITLE
Add VisitUtf8Span to deserialize and use in JSON

### DIFF
--- a/src/serde/IDeserialize.cs
+++ b/src/serde/IDeserialize.cs
@@ -61,6 +61,7 @@ namespace Serde
         T VisitDouble(double d) => throw new InvalidDeserializeValueException("Expected type " + ExpectedTypeName);
         T VisitDecimal(decimal d) => throw new InvalidDeserializeValueException("Expected type " + ExpectedTypeName);
         T VisitString(string s) => throw new InvalidDeserializeValueException("Expected type " + ExpectedTypeName);
+        T VisitUtf8Span(ReadOnlySpan<byte> s) => throw new InvalidDeserializeValueException("Expected type " + ExpectedTypeName);
         T VisitEnumerable<D>(ref D d) where D : IDeserializeEnumerable
             => throw new InvalidDeserializeValueException("Expected type " + ExpectedTypeName);
         T VisitDictionary<D>(ref D d) where D : IDeserializeDictionary

--- a/src/serde/Wrappers.cs
+++ b/src/serde/Wrappers.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Diagnostics;
+using System.Text;
 
 namespace Serde
 {
@@ -62,13 +63,18 @@ namespace Serde
         {
             public string ExpectedTypeName => s_typeName;
             char IDeserializeVisitor<char>.VisitChar(char c) => c;
-            char IDeserializeVisitor<char>.VisitString(string s)
+            char IDeserializeVisitor<char>.VisitString(string s) => GetChar(s);
+            private char GetChar(string s)
             {
                 if (s.Length == 1)
                 {
                     return s[0];
                 }
                 throw new InvalidDeserializeValueException("Expected type " + ExpectedTypeName);
+            }
+            char IDeserializeVisitor<char>.VisitUtf8Span(ReadOnlySpan<byte> s)
+            {
+                return GetChar(Encoding.UTF8.GetString(s));
             }
         }
     }
@@ -385,6 +391,7 @@ namespace Serde
             public string ExpectedTypeName => s_typeName;
             public string VisitString(string s) => s;
             string IDeserializeVisitor<string>.VisitChar(char c) => c.ToString();
+            string IDeserializeVisitor<string>.VisitUtf8Span(ReadOnlySpan<byte> s) => Encoding.UTF8.GetString(s);
         }
     }
 

--- a/src/serde/json/JsonValue.Deserialize.cs
+++ b/src/serde/json/JsonValue.Deserialize.cs
@@ -1,5 +1,7 @@
 
+using System;
 using System.Collections.Immutable;
+using System.Text;
 
 namespace Serde.Json
 {
@@ -42,6 +44,7 @@ namespace Serde.Json
             public JsonValue VisitBool(bool b) => new Bool(b);
             public JsonValue VisitI64(long i) => new Number(i);
             public JsonValue VisitString(string s) => new String(s);
+            public JsonValue VisitUtf8Span(ReadOnlySpan<byte> s) => VisitString(Encoding.UTF8.GetString(s));
         }
     }
 }

--- a/test/Serde.Test/AllInOneJsonTest.cs
+++ b/test/Serde.Test/AllInOneJsonTest.cs
@@ -198,26 +198,18 @@ namespace Serde
         private sealed class SerdeVisitor : Serde.IDeserializeVisitor<Serde.Test.AllInOne.ColorEnum>
         {
             public string ExpectedTypeName => "Serde.Test.AllInOne.ColorEnum";
-            Serde.Test.AllInOne.ColorEnum Serde.IDeserializeVisitor<Serde.Test.AllInOne.ColorEnum>.VisitString(string s)
+            Serde.Test.AllInOne.ColorEnum Serde.IDeserializeVisitor<Serde.Test.AllInOne.ColorEnum>.VisitString(string s) => s switch
             {
-                Serde.Test.AllInOne.ColorEnum enumValue;
-                switch (s)
-                {
-                    case "red":
-                        enumValue = Serde.Test.AllInOne.ColorEnum.Red;
-                        break;
-                    case "blue":
-                        enumValue = Serde.Test.AllInOne.ColorEnum.Blue;
-                        break;
-                    case "green":
-                        enumValue = Serde.Test.AllInOne.ColorEnum.Green;
-                        break;
-                    default:
-                        throw new InvalidDeserializeValueException("Unexpected enum field name: " + s);
-                }
-
-                return enumValue;
-            }
+                "red" => Serde.Test.AllInOne.ColorEnum.Red,
+                "blue" => Serde.Test.AllInOne.ColorEnum.Blue,
+                "green" => Serde.Test.AllInOne.ColorEnum.Green,
+                _ => throw new InvalidDeserializeValueException("Unexpected enum field name: " + s)};
+            Serde.Test.AllInOne.ColorEnum Serde.IDeserializeVisitor<Serde.Test.AllInOne.ColorEnum>.VisitUtf8Span(System.ReadOnlySpan<byte> s) => s switch
+            {
+                _ when System.MemoryExtensions.SequenceEqual(s, "red"u8) => Serde.Test.AllInOne.ColorEnum.Red,
+                _ when System.MemoryExtensions.SequenceEqual(s, "blue"u8) => Serde.Test.AllInOne.ColorEnum.Blue,
+                _ when System.MemoryExtensions.SequenceEqual(s, "green"u8) => Serde.Test.AllInOne.ColorEnum.Green,
+                _ => throw new InvalidDeserializeValueException("Unexpected enum field name: " + System.Text.Encoding.UTF8.GetString(s))};
         }
     }
 }

--- a/test/Serde.Test/GeneratorDeserializeTests.cs
+++ b/test/Serde.Test/GeneratorDeserializeTests.cs
@@ -446,26 +446,18 @@ namespace Serde
         private sealed class SerdeVisitor : Serde.IDeserializeVisitor<ColorInt>
         {
             public string ExpectedTypeName => "ColorInt";
-            ColorInt Serde.IDeserializeVisitor<ColorInt>.VisitString(string s)
+            ColorInt Serde.IDeserializeVisitor<ColorInt>.VisitString(string s) => s switch
             {
-                ColorInt enumValue;
-                switch (s)
-                {
-                    case "red":
-                        enumValue = ColorInt.Red;
-                        break;
-                    case "green":
-                        enumValue = ColorInt.Green;
-                        break;
-                    case "blue":
-                        enumValue = ColorInt.Blue;
-                        break;
-                    default:
-                        throw new InvalidDeserializeValueException("Unexpected enum field name: " + s);
-                }
-
-                return enumValue;
-            }
+                "red" => ColorInt.Red,
+                "green" => ColorInt.Green,
+                "blue" => ColorInt.Blue,
+                _ => throw new InvalidDeserializeValueException("Unexpected enum field name: " + s)};
+            ColorInt Serde.IDeserializeVisitor<ColorInt>.VisitUtf8Span(System.ReadOnlySpan<byte> s) => s switch
+            {
+                _ when System.MemoryExtensions.SequenceEqual(s, "red"u8) => ColorInt.Red,
+                _ when System.MemoryExtensions.SequenceEqual(s, "green"u8) => ColorInt.Green,
+                _ when System.MemoryExtensions.SequenceEqual(s, "blue"u8) => ColorInt.Blue,
+                _ => throw new InvalidDeserializeValueException("Unexpected enum field name: " + System.Text.Encoding.UTF8.GetString(s))};
         }
     }
 }
@@ -493,26 +485,18 @@ namespace Serde
         private sealed class SerdeVisitor : Serde.IDeserializeVisitor<ColorByte>
         {
             public string ExpectedTypeName => "ColorByte";
-            ColorByte Serde.IDeserializeVisitor<ColorByte>.VisitString(string s)
+            ColorByte Serde.IDeserializeVisitor<ColorByte>.VisitString(string s) => s switch
             {
-                ColorByte enumValue;
-                switch (s)
-                {
-                    case "red":
-                        enumValue = ColorByte.Red;
-                        break;
-                    case "green":
-                        enumValue = ColorByte.Green;
-                        break;
-                    case "blue":
-                        enumValue = ColorByte.Blue;
-                        break;
-                    default:
-                        throw new InvalidDeserializeValueException("Unexpected enum field name: " + s);
-                }
-
-                return enumValue;
-            }
+                "red" => ColorByte.Red,
+                "green" => ColorByte.Green,
+                "blue" => ColorByte.Blue,
+                _ => throw new InvalidDeserializeValueException("Unexpected enum field name: " + s)};
+            ColorByte Serde.IDeserializeVisitor<ColorByte>.VisitUtf8Span(System.ReadOnlySpan<byte> s) => s switch
+            {
+                _ when System.MemoryExtensions.SequenceEqual(s, "red"u8) => ColorByte.Red,
+                _ when System.MemoryExtensions.SequenceEqual(s, "green"u8) => ColorByte.Green,
+                _ when System.MemoryExtensions.SequenceEqual(s, "blue"u8) => ColorByte.Blue,
+                _ => throw new InvalidDeserializeValueException("Unexpected enum field name: " + System.Text.Encoding.UTF8.GetString(s))};
         }
     }
 }
@@ -540,26 +524,18 @@ namespace Serde
         private sealed class SerdeVisitor : Serde.IDeserializeVisitor<ColorLong>
         {
             public string ExpectedTypeName => "ColorLong";
-            ColorLong Serde.IDeserializeVisitor<ColorLong>.VisitString(string s)
+            ColorLong Serde.IDeserializeVisitor<ColorLong>.VisitString(string s) => s switch
             {
-                ColorLong enumValue;
-                switch (s)
-                {
-                    case "red":
-                        enumValue = ColorLong.Red;
-                        break;
-                    case "green":
-                        enumValue = ColorLong.Green;
-                        break;
-                    case "blue":
-                        enumValue = ColorLong.Blue;
-                        break;
-                    default:
-                        throw new InvalidDeserializeValueException("Unexpected enum field name: " + s);
-                }
-
-                return enumValue;
-            }
+                "red" => ColorLong.Red,
+                "green" => ColorLong.Green,
+                "blue" => ColorLong.Blue,
+                _ => throw new InvalidDeserializeValueException("Unexpected enum field name: " + s)};
+            ColorLong Serde.IDeserializeVisitor<ColorLong>.VisitUtf8Span(System.ReadOnlySpan<byte> s) => s switch
+            {
+                _ when System.MemoryExtensions.SequenceEqual(s, "red"u8) => ColorLong.Red,
+                _ when System.MemoryExtensions.SequenceEqual(s, "green"u8) => ColorLong.Green,
+                _ when System.MemoryExtensions.SequenceEqual(s, "blue"u8) => ColorLong.Blue,
+                _ => throw new InvalidDeserializeValueException("Unexpected enum field name: " + System.Text.Encoding.UTF8.GetString(s))};
         }
     }
 }
@@ -587,26 +563,18 @@ namespace Serde
         private sealed class SerdeVisitor : Serde.IDeserializeVisitor<ColorULong>
         {
             public string ExpectedTypeName => "ColorULong";
-            ColorULong Serde.IDeserializeVisitor<ColorULong>.VisitString(string s)
+            ColorULong Serde.IDeserializeVisitor<ColorULong>.VisitString(string s) => s switch
             {
-                ColorULong enumValue;
-                switch (s)
-                {
-                    case "red":
-                        enumValue = ColorULong.Red;
-                        break;
-                    case "green":
-                        enumValue = ColorULong.Green;
-                        break;
-                    case "blue":
-                        enumValue = ColorULong.Blue;
-                        break;
-                    default:
-                        throw new InvalidDeserializeValueException("Unexpected enum field name: " + s);
-                }
-
-                return enumValue;
-            }
+                "red" => ColorULong.Red,
+                "green" => ColorULong.Green,
+                "blue" => ColorULong.Blue,
+                _ => throw new InvalidDeserializeValueException("Unexpected enum field name: " + s)};
+            ColorULong Serde.IDeserializeVisitor<ColorULong>.VisitUtf8Span(System.ReadOnlySpan<byte> s) => s switch
+            {
+                _ when System.MemoryExtensions.SequenceEqual(s, "red"u8) => ColorULong.Red,
+                _ when System.MemoryExtensions.SequenceEqual(s, "green"u8) => ColorULong.Green,
+                _ when System.MemoryExtensions.SequenceEqual(s, "blue"u8) => ColorULong.Blue,
+                _ => throw new InvalidDeserializeValueException("Unexpected enum field name: " + System.Text.Encoding.UTF8.GetString(s))};
         }
     }
 }

--- a/test/Serde.Test/GeneratorWrapperTests.cs
+++ b/test/Serde.Test/GeneratorWrapperTests.cs
@@ -421,26 +421,18 @@ namespace Serde
         private sealed class SerdeVisitor : Serde.IDeserializeVisitor<Test.Channel>
         {
             public string ExpectedTypeName => "Test.Channel";
-            Test.Channel Serde.IDeserializeVisitor<Test.Channel>.VisitString(string s)
+            Test.Channel Serde.IDeserializeVisitor<Test.Channel>.VisitString(string s) => s switch
             {
-                Test.Channel enumValue;
-                switch (s)
-                {
-                    case "a":
-                        enumValue = Test.Channel.A;
-                        break;
-                    case "b":
-                        enumValue = Test.Channel.B;
-                        break;
-                    case "c":
-                        enumValue = Test.Channel.C;
-                        break;
-                    default:
-                        throw new InvalidDeserializeValueException("Unexpected enum field name: " + s);
-                }
-
-                return enumValue;
-            }
+                "a" => Test.Channel.A,
+                "b" => Test.Channel.B,
+                "c" => Test.Channel.C,
+                _ => throw new InvalidDeserializeValueException("Unexpected enum field name: " + s)};
+            Test.Channel Serde.IDeserializeVisitor<Test.Channel>.VisitUtf8Span(System.ReadOnlySpan<byte> s) => s switch
+            {
+                _ when System.MemoryExtensions.SequenceEqual(s, "a"u8) => Test.Channel.A,
+                _ when System.MemoryExtensions.SequenceEqual(s, "b"u8) => Test.Channel.B,
+                _ when System.MemoryExtensions.SequenceEqual(s, "c"u8) => Test.Channel.C,
+                _ => throw new InvalidDeserializeValueException("Unexpected enum field name: " + System.Text.Encoding.UTF8.GetString(s))};
         }
     }
 }

--- a/test/Serde.Test/MemberFormatTests.cs
+++ b/test/Serde.Test/MemberFormatTests.cs
@@ -151,26 +151,18 @@ namespace Serde
         private sealed class SerdeVisitor : Serde.IDeserializeVisitor<ColorEnum>
         {
             public string ExpectedTypeName => "ColorEnum";
-            ColorEnum Serde.IDeserializeVisitor<ColorEnum>.VisitString(string s)
+            ColorEnum Serde.IDeserializeVisitor<ColorEnum>.VisitString(string s) => s switch
             {
-                ColorEnum enumValue;
-                switch (s)
-                {
-                    case "red":
-                        enumValue = ColorEnum.Red;
-                        break;
-                    case "green":
-                        enumValue = ColorEnum.Green;
-                        break;
-                    case "blue":
-                        enumValue = ColorEnum.Blue;
-                        break;
-                    default:
-                        throw new InvalidDeserializeValueException("Unexpected enum field name: " + s);
-                }
-
-                return enumValue;
-            }
+                "red" => ColorEnum.Red,
+                "green" => ColorEnum.Green,
+                "blue" => ColorEnum.Blue,
+                _ => throw new InvalidDeserializeValueException("Unexpected enum field name: " + s)};
+            ColorEnum Serde.IDeserializeVisitor<ColorEnum>.VisitUtf8Span(System.ReadOnlySpan<byte> s) => s switch
+            {
+                _ when System.MemoryExtensions.SequenceEqual(s, "red"u8) => ColorEnum.Red,
+                _ when System.MemoryExtensions.SequenceEqual(s, "green"u8) => ColorEnum.Green,
+                _ when System.MemoryExtensions.SequenceEqual(s, "blue"u8) => ColorEnum.Blue,
+                _ => throw new InvalidDeserializeValueException("Unexpected enum field name: " + System.Text.Encoding.UTF8.GetString(s))};
         }
     }
 }
@@ -346,5 +338,5 @@ partial struct S : Serde.IDeserialize<S>
 """)
             });
         }
-    }
+   }
 }

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.Generator/Serde.AllInOneColorEnumWrap.IDeserialize.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.Generator/Serde.AllInOneColorEnumWrap.IDeserialize.cs
@@ -15,26 +15,18 @@ namespace Serde
         private sealed class SerdeVisitor : Serde.IDeserializeVisitor<Serde.Test.AllInOne.ColorEnum>
         {
             public string ExpectedTypeName => "Serde.Test.AllInOne.ColorEnum";
-            Serde.Test.AllInOne.ColorEnum Serde.IDeserializeVisitor<Serde.Test.AllInOne.ColorEnum>.VisitString(string s)
+            Serde.Test.AllInOne.ColorEnum Serde.IDeserializeVisitor<Serde.Test.AllInOne.ColorEnum>.VisitString(string s) => s switch
             {
-                Serde.Test.AllInOne.ColorEnum enumValue;
-                switch (s)
-                {
-                    case "red":
-                        enumValue = Serde.Test.AllInOne.ColorEnum.Red;
-                        break;
-                    case "blue":
-                        enumValue = Serde.Test.AllInOne.ColorEnum.Blue;
-                        break;
-                    case "green":
-                        enumValue = Serde.Test.AllInOne.ColorEnum.Green;
-                        break;
-                    default:
-                        throw new InvalidDeserializeValueException("Unexpected enum field name: " + s);
-                }
-
-                return enumValue;
-            }
+                "red" => Serde.Test.AllInOne.ColorEnum.Red,
+                "blue" => Serde.Test.AllInOne.ColorEnum.Blue,
+                "green" => Serde.Test.AllInOne.ColorEnum.Green,
+                _ => throw new InvalidDeserializeValueException("Unexpected enum field name: " + s)};
+            Serde.Test.AllInOne.ColorEnum Serde.IDeserializeVisitor<Serde.Test.AllInOne.ColorEnum>.VisitUtf8Span(System.ReadOnlySpan<byte> s) => s switch
+            {
+                _ when System.MemoryExtensions.SequenceEqual(s, "red"u8) => Serde.Test.AllInOne.ColorEnum.Red,
+                _ when System.MemoryExtensions.SequenceEqual(s, "blue"u8) => Serde.Test.AllInOne.ColorEnum.Blue,
+                _ when System.MemoryExtensions.SequenceEqual(s, "green"u8) => Serde.Test.AllInOne.ColorEnum.Green,
+                _ => throw new InvalidDeserializeValueException("Unexpected enum field name: " + System.Text.Encoding.UTF8.GetString(s))};
         }
     }
 }

--- a/test/Serde.Xml.Test/generated/SerdeGenerator/Serde.Generator/Serde.AllInOneColorEnumWrap.IDeserialize.cs
+++ b/test/Serde.Xml.Test/generated/SerdeGenerator/Serde.Generator/Serde.AllInOneColorEnumWrap.IDeserialize.cs
@@ -15,26 +15,18 @@ namespace Serde
         private sealed class SerdeVisitor : Serde.IDeserializeVisitor<Serde.Test.AllInOne.ColorEnum>
         {
             public string ExpectedTypeName => "Serde.Test.AllInOne.ColorEnum";
-            Serde.Test.AllInOne.ColorEnum Serde.IDeserializeVisitor<Serde.Test.AllInOne.ColorEnum>.VisitString(string s)
+            Serde.Test.AllInOne.ColorEnum Serde.IDeserializeVisitor<Serde.Test.AllInOne.ColorEnum>.VisitString(string s) => s switch
             {
-                Serde.Test.AllInOne.ColorEnum enumValue;
-                switch (s)
-                {
-                    case "red":
-                        enumValue = Serde.Test.AllInOne.ColorEnum.Red;
-                        break;
-                    case "blue":
-                        enumValue = Serde.Test.AllInOne.ColorEnum.Blue;
-                        break;
-                    case "green":
-                        enumValue = Serde.Test.AllInOne.ColorEnum.Green;
-                        break;
-                    default:
-                        throw new InvalidDeserializeValueException("Unexpected enum field name: " + s);
-                }
-
-                return enumValue;
-            }
+                "red" => Serde.Test.AllInOne.ColorEnum.Red,
+                "blue" => Serde.Test.AllInOne.ColorEnum.Blue,
+                "green" => Serde.Test.AllInOne.ColorEnum.Green,
+                _ => throw new InvalidDeserializeValueException("Unexpected enum field name: " + s)};
+            Serde.Test.AllInOne.ColorEnum Serde.IDeserializeVisitor<Serde.Test.AllInOne.ColorEnum>.VisitUtf8Span(System.ReadOnlySpan<byte> s) => s switch
+            {
+                _ when System.MemoryExtensions.SequenceEqual(s, "red"u8) => Serde.Test.AllInOne.ColorEnum.Red,
+                _ when System.MemoryExtensions.SequenceEqual(s, "blue"u8) => Serde.Test.AllInOne.ColorEnum.Blue,
+                _ when System.MemoryExtensions.SequenceEqual(s, "green"u8) => Serde.Test.AllInOne.ColorEnum.Green,
+                _ => throw new InvalidDeserializeValueException("Unexpected enum field name: " + System.Text.Encoding.UTF8.GetString(s))};
         }
     }
 }


### PR DESCRIPTION
VisitUtf8Span allows deserializers to potentially avoid an allocation by producing a span directly to the parser's buffer.