### PR TITLE
Implement zero-alloc support for reading field names

### DIFF
--- a/src/generator/Generator.Deserialize.cs
+++ b/src/generator/Generator.Deserialize.cs
@@ -256,7 +256,7 @@ namespace Serde
         private static MemberDeclarationSyntax GenerateFieldNameVisitor(ITypeSymbol type, string typeName, List<DataMemberSymbol> members)
         {
             var text = $$"""
-private sealed class FieldNameVisitor : Serde.IDeserialize<byte>, Serde.IDeserializeVisitor<byte>
+private struct FieldNameVisitor : Serde.IDeserialize<byte>, Serde.IDeserializeVisitor<byte>
 {
     public static byte Deserialize<D>(ref D deserializer) where D : IDeserializer
         => deserializer.DeserializeString<byte, FieldNameVisitor>(new FieldNameVisitor());

--- a/src/generator/Generator.Impl.cs
+++ b/src/generator/Generator.Impl.cs
@@ -128,7 +128,7 @@ partial class SerdeImplRoslynGenerator
 
         var tree = CompilationUnit(
             externs: default,
-            usings: List(new[] { UsingDirective(IdentifierName("Serde")) }),
+            usings: List(new[] { UsingDirective(IdentifierName("System")), UsingDirective(IdentifierName("Serde")) }),
             attributeLists: default,
             members: List<MemberDeclarationSyntax>(new[] { newType }));
         tree = tree.NormalizeWhitespace(eol: Environment.NewLine);

--- a/test/Serde.Generation.Test/test_output/AllInOneTest.GeneratorTest/Serde.AllInOneColorEnumWrap.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/AllInOneTest.GeneratorTest/Serde.AllInOneColorEnumWrap.IDeserialize.verified.cs
@@ -1,6 +1,7 @@
 ﻿//HintName: Serde.AllInOneColorEnumWrap.IDeserialize.cs
 
 #nullable enable
+using System;
 using Serde;
 
 namespace Serde

--- a/test/Serde.Generation.Test/test_output/AllInOneTest.GeneratorTest/Serde.AllInOneColorEnumWrap.ISerialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/AllInOneTest.GeneratorTest/Serde.AllInOneColorEnumWrap.ISerialize.verified.cs
@@ -1,6 +1,7 @@
 ﻿//HintName: Serde.AllInOneColorEnumWrap.ISerialize.cs
 
 #nullable enable
+using System;
 using Serde;
 
 namespace Serde

--- a/test/Serde.Generation.Test/test_output/AllInOneTest.GeneratorTest/Serde.Test.AllInOne.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/AllInOneTest.GeneratorTest/Serde.Test.AllInOne.IDeserialize.verified.cs
@@ -37,7 +37,7 @@ namespace Serde.Test
         {
             public string ExpectedTypeName => "Serde.Test.AllInOne";
 
-            private sealed class FieldNameVisitor : Serde.IDeserialize<byte>, Serde.IDeserializeVisitor<byte>
+            private struct FieldNameVisitor : Serde.IDeserialize<byte>, Serde.IDeserializeVisitor<byte>
             {
                 public static byte Deserialize<D>(ref D deserializer)
                     where D : IDeserializer => deserializer.DeserializeString<byte, FieldNameVisitor>(new FieldNameVisitor());

--- a/test/Serde.Generation.Test/test_output/AllInOneTest.GeneratorTest/Serde.Test.AllInOne.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/AllInOneTest.GeneratorTest/Serde.Test.AllInOne.IDeserialize.verified.cs
@@ -1,6 +1,7 @@
 ﻿//HintName: Serde.Test.AllInOne.IDeserialize.cs
 
 #nullable enable
+using System;
 using Serde;
 
 namespace Serde.Test
@@ -36,6 +37,55 @@ namespace Serde.Test
         {
             public string ExpectedTypeName => "Serde.Test.AllInOne";
 
+            private sealed class FieldNameVisitor : Serde.IDeserialize<byte>, Serde.IDeserializeVisitor<byte>
+            {
+                public static byte Deserialize<D>(ref D deserializer)
+                    where D : IDeserializer => deserializer.DeserializeString<byte, FieldNameVisitor>(new FieldNameVisitor());
+                public string ExpectedTypeName => "string";
+
+                byte Serde.IDeserializeVisitor<byte>.VisitString(string s) => VisitUtf8Span(System.Text.Encoding.UTF8.GetBytes(s));
+                public byte VisitUtf8Span(System.ReadOnlySpan<byte> s)
+                {
+                    switch (s[0])
+                    {
+                        case (byte)'b'when s.SequenceEqual("boolField"u8):
+                            return 1;
+                        case (byte)'c'when s.SequenceEqual("charField"u8):
+                            return 2;
+                        case (byte)'b'when s.SequenceEqual("byteField"u8):
+                            return 3;
+                        case (byte)'u'when s.SequenceEqual("uShortField"u8):
+                            return 4;
+                        case (byte)'u'when s.SequenceEqual("uIntField"u8):
+                            return 5;
+                        case (byte)'u'when s.SequenceEqual("uLongField"u8):
+                            return 6;
+                        case (byte)'s'when s.SequenceEqual("sByteField"u8):
+                            return 7;
+                        case (byte)'s'when s.SequenceEqual("shortField"u8):
+                            return 8;
+                        case (byte)'i'when s.SequenceEqual("intField"u8):
+                            return 9;
+                        case (byte)'l'when s.SequenceEqual("longField"u8):
+                            return 10;
+                        case (byte)'s'when s.SequenceEqual("stringField"u8):
+                            return 11;
+                        case (byte)'n'when s.SequenceEqual("nullStringField"u8):
+                            return 12;
+                        case (byte)'u'when s.SequenceEqual("uIntArr"u8):
+                            return 13;
+                        case (byte)'n'when s.SequenceEqual("nestedArr"u8):
+                            return 14;
+                        case (byte)'i'when s.SequenceEqual("intImm"u8):
+                            return 15;
+                        case (byte)'c'when s.SequenceEqual("color"u8):
+                            return 16;
+                        default:
+                            return 0;
+                    }
+                }
+            }
+
             Serde.Test.AllInOne Serde.IDeserializeVisitor<Serde.Test.AllInOne>.VisitDictionary<D>(ref D d)
             {
                 Serde.Option<bool> boolfield = default;
@@ -54,59 +104,57 @@ namespace Serde.Test
                 Serde.Option<int[][]> nestedarr = default;
                 Serde.Option<System.Collections.Immutable.ImmutableArray<int>> intimm = default;
                 Serde.Option<Serde.Test.AllInOne.ColorEnum> color = default;
-                while (d.TryGetNextKey<string, StringWrap>(out string? key))
+                while (d.TryGetNextKey<byte, FieldNameVisitor>(out byte key))
                 {
                     switch (key)
                     {
-                        case "boolField":
+                        case 1:
                             boolfield = d.GetNextValue<bool, BoolWrap>();
                             break;
-                        case "charField":
+                        case 2:
                             charfield = d.GetNextValue<char, CharWrap>();
                             break;
-                        case "byteField":
+                        case 3:
                             bytefield = d.GetNextValue<byte, ByteWrap>();
                             break;
-                        case "uShortField":
+                        case 4:
                             ushortfield = d.GetNextValue<ushort, UInt16Wrap>();
                             break;
-                        case "uIntField":
+                        case 5:
                             uintfield = d.GetNextValue<uint, UInt32Wrap>();
                             break;
-                        case "uLongField":
+                        case 6:
                             ulongfield = d.GetNextValue<ulong, UInt64Wrap>();
                             break;
-                        case "sByteField":
+                        case 7:
                             sbytefield = d.GetNextValue<sbyte, SByteWrap>();
                             break;
-                        case "shortField":
+                        case 8:
                             shortfield = d.GetNextValue<short, Int16Wrap>();
                             break;
-                        case "intField":
+                        case 9:
                             intfield = d.GetNextValue<int, Int32Wrap>();
                             break;
-                        case "longField":
+                        case 10:
                             longfield = d.GetNextValue<long, Int64Wrap>();
                             break;
-                        case "stringField":
+                        case 11:
                             stringfield = d.GetNextValue<string, StringWrap>();
                             break;
-                        case "nullStringField":
+                        case 12:
                             nullstringfield = d.GetNextValue<string?, NullableRefWrap.DeserializeImpl<string, StringWrap>>();
                             break;
-                        case "uIntArr":
+                        case 13:
                             uintarr = d.GetNextValue<uint[], ArrayWrap.DeserializeImpl<uint, UInt32Wrap>>();
                             break;
-                        case "nestedArr":
+                        case 14:
                             nestedarr = d.GetNextValue<int[][], ArrayWrap.DeserializeImpl<int[], ArrayWrap.DeserializeImpl<int, Int32Wrap>>>();
                             break;
-                        case "intImm":
+                        case 15:
                             intimm = d.GetNextValue<System.Collections.Immutable.ImmutableArray<int>, ImmutableArrayWrap.DeserializeImpl<int, Int32Wrap>>();
                             break;
-                        case "color":
+                        case 16:
                             color = d.GetNextValue<Serde.Test.AllInOne.ColorEnum, AllInOneColorEnumWrap>();
-                            break;
-                        default:
                             break;
                     }
                 }

--- a/test/Serde.Generation.Test/test_output/AllInOneTest.GeneratorTest/Serde.Test.AllInOne.ISerialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/AllInOneTest.GeneratorTest/Serde.Test.AllInOne.ISerialize.verified.cs
@@ -1,6 +1,7 @@
 ﻿//HintName: Serde.Test.AllInOne.ISerialize.cs
 
 #nullable enable
+using System;
 using Serde;
 
 namespace Serde.Test

--- a/test/Serde.Generation.Test/test_output/DeserializeTests.EnumMember/C.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/DeserializeTests.EnumMember/C.IDeserialize.verified.cs
@@ -23,7 +23,7 @@ partial class C : Serde.IDeserialize<C>
     {
         public string ExpectedTypeName => "C";
 
-        private sealed class FieldNameVisitor : Serde.IDeserialize<byte>, Serde.IDeserializeVisitor<byte>
+        private struct FieldNameVisitor : Serde.IDeserialize<byte>, Serde.IDeserializeVisitor<byte>
         {
             public static byte Deserialize<D>(ref D deserializer)
                 where D : IDeserializer => deserializer.DeserializeString<byte, FieldNameVisitor>(new FieldNameVisitor());

--- a/test/Serde.Generation.Test/test_output/DeserializeTests.EnumMember/C.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/DeserializeTests.EnumMember/C.IDeserialize.verified.cs
@@ -1,6 +1,7 @@
 ﻿//HintName: C.IDeserialize.cs
 
 #nullable enable
+using System;
 using Serde;
 
 partial class C : Serde.IDeserialize<C>
@@ -22,29 +23,52 @@ partial class C : Serde.IDeserialize<C>
     {
         public string ExpectedTypeName => "C";
 
+        private sealed class FieldNameVisitor : Serde.IDeserialize<byte>, Serde.IDeserializeVisitor<byte>
+        {
+            public static byte Deserialize<D>(ref D deserializer)
+                where D : IDeserializer => deserializer.DeserializeString<byte, FieldNameVisitor>(new FieldNameVisitor());
+            public string ExpectedTypeName => "string";
+
+            byte Serde.IDeserializeVisitor<byte>.VisitString(string s) => VisitUtf8Span(System.Text.Encoding.UTF8.GetBytes(s));
+            public byte VisitUtf8Span(System.ReadOnlySpan<byte> s)
+            {
+                switch (s[0])
+                {
+                    case (byte)'c'when s.SequenceEqual("colorInt"u8):
+                        return 1;
+                    case (byte)'c'when s.SequenceEqual("colorByte"u8):
+                        return 2;
+                    case (byte)'c'when s.SequenceEqual("colorLong"u8):
+                        return 3;
+                    case (byte)'c'when s.SequenceEqual("colorULong"u8):
+                        return 4;
+                    default:
+                        return 0;
+                }
+            }
+        }
+
         C Serde.IDeserializeVisitor<C>.VisitDictionary<D>(ref D d)
         {
             Serde.Option<ColorInt> colorint = default;
             Serde.Option<ColorByte> colorbyte = default;
             Serde.Option<ColorLong> colorlong = default;
             Serde.Option<ColorULong> colorulong = default;
-            while (d.TryGetNextKey<string, StringWrap>(out string? key))
+            while (d.TryGetNextKey<byte, FieldNameVisitor>(out byte key))
             {
                 switch (key)
                 {
-                    case "colorInt":
+                    case 1:
                         colorint = d.GetNextValue<ColorInt, ColorIntWrap>();
                         break;
-                    case "colorByte":
+                    case 2:
                         colorbyte = d.GetNextValue<ColorByte, ColorByteWrap>();
                         break;
-                    case "colorLong":
+                    case 3:
                         colorlong = d.GetNextValue<ColorLong, ColorLongWrap>();
                         break;
-                    case "colorULong":
+                    case 4:
                         colorulong = d.GetNextValue<ColorULong, ColorULongWrap>();
-                        break;
-                    default:
                         break;
                 }
             }

--- a/test/Serde.Generation.Test/test_output/DeserializeTests.EnumMember/Serde.ColorByteWrap.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/DeserializeTests.EnumMember/Serde.ColorByteWrap.IDeserialize.verified.cs
@@ -1,6 +1,7 @@
 ﻿//HintName: Serde.ColorByteWrap.IDeserialize.cs
 
 #nullable enable
+using System;
 using Serde;
 
 namespace Serde

--- a/test/Serde.Generation.Test/test_output/DeserializeTests.EnumMember/Serde.ColorIntWrap.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/DeserializeTests.EnumMember/Serde.ColorIntWrap.IDeserialize.verified.cs
@@ -1,6 +1,7 @@
 ﻿//HintName: Serde.ColorIntWrap.IDeserialize.cs
 
 #nullable enable
+using System;
 using Serde;
 
 namespace Serde

--- a/test/Serde.Generation.Test/test_output/DeserializeTests.EnumMember/Serde.ColorLongWrap.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/DeserializeTests.EnumMember/Serde.ColorLongWrap.IDeserialize.verified.cs
@@ -1,6 +1,7 @@
 ﻿//HintName: Serde.ColorLongWrap.IDeserialize.cs
 
 #nullable enable
+using System;
 using Serde;
 
 namespace Serde

--- a/test/Serde.Generation.Test/test_output/DeserializeTests.EnumMember/Serde.ColorULongWrap.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/DeserializeTests.EnumMember/Serde.ColorULongWrap.IDeserialize.verified.cs
@@ -1,6 +1,7 @@
 ﻿//HintName: Serde.ColorULongWrap.IDeserialize.cs
 
 #nullable enable
+using System;
 using Serde;
 
 namespace Serde

--- a/test/Serde.Generation.Test/test_output/DeserializeTests/Array#ArrayField.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/DeserializeTests/Array#ArrayField.IDeserialize.verified.cs
@@ -20,7 +20,7 @@ partial class ArrayField : Serde.IDeserialize<ArrayField>
     {
         public string ExpectedTypeName => "ArrayField";
 
-        private sealed class FieldNameVisitor : Serde.IDeserialize<byte>, Serde.IDeserializeVisitor<byte>
+        private struct FieldNameVisitor : Serde.IDeserialize<byte>, Serde.IDeserializeVisitor<byte>
         {
             public static byte Deserialize<D>(ref D deserializer)
                 where D : IDeserializer => deserializer.DeserializeString<byte, FieldNameVisitor>(new FieldNameVisitor());

--- a/test/Serde.Generation.Test/test_output/DeserializeTests/DeserializeMissing#SetToNull.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/DeserializeTests/DeserializeMissing#SetToNull.IDeserialize.verified.cs
@@ -22,7 +22,7 @@ partial record struct SetToNull : Serde.IDeserialize<SetToNull>
     {
         public string ExpectedTypeName => "SetToNull";
 
-        private sealed class FieldNameVisitor : Serde.IDeserialize<byte>, Serde.IDeserializeVisitor<byte>
+        private struct FieldNameVisitor : Serde.IDeserialize<byte>, Serde.IDeserializeVisitor<byte>
         {
             public static byte Deserialize<D>(ref D deserializer)
                 where D : IDeserializer => deserializer.DeserializeString<byte, FieldNameVisitor>(new FieldNameVisitor());

--- a/test/Serde.Generation.Test/test_output/DeserializeTests/MemberSkip#Rgb.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/DeserializeTests/MemberSkip#Rgb.IDeserialize.verified.cs
@@ -1,6 +1,7 @@
 ﻿//HintName: Rgb.IDeserialize.cs
 
 #nullable enable
+using System;
 using Serde;
 
 partial struct Rgb : Serde.IDeserialize<Rgb>
@@ -20,21 +21,40 @@ partial struct Rgb : Serde.IDeserialize<Rgb>
     {
         public string ExpectedTypeName => "Rgb";
 
+        private sealed class FieldNameVisitor : Serde.IDeserialize<byte>, Serde.IDeserializeVisitor<byte>
+        {
+            public static byte Deserialize<D>(ref D deserializer)
+                where D : IDeserializer => deserializer.DeserializeString<byte, FieldNameVisitor>(new FieldNameVisitor());
+            public string ExpectedTypeName => "string";
+
+            byte Serde.IDeserializeVisitor<byte>.VisitString(string s) => VisitUtf8Span(System.Text.Encoding.UTF8.GetBytes(s));
+            public byte VisitUtf8Span(System.ReadOnlySpan<byte> s)
+            {
+                switch (s[0])
+                {
+                    case (byte)'r'when s.SequenceEqual("red"u8):
+                        return 1;
+                    case (byte)'b'when s.SequenceEqual("blue"u8):
+                        return 2;
+                    default:
+                        return 0;
+                }
+            }
+        }
+
         Rgb Serde.IDeserializeVisitor<Rgb>.VisitDictionary<D>(ref D d)
         {
             Serde.Option<byte> red = default;
             Serde.Option<byte> blue = default;
-            while (d.TryGetNextKey<string, StringWrap>(out string? key))
+            while (d.TryGetNextKey<byte, FieldNameVisitor>(out byte key))
             {
                 switch (key)
                 {
-                    case "red":
+                    case 1:
                         red = d.GetNextValue<byte, ByteWrap>();
                         break;
-                    case "blue":
+                    case 2:
                         blue = d.GetNextValue<byte, ByteWrap>();
-                        break;
-                    default:
                         break;
                 }
             }

--- a/test/Serde.Generation.Test/test_output/DeserializeTests/MemberSkip#Rgb.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/DeserializeTests/MemberSkip#Rgb.IDeserialize.verified.cs
@@ -21,7 +21,7 @@ partial struct Rgb : Serde.IDeserialize<Rgb>
     {
         public string ExpectedTypeName => "Rgb";
 
-        private sealed class FieldNameVisitor : Serde.IDeserialize<byte>, Serde.IDeserializeVisitor<byte>
+        private struct FieldNameVisitor : Serde.IDeserialize<byte>, Serde.IDeserializeVisitor<byte>
         {
             public static byte Deserialize<D>(ref D deserializer)
                 where D : IDeserializer => deserializer.DeserializeString<byte, FieldNameVisitor>(new FieldNameVisitor());

--- a/test/Serde.Generation.Test/test_output/DeserializeTests/MemberSkipDeserialize#Rgb.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/DeserializeTests/MemberSkipDeserialize#Rgb.IDeserialize.verified.cs
@@ -22,7 +22,7 @@ partial struct Rgb : Serde.IDeserialize<Rgb>
     {
         public string ExpectedTypeName => "Rgb";
 
-        private sealed class FieldNameVisitor : Serde.IDeserialize<byte>, Serde.IDeserializeVisitor<byte>
+        private struct FieldNameVisitor : Serde.IDeserialize<byte>, Serde.IDeserializeVisitor<byte>
         {
             public static byte Deserialize<D>(ref D deserializer)
                 where D : IDeserializer => deserializer.DeserializeString<byte, FieldNameVisitor>(new FieldNameVisitor());

--- a/test/Serde.Generation.Test/test_output/DeserializeTests/MemberSkipSerialize#Rgb.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/DeserializeTests/MemberSkipSerialize#Rgb.IDeserialize.verified.cs
@@ -1,6 +1,7 @@
 ﻿//HintName: Rgb.IDeserialize.cs
 
 #nullable enable
+using System;
 using Serde;
 
 partial struct Rgb : Serde.IDeserialize<Rgb>
@@ -20,21 +21,40 @@ partial struct Rgb : Serde.IDeserialize<Rgb>
     {
         public string ExpectedTypeName => "Rgb";
 
+        private sealed class FieldNameVisitor : Serde.IDeserialize<byte>, Serde.IDeserializeVisitor<byte>
+        {
+            public static byte Deserialize<D>(ref D deserializer)
+                where D : IDeserializer => deserializer.DeserializeString<byte, FieldNameVisitor>(new FieldNameVisitor());
+            public string ExpectedTypeName => "string";
+
+            byte Serde.IDeserializeVisitor<byte>.VisitString(string s) => VisitUtf8Span(System.Text.Encoding.UTF8.GetBytes(s));
+            public byte VisitUtf8Span(System.ReadOnlySpan<byte> s)
+            {
+                switch (s[0])
+                {
+                    case (byte)'r'when s.SequenceEqual("red"u8):
+                        return 1;
+                    case (byte)'b'when s.SequenceEqual("blue"u8):
+                        return 2;
+                    default:
+                        return 0;
+                }
+            }
+        }
+
         Rgb Serde.IDeserializeVisitor<Rgb>.VisitDictionary<D>(ref D d)
         {
             Serde.Option<byte> red = default;
             Serde.Option<byte> blue = default;
-            while (d.TryGetNextKey<string, StringWrap>(out string? key))
+            while (d.TryGetNextKey<byte, FieldNameVisitor>(out byte key))
             {
                 switch (key)
                 {
-                    case "red":
+                    case 1:
                         red = d.GetNextValue<byte, ByteWrap>();
                         break;
-                    case "blue":
+                    case 2:
                         blue = d.GetNextValue<byte, ByteWrap>();
-                        break;
-                    default:
                         break;
                 }
             }

--- a/test/Serde.Generation.Test/test_output/DeserializeTests/MemberSkipSerialize#Rgb.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/DeserializeTests/MemberSkipSerialize#Rgb.IDeserialize.verified.cs
@@ -21,7 +21,7 @@ partial struct Rgb : Serde.IDeserialize<Rgb>
     {
         public string ExpectedTypeName => "Rgb";
 
-        private sealed class FieldNameVisitor : Serde.IDeserialize<byte>, Serde.IDeserializeVisitor<byte>
+        private struct FieldNameVisitor : Serde.IDeserialize<byte>, Serde.IDeserializeVisitor<byte>
         {
             public static byte Deserialize<D>(ref D deserializer)
                 where D : IDeserializer => deserializer.DeserializeString<byte, FieldNameVisitor>(new FieldNameVisitor());

--- a/test/Serde.Generation.Test/test_output/DeserializeTests/NullableRefField#S.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/DeserializeTests/NullableRefField#S.IDeserialize.verified.cs
@@ -1,6 +1,7 @@
 ﻿//HintName: S.IDeserialize.cs
 
 #nullable enable
+using System;
 using Serde;
 
 partial struct S : Serde.IDeserialize<S>
@@ -19,17 +20,34 @@ partial struct S : Serde.IDeserialize<S>
     {
         public string ExpectedTypeName => "S";
 
+        private sealed class FieldNameVisitor : Serde.IDeserialize<byte>, Serde.IDeserializeVisitor<byte>
+        {
+            public static byte Deserialize<D>(ref D deserializer)
+                where D : IDeserializer => deserializer.DeserializeString<byte, FieldNameVisitor>(new FieldNameVisitor());
+            public string ExpectedTypeName => "string";
+
+            byte Serde.IDeserializeVisitor<byte>.VisitString(string s) => VisitUtf8Span(System.Text.Encoding.UTF8.GetBytes(s));
+            public byte VisitUtf8Span(System.ReadOnlySpan<byte> s)
+            {
+                switch (s[0])
+                {
+                    case (byte)'f'when s.SequenceEqual("f"u8):
+                        return 1;
+                    default:
+                        return 0;
+                }
+            }
+        }
+
         S Serde.IDeserializeVisitor<S>.VisitDictionary<D>(ref D d)
         {
             Serde.Option<string?> f = default;
-            while (d.TryGetNextKey<string, StringWrap>(out string? key))
+            while (d.TryGetNextKey<byte, FieldNameVisitor>(out byte key))
             {
                 switch (key)
                 {
-                    case "f":
+                    case 1:
                         f = d.GetNextValue<string?, NullableRefWrap.DeserializeImpl<string, StringWrap>>();
-                        break;
-                    default:
                         break;
                 }
             }

--- a/test/Serde.Generation.Test/test_output/DeserializeTests/NullableRefField#S.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/DeserializeTests/NullableRefField#S.IDeserialize.verified.cs
@@ -20,7 +20,7 @@ partial struct S : Serde.IDeserialize<S>
     {
         public string ExpectedTypeName => "S";
 
-        private sealed class FieldNameVisitor : Serde.IDeserialize<byte>, Serde.IDeserializeVisitor<byte>
+        private struct FieldNameVisitor : Serde.IDeserialize<byte>, Serde.IDeserializeVisitor<byte>
         {
             public static byte Deserialize<D>(ref D deserializer)
                 where D : IDeserializer => deserializer.DeserializeString<byte, FieldNameVisitor>(new FieldNameVisitor());

--- a/test/Serde.Generation.Test/test_output/DeserializeTests/Rgb#Rgb.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/DeserializeTests/Rgb#Rgb.IDeserialize.verified.cs
@@ -22,7 +22,7 @@ partial struct Rgb : Serde.IDeserialize<Rgb>
     {
         public string ExpectedTypeName => "Rgb";
 
-        private sealed class FieldNameVisitor : Serde.IDeserialize<byte>, Serde.IDeserializeVisitor<byte>
+        private struct FieldNameVisitor : Serde.IDeserialize<byte>, Serde.IDeserializeVisitor<byte>
         {
             public static byte Deserialize<D>(ref D deserializer)
                 where D : IDeserializer => deserializer.DeserializeString<byte, FieldNameVisitor>(new FieldNameVisitor());

--- a/test/Serde.Generation.Test/test_output/MemberFormatTests.CamelCase/S.ISerialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/MemberFormatTests.CamelCase/S.ISerialize.verified.cs
@@ -1,6 +1,7 @@
 ﻿//HintName: S.ISerialize.cs
 
 #nullable enable
+using System;
 using Serde;
 
 partial struct S : Serde.ISerialize

--- a/test/Serde.Generation.Test/test_output/MemberFormatTests.Default/S.ISerialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/MemberFormatTests.Default/S.ISerialize.verified.cs
@@ -1,6 +1,7 @@
 ﻿//HintName: S.ISerialize.cs
 
 #nullable enable
+using System;
 using Serde;
 
 partial struct S : Serde.ISerialize

--- a/test/Serde.Generation.Test/test_output/MemberFormatTests.EnumValues/S.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/MemberFormatTests.EnumValues/S.IDeserialize.verified.cs
@@ -1,6 +1,7 @@
 ﻿//HintName: S.IDeserialize.cs
 
 #nullable enable
+using System;
 using Serde;
 
 partial struct S : Serde.IDeserialize<S>
@@ -19,17 +20,34 @@ partial struct S : Serde.IDeserialize<S>
     {
         public string ExpectedTypeName => "S";
 
+        private sealed class FieldNameVisitor : Serde.IDeserialize<byte>, Serde.IDeserializeVisitor<byte>
+        {
+            public static byte Deserialize<D>(ref D deserializer)
+                where D : IDeserializer => deserializer.DeserializeString<byte, FieldNameVisitor>(new FieldNameVisitor());
+            public string ExpectedTypeName => "string";
+
+            byte Serde.IDeserializeVisitor<byte>.VisitString(string s) => VisitUtf8Span(System.Text.Encoding.UTF8.GetBytes(s));
+            public byte VisitUtf8Span(System.ReadOnlySpan<byte> s)
+            {
+                switch (s[0])
+                {
+                    case (byte)'e'when s.SequenceEqual("e"u8):
+                        return 1;
+                    default:
+                        return 0;
+                }
+            }
+        }
+
         S Serde.IDeserializeVisitor<S>.VisitDictionary<D>(ref D d)
         {
             Serde.Option<ColorEnum> e = default;
-            while (d.TryGetNextKey<string, StringWrap>(out string? key))
+            while (d.TryGetNextKey<byte, FieldNameVisitor>(out byte key))
             {
                 switch (key)
                 {
-                    case "e":
+                    case 1:
                         e = d.GetNextValue<ColorEnum, ColorEnumWrap>();
-                        break;
-                    default:
                         break;
                 }
             }

--- a/test/Serde.Generation.Test/test_output/MemberFormatTests.EnumValues/S.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/MemberFormatTests.EnumValues/S.IDeserialize.verified.cs
@@ -20,7 +20,7 @@ partial struct S : Serde.IDeserialize<S>
     {
         public string ExpectedTypeName => "S";
 
-        private sealed class FieldNameVisitor : Serde.IDeserialize<byte>, Serde.IDeserializeVisitor<byte>
+        private struct FieldNameVisitor : Serde.IDeserialize<byte>, Serde.IDeserializeVisitor<byte>
         {
             public static byte Deserialize<D>(ref D deserializer)
                 where D : IDeserializer => deserializer.DeserializeString<byte, FieldNameVisitor>(new FieldNameVisitor());

--- a/test/Serde.Generation.Test/test_output/MemberFormatTests.EnumValues/S.ISerialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/MemberFormatTests.EnumValues/S.ISerialize.verified.cs
@@ -1,6 +1,7 @@
 ﻿//HintName: S.ISerialize.cs
 
 #nullable enable
+using System;
 using Serde;
 
 partial struct S : Serde.ISerialize

--- a/test/Serde.Generation.Test/test_output/MemberFormatTests.EnumValues/S2.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/MemberFormatTests.EnumValues/S2.IDeserialize.verified.cs
@@ -1,6 +1,7 @@
 ﻿//HintName: S2.IDeserialize.cs
 
 #nullable enable
+using System;
 using Serde;
 
 partial struct S2 : Serde.IDeserialize<S2>
@@ -19,17 +20,34 @@ partial struct S2 : Serde.IDeserialize<S2>
     {
         public string ExpectedTypeName => "S2";
 
+        private sealed class FieldNameVisitor : Serde.IDeserialize<byte>, Serde.IDeserializeVisitor<byte>
+        {
+            public static byte Deserialize<D>(ref D deserializer)
+                where D : IDeserializer => deserializer.DeserializeString<byte, FieldNameVisitor>(new FieldNameVisitor());
+            public string ExpectedTypeName => "string";
+
+            byte Serde.IDeserializeVisitor<byte>.VisitString(string s) => VisitUtf8Span(System.Text.Encoding.UTF8.GetBytes(s));
+            public byte VisitUtf8Span(System.ReadOnlySpan<byte> s)
+            {
+                switch (s[0])
+                {
+                    case (byte)'E'when s.SequenceEqual("E"u8):
+                        return 1;
+                    default:
+                        return 0;
+                }
+            }
+        }
+
         S2 Serde.IDeserializeVisitor<S2>.VisitDictionary<D>(ref D d)
         {
             Serde.Option<ColorEnum> e = default;
-            while (d.TryGetNextKey<string, StringWrap>(out string? key))
+            while (d.TryGetNextKey<byte, FieldNameVisitor>(out byte key))
             {
                 switch (key)
                 {
-                    case "E":
+                    case 1:
                         e = d.GetNextValue<ColorEnum, ColorEnumWrap>();
-                        break;
-                    default:
                         break;
                 }
             }

--- a/test/Serde.Generation.Test/test_output/MemberFormatTests.EnumValues/S2.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/MemberFormatTests.EnumValues/S2.IDeserialize.verified.cs
@@ -20,7 +20,7 @@ partial struct S2 : Serde.IDeserialize<S2>
     {
         public string ExpectedTypeName => "S2";
 
-        private sealed class FieldNameVisitor : Serde.IDeserialize<byte>, Serde.IDeserializeVisitor<byte>
+        private struct FieldNameVisitor : Serde.IDeserialize<byte>, Serde.IDeserializeVisitor<byte>
         {
             public static byte Deserialize<D>(ref D deserializer)
                 where D : IDeserializer => deserializer.DeserializeString<byte, FieldNameVisitor>(new FieldNameVisitor());

--- a/test/Serde.Generation.Test/test_output/MemberFormatTests.EnumValues/S2.ISerialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/MemberFormatTests.EnumValues/S2.ISerialize.verified.cs
@@ -1,6 +1,7 @@
 ﻿//HintName: S2.ISerialize.cs
 
 #nullable enable
+using System;
 using Serde;
 
 partial struct S2 : Serde.ISerialize

--- a/test/Serde.Generation.Test/test_output/MemberFormatTests.EnumValues/Serde.ColorEnumWrap.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/MemberFormatTests.EnumValues/Serde.ColorEnumWrap.IDeserialize.verified.cs
@@ -1,6 +1,7 @@
 ﻿//HintName: Serde.ColorEnumWrap.IDeserialize.cs
 
 #nullable enable
+using System;
 using Serde;
 
 namespace Serde

--- a/test/Serde.Generation.Test/test_output/MemberFormatTests.EnumValues/Serde.ColorEnumWrap.ISerialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/MemberFormatTests.EnumValues/Serde.ColorEnumWrap.ISerialize.verified.cs
@@ -1,6 +1,7 @@
 ﻿//HintName: Serde.ColorEnumWrap.ISerialize.cs
 
 #nullable enable
+using System;
 using Serde;
 
 namespace Serde

--- a/test/Serde.Generation.Test/test_output/MemberFormatTests.KebabCase/S.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/MemberFormatTests.KebabCase/S.IDeserialize.verified.cs
@@ -21,7 +21,7 @@ partial struct S : Serde.IDeserialize<S>
     {
         public string ExpectedTypeName => "S";
 
-        private sealed class FieldNameVisitor : Serde.IDeserialize<byte>, Serde.IDeserializeVisitor<byte>
+        private struct FieldNameVisitor : Serde.IDeserialize<byte>, Serde.IDeserializeVisitor<byte>
         {
             public static byte Deserialize<D>(ref D deserializer)
                 where D : IDeserializer => deserializer.DeserializeString<byte, FieldNameVisitor>(new FieldNameVisitor());

--- a/test/Serde.Generation.Test/test_output/MemberFormatTests.KebabCase/S.ISerialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/MemberFormatTests.KebabCase/S.ISerialize.verified.cs
@@ -1,6 +1,7 @@
 ﻿//HintName: S.ISerialize.cs
 
 #nullable enable
+using System;
 using Serde;
 
 partial struct S : Serde.ISerialize

--- a/test/Serde.Generation.Test/test_output/SerializeTests.ArrayOfGenerateSerialize/TestCase15.Class0.ISerialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/SerializeTests.ArrayOfGenerateSerialize/TestCase15.Class0.ISerialize.verified.cs
@@ -1,6 +1,7 @@
 ﻿//HintName: TestCase15.Class0.ISerialize.cs
 
 #nullable enable
+using System;
 using Serde;
 
 partial class TestCase15

--- a/test/Serde.Generation.Test/test_output/SerializeTests.ArrayOfGenerateSerialize/TestCase15.Class1.ISerialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/SerializeTests.ArrayOfGenerateSerialize/TestCase15.Class1.ISerialize.verified.cs
@@ -1,6 +1,7 @@
 ﻿//HintName: TestCase15.Class1.ISerialize.cs
 
 #nullable enable
+using System;
 using Serde;
 
 partial class TestCase15

--- a/test/Serde.Generation.Test/test_output/SerializeTests.DictionaryGenerate2/C.ISerialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/SerializeTests.DictionaryGenerate2/C.ISerialize.verified.cs
@@ -1,6 +1,7 @@
 ﻿//HintName: C.ISerialize.cs
 
 #nullable enable
+using System;
 using Serde;
 
 partial record C : Serde.ISerialize

--- a/test/Serde.Generation.Test/test_output/SerializeTests.DictionaryGenerate2/C2.ISerialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/SerializeTests.DictionaryGenerate2/C2.ISerialize.verified.cs
@@ -1,6 +1,7 @@
 ﻿//HintName: C2.ISerialize.cs
 
 #nullable enable
+using System;
 using Serde;
 
 partial class C2 : Serde.ISerialize

--- a/test/Serde.Generation.Test/test_output/SerializeTests.EnumMember/Serde.ColorByteWrap.ISerialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/SerializeTests.EnumMember/Serde.ColorByteWrap.ISerialize.verified.cs
@@ -1,6 +1,7 @@
 ﻿//HintName: Serde.ColorByteWrap.ISerialize.cs
 
 #nullable enable
+using System;
 using Serde;
 
 namespace Serde

--- a/test/Serde.Generation.Test/test_output/SerializeTests.EnumMember/Serde.ColorIntWrap.ISerialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/SerializeTests.EnumMember/Serde.ColorIntWrap.ISerialize.verified.cs
@@ -1,6 +1,7 @@
 ﻿//HintName: Serde.ColorIntWrap.ISerialize.cs
 
 #nullable enable
+using System;
 using Serde;
 
 namespace Serde

--- a/test/Serde.Generation.Test/test_output/SerializeTests.EnumMember/Serde.ColorLongWrap.ISerialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/SerializeTests.EnumMember/Serde.ColorLongWrap.ISerialize.verified.cs
@@ -1,6 +1,7 @@
 ﻿//HintName: Serde.ColorLongWrap.ISerialize.cs
 
 #nullable enable
+using System;
 using Serde;
 
 namespace Serde

--- a/test/Serde.Generation.Test/test_output/SerializeTests.EnumMember/Serde.ColorULongWrap.ISerialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/SerializeTests.EnumMember/Serde.ColorULongWrap.ISerialize.verified.cs
@@ -1,6 +1,7 @@
 ﻿//HintName: Serde.ColorULongWrap.ISerialize.cs
 
 #nullable enable
+using System;
 using Serde;
 
 namespace Serde

--- a/test/Serde.Generation.Test/test_output/SerializeTests.EnumMember/Some.Nested.Namespace.C.ISerialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/SerializeTests.EnumMember/Some.Nested.Namespace.C.ISerialize.verified.cs
@@ -1,6 +1,7 @@
 ﻿//HintName: Some.Nested.Namespace.C.ISerialize.cs
 
 #nullable enable
+using System;
 using Serde;
 
 namespace Some.Nested.Namespace

--- a/test/Serde.Generation.Test/test_output/SerializeTests/DictionaryGenerate#C.ISerialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/SerializeTests/DictionaryGenerate#C.ISerialize.verified.cs
@@ -1,6 +1,7 @@
 ﻿//HintName: C.ISerialize.cs
 
 #nullable enable
+using System;
 using Serde;
 
 partial class C : Serde.ISerialize

--- a/test/Serde.Generation.Test/test_output/SerializeTests/ExplicitGenericWrapper#C.ISerialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/SerializeTests/ExplicitGenericWrapper#C.ISerialize.verified.cs
@@ -1,6 +1,7 @@
 ﻿//HintName: C.ISerialize.cs
 
 #nullable enable
+using System;
 using Serde;
 
 partial class C : Serde.ISerialize

--- a/test/Serde.Generation.Test/test_output/SerializeTests/ExplicitWrapper#C.ISerialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/SerializeTests/ExplicitWrapper#C.ISerialize.verified.cs
@@ -1,6 +1,7 @@
 ﻿//HintName: C.ISerialize.cs
 
 #nullable enable
+using System;
 using Serde;
 
 partial class C : Serde.ISerialize

--- a/test/Serde.Generation.Test/test_output/SerializeTests/IDictionaryImplGenerate#C.ISerialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/SerializeTests/IDictionaryImplGenerate#C.ISerialize.verified.cs
@@ -1,6 +1,7 @@
 ﻿//HintName: C.ISerialize.cs
 
 #nullable enable
+using System;
 using Serde;
 
 partial class C : Serde.ISerialize

--- a/test/Serde.Generation.Test/test_output/SerializeTests/MemberSkip#Rgb.ISerialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/SerializeTests/MemberSkip#Rgb.ISerialize.verified.cs
@@ -1,6 +1,7 @@
 ﻿//HintName: Rgb.ISerialize.cs
 
 #nullable enable
+using System;
 using Serde;
 
 partial struct Rgb : Serde.ISerialize

--- a/test/Serde.Generation.Test/test_output/SerializeTests/MemberSkipDeserialize#Rgb.ISerialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/SerializeTests/MemberSkipDeserialize#Rgb.ISerialize.verified.cs
@@ -1,6 +1,7 @@
 ﻿//HintName: Rgb.ISerialize.cs
 
 #nullable enable
+using System;
 using Serde;
 
 partial struct Rgb : Serde.ISerialize

--- a/test/Serde.Generation.Test/test_output/SerializeTests/MemberSkipSerialize#Rgb.ISerialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/SerializeTests/MemberSkipSerialize#Rgb.ISerialize.verified.cs
@@ -1,6 +1,7 @@
 ﻿//HintName: Rgb.ISerialize.cs
 
 #nullable enable
+using System;
 using Serde;
 
 partial struct Rgb : Serde.ISerialize

--- a/test/Serde.Generation.Test/test_output/SerializeTests/NestedArray#C.ISerialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/SerializeTests/NestedArray#C.ISerialize.verified.cs
@@ -1,6 +1,7 @@
 ﻿//HintName: C.ISerialize.cs
 
 #nullable enable
+using System;
 using Serde;
 
 partial class C : Serde.ISerialize

--- a/test/Serde.Generation.Test/test_output/SerializeTests/NestedArray2#C.ISerialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/SerializeTests/NestedArray2#C.ISerialize.verified.cs
@@ -1,6 +1,7 @@
 ﻿//HintName: C.ISerialize.cs
 
 #nullable enable
+using System;
 using Serde;
 
 partial class C : Serde.ISerialize

--- a/test/Serde.Generation.Test/test_output/SerializeTests/NullableFields#S.ISerialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/SerializeTests/NullableFields#S.ISerialize.verified.cs
@@ -1,6 +1,7 @@
 ﻿//HintName: S.ISerialize.cs
 
 #nullable enable
+using System;
 using Serde;
 
 partial struct S<T1, T2, TSerialize> : Serde.ISerialize

--- a/test/Serde.Generation.Test/test_output/SerializeTests/NullableRefFields#S.ISerialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/SerializeTests/NullableRefFields#S.ISerialize.verified.cs
@@ -1,6 +1,7 @@
 ﻿//HintName: S.ISerialize.cs
 
 #nullable enable
+using System;
 using Serde;
 
 partial struct S<T1, T2, T3, T4, T5> : Serde.ISerialize

--- a/test/Serde.Generation.Test/test_output/SerializeTests/Rgb#Rgb.ISerialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/SerializeTests/Rgb#Rgb.ISerialize.verified.cs
@@ -1,6 +1,7 @@
 ﻿//HintName: Rgb.ISerialize.cs
 
 #nullable enable
+using System;
 using Serde;
 
 partial struct Rgb : Serde.ISerialize

--- a/test/Serde.Generation.Test/test_output/SerializeTests/TypeDoesntImplementISerialize#S1.ISerialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/SerializeTests/TypeDoesntImplementISerialize#S1.ISerialize.verified.cs
@@ -1,6 +1,7 @@
 ﻿//HintName: S1.ISerialize.cs
 
 #nullable enable
+using System;
 using Serde;
 
 partial struct S1 : Serde.ISerialize

--- a/test/Serde.Generation.Test/test_output/SerializeTests/TypeWithArray#C.ISerialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/SerializeTests/TypeWithArray#C.ISerialize.verified.cs
@@ -1,6 +1,7 @@
 ﻿//HintName: C.ISerialize.cs
 
 #nullable enable
+using System;
 using Serde;
 
 partial class C : Serde.ISerialize

--- a/test/Serde.Generation.Test/test_output/SerializeTests/WrongGenericWrapperForm#C.ISerialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/SerializeTests/WrongGenericWrapperForm#C.ISerialize.verified.cs
@@ -1,6 +1,7 @@
 ﻿//HintName: C.ISerialize.cs
 
 #nullable enable
+using System;
 using Serde;
 
 partial class C : Serde.ISerialize

--- a/test/Serde.Generation.Test/test_output/WrapperTests.AttributeWrapperTest/Address.ISerialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/WrapperTests.AttributeWrapperTest/Address.ISerialize.verified.cs
@@ -1,6 +1,7 @@
 ﻿//HintName: Address.ISerialize.cs
 
 #nullable enable
+using System;
 using Serde;
 
 partial class Address : Serde.ISerialize

--- a/test/Serde.Generation.Test/test_output/WrapperTests.ImmutableArrayEnumDeserialize/Serde.ChannelWrap.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/WrapperTests.ImmutableArrayEnumDeserialize/Serde.ChannelWrap.IDeserialize.verified.cs
@@ -1,6 +1,7 @@
 ﻿//HintName: Serde.ChannelWrap.IDeserialize.cs
 
 #nullable enable
+using System;
 using Serde;
 
 namespace Serde

--- a/test/Serde.Generation.Test/test_output/WrapperTests.ImmutableArrayEnumDeserialize/Test.ChannelList.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/WrapperTests.ImmutableArrayEnumDeserialize/Test.ChannelList.IDeserialize.verified.cs
@@ -22,7 +22,7 @@ namespace Test
         {
             public string ExpectedTypeName => "Test.ChannelList";
 
-            private sealed class FieldNameVisitor : Serde.IDeserialize<byte>, Serde.IDeserializeVisitor<byte>
+            private struct FieldNameVisitor : Serde.IDeserialize<byte>, Serde.IDeserializeVisitor<byte>
             {
                 public static byte Deserialize<D>(ref D deserializer)
                     where D : IDeserializer => deserializer.DeserializeString<byte, FieldNameVisitor>(new FieldNameVisitor());

--- a/test/Serde.Generation.Test/test_output/WrapperTests.NestedDeserializeWrap/C.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/WrapperTests.NestedDeserializeWrap/C.IDeserialize.verified.cs
@@ -1,6 +1,7 @@
 ﻿//HintName: C.IDeserialize.cs
 
 #nullable enable
+using System;
 using Serde;
 
 partial class C : Serde.IDeserialize<C>
@@ -19,17 +20,34 @@ partial class C : Serde.IDeserialize<C>
     {
         public string ExpectedTypeName => "C";
 
+        private sealed class FieldNameVisitor : Serde.IDeserialize<byte>, Serde.IDeserializeVisitor<byte>
+        {
+            public static byte Deserialize<D>(ref D deserializer)
+                where D : IDeserializer => deserializer.DeserializeString<byte, FieldNameVisitor>(new FieldNameVisitor());
+            public string ExpectedTypeName => "string";
+
+            byte Serde.IDeserializeVisitor<byte>.VisitString(string s) => VisitUtf8Span(System.Text.Encoding.UTF8.GetBytes(s));
+            public byte VisitUtf8Span(System.ReadOnlySpan<byte> s)
+            {
+                switch (s[0])
+                {
+                    case (byte)'s'when s.SequenceEqual("s"u8):
+                        return 1;
+                    default:
+                        return 0;
+                }
+            }
+        }
+
         C Serde.IDeserializeVisitor<C>.VisitDictionary<D>(ref D d)
         {
             Serde.Option<System.Collections.Specialized.BitVector32.Section> s = default;
-            while (d.TryGetNextKey<string, StringWrap>(out string? key))
+            while (d.TryGetNextKey<byte, FieldNameVisitor>(out byte key))
             {
                 switch (key)
                 {
-                    case "s":
+                    case 1:
                         s = d.GetNextValue<System.Collections.Specialized.BitVector32.Section, BitVector32SectionWrap>();
-                        break;
-                    default:
                         break;
                 }
             }

--- a/test/Serde.Generation.Test/test_output/WrapperTests.NestedDeserializeWrap/C.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/WrapperTests.NestedDeserializeWrap/C.IDeserialize.verified.cs
@@ -20,7 +20,7 @@ partial class C : Serde.IDeserialize<C>
     {
         public string ExpectedTypeName => "C";
 
-        private sealed class FieldNameVisitor : Serde.IDeserialize<byte>, Serde.IDeserializeVisitor<byte>
+        private struct FieldNameVisitor : Serde.IDeserialize<byte>, Serde.IDeserializeVisitor<byte>
         {
             public static byte Deserialize<D>(ref D deserializer)
                 where D : IDeserializer => deserializer.DeserializeString<byte, FieldNameVisitor>(new FieldNameVisitor());

--- a/test/Serde.Generation.Test/test_output/WrapperTests.NestedDeserializeWrap/Serde.BitVector32SectionWrap.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/WrapperTests.NestedDeserializeWrap/Serde.BitVector32SectionWrap.IDeserialize.verified.cs
@@ -23,7 +23,7 @@ namespace Serde
         {
             public string ExpectedTypeName => "System.Collections.Specialized.BitVector32.Section";
 
-            private sealed class FieldNameVisitor : Serde.IDeserialize<byte>, Serde.IDeserializeVisitor<byte>
+            private struct FieldNameVisitor : Serde.IDeserialize<byte>, Serde.IDeserializeVisitor<byte>
             {
                 public static byte Deserialize<D>(ref D deserializer)
                     where D : IDeserializer => deserializer.DeserializeString<byte, FieldNameVisitor>(new FieldNameVisitor());

--- a/test/Serde.Generation.Test/test_output/WrapperTests.NestedDeserializeWrap/Serde.BitVector32SectionWrap.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/WrapperTests.NestedDeserializeWrap/Serde.BitVector32SectionWrap.IDeserialize.verified.cs
@@ -1,6 +1,7 @@
 ﻿//HintName: Serde.BitVector32SectionWrap.IDeserialize.cs
 
 #nullable enable
+using System;
 using Serde;
 
 namespace Serde
@@ -22,21 +23,40 @@ namespace Serde
         {
             public string ExpectedTypeName => "System.Collections.Specialized.BitVector32.Section";
 
+            private sealed class FieldNameVisitor : Serde.IDeserialize<byte>, Serde.IDeserializeVisitor<byte>
+            {
+                public static byte Deserialize<D>(ref D deserializer)
+                    where D : IDeserializer => deserializer.DeserializeString<byte, FieldNameVisitor>(new FieldNameVisitor());
+                public string ExpectedTypeName => "string";
+
+                byte Serde.IDeserializeVisitor<byte>.VisitString(string s) => VisitUtf8Span(System.Text.Encoding.UTF8.GetBytes(s));
+                public byte VisitUtf8Span(System.ReadOnlySpan<byte> s)
+                {
+                    switch (s[0])
+                    {
+                        case (byte)'m'when s.SequenceEqual("mask"u8):
+                            return 1;
+                        case (byte)'o'when s.SequenceEqual("offset"u8):
+                            return 2;
+                        default:
+                            return 0;
+                    }
+                }
+            }
+
             System.Collections.Specialized.BitVector32.Section Serde.IDeserializeVisitor<System.Collections.Specialized.BitVector32.Section>.VisitDictionary<D>(ref D d)
             {
                 Serde.Option<short> mask = default;
                 Serde.Option<short> offset = default;
-                while (d.TryGetNextKey<string, StringWrap>(out string? key))
+                while (d.TryGetNextKey<byte, FieldNameVisitor>(out byte key))
                 {
                     switch (key)
                     {
-                        case "mask":
+                        case 1:
                             mask = d.GetNextValue<short, Int16Wrap>();
                             break;
-                        case "offset":
+                        case 2:
                             offset = d.GetNextValue<short, Int16Wrap>();
-                            break;
-                        default:
                             break;
                     }
                 }

--- a/test/Serde.Generation.Test/test_output/WrapperTests.NestedSerializeWrap/C.ISerialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/WrapperTests.NestedSerializeWrap/C.ISerialize.verified.cs
@@ -1,6 +1,7 @@
 ﻿//HintName: C.ISerialize.cs
 
 #nullable enable
+using System;
 using Serde;
 
 partial class C : Serde.ISerialize

--- a/test/Serde.Generation.Test/test_output/WrapperTests.NestedSerializeWrap/Serde.BitVector32SectionWrap.ISerialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/WrapperTests.NestedSerializeWrap/Serde.BitVector32SectionWrap.ISerialize.verified.cs
@@ -1,6 +1,7 @@
 ﻿//HintName: Serde.BitVector32SectionWrap.ISerialize.cs
 
 #nullable enable
+using System;
 using Serde;
 
 namespace Serde

--- a/test/Serde.Generation.Test/test_output/WrapperTests.PointWrap/PointWrap.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/WrapperTests.PointWrap/PointWrap.IDeserialize.verified.cs
@@ -1,6 +1,7 @@
 ﻿//HintName: PointWrap.IDeserialize.cs
 
 #nullable enable
+using System;
 using Serde;
 
 partial struct PointWrap : Serde.IDeserialize<Point>
@@ -20,21 +21,40 @@ partial struct PointWrap : Serde.IDeserialize<Point>
     {
         public string ExpectedTypeName => "Point";
 
+        private sealed class FieldNameVisitor : Serde.IDeserialize<byte>, Serde.IDeserializeVisitor<byte>
+        {
+            public static byte Deserialize<D>(ref D deserializer)
+                where D : IDeserializer => deserializer.DeserializeString<byte, FieldNameVisitor>(new FieldNameVisitor());
+            public string ExpectedTypeName => "string";
+
+            byte Serde.IDeserializeVisitor<byte>.VisitString(string s) => VisitUtf8Span(System.Text.Encoding.UTF8.GetBytes(s));
+            public byte VisitUtf8Span(System.ReadOnlySpan<byte> s)
+            {
+                switch (s[0])
+                {
+                    case (byte)'x'when s.SequenceEqual("x"u8):
+                        return 1;
+                    case (byte)'y'when s.SequenceEqual("y"u8):
+                        return 2;
+                    default:
+                        return 0;
+                }
+            }
+        }
+
         Point Serde.IDeserializeVisitor<Point>.VisitDictionary<D>(ref D d)
         {
             Serde.Option<int> x = default;
             Serde.Option<int> y = default;
-            while (d.TryGetNextKey<string, StringWrap>(out string? key))
+            while (d.TryGetNextKey<byte, FieldNameVisitor>(out byte key))
             {
                 switch (key)
                 {
-                    case "x":
+                    case 1:
                         x = d.GetNextValue<int, Int32Wrap>();
                         break;
-                    case "y":
+                    case 2:
                         y = d.GetNextValue<int, Int32Wrap>();
-                        break;
-                    default:
                         break;
                 }
             }

--- a/test/Serde.Generation.Test/test_output/WrapperTests.PointWrap/PointWrap.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/WrapperTests.PointWrap/PointWrap.IDeserialize.verified.cs
@@ -21,7 +21,7 @@ partial struct PointWrap : Serde.IDeserialize<Point>
     {
         public string ExpectedTypeName => "Point";
 
-        private sealed class FieldNameVisitor : Serde.IDeserialize<byte>, Serde.IDeserializeVisitor<byte>
+        private struct FieldNameVisitor : Serde.IDeserialize<byte>, Serde.IDeserializeVisitor<byte>
         {
             public static byte Deserialize<D>(ref D deserializer)
                 where D : IDeserializer => deserializer.DeserializeString<byte, FieldNameVisitor>(new FieldNameVisitor());

--- a/test/Serde.Generation.Test/test_output/WrapperTests.PointWrap/PointWrap.ISerialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/WrapperTests.PointWrap/PointWrap.ISerialize.verified.cs
@@ -1,6 +1,7 @@
 ﻿//HintName: PointWrap.ISerialize.cs
 
 #nullable enable
+using System;
 using Serde;
 
 partial struct PointWrap : Serde.ISerialize

--- a/test/Serde.Generation.Test/test_output/WrapperTests.PositionalRecordDeserialize/R.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/WrapperTests.PositionalRecordDeserialize/R.IDeserialize.verified.cs
@@ -21,7 +21,7 @@ partial record R : Serde.IDeserialize<R>
     {
         public string ExpectedTypeName => "R";
 
-        private sealed class FieldNameVisitor : Serde.IDeserialize<byte>, Serde.IDeserializeVisitor<byte>
+        private struct FieldNameVisitor : Serde.IDeserialize<byte>, Serde.IDeserializeVisitor<byte>
         {
             public static byte Deserialize<D>(ref D deserializer)
                 where D : IDeserializer => deserializer.DeserializeString<byte, FieldNameVisitor>(new FieldNameVisitor());

--- a/test/Serde.Test/JsonDeserializeTests.cs
+++ b/test/Serde.Test/JsonDeserializeTests.cs
@@ -222,6 +222,24 @@ namespace Serde.Test
             Assert.Throws<InvalidDeserializeValueException>(() => JsonSerializer.Deserialize<ThrowMissing>(src));
         }
 
+        [Fact]
+        public void DenyUnknownTest()
+        {
+            var src = @"
+{
+    ""present"": ""abc"",
+    ""extra"": ""def""
+}";
+            Assert.Throws<InvalidDeserializeValueException>(() => JsonSerializer.Deserialize<DenyUnknown>(src));
+        }
+
+        [GenerateDeserialize]
+        [SerdeTypeOptions(DenyUnknownMembers = true)]
+        private readonly partial record struct DenyUnknown
+        {
+            public string Present { get; init; }
+            public string? Missing { get; init; }
+        }
 
         [GenerateDeserialize]
         private partial class NullableFields

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.AllInOneColorEnumWrap.IDeserialize.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.AllInOneColorEnumWrap.IDeserialize.cs
@@ -1,5 +1,6 @@
 ﻿
 #nullable enable
+using System;
 using Serde;
 
 namespace Serde

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.AllInOneColorEnumWrap.ISerialize.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.AllInOneColorEnumWrap.ISerialize.cs
@@ -1,5 +1,6 @@
 ﻿
 #nullable enable
+using System;
 using Serde;
 
 namespace Serde

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.AllInOne.IDeserialize.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.AllInOne.IDeserialize.cs
@@ -1,5 +1,6 @@
 ﻿
 #nullable enable
+using System;
 using Serde;
 
 namespace Serde.Test
@@ -34,6 +35,54 @@ namespace Serde.Test
         private sealed class SerdeVisitor : Serde.IDeserializeVisitor<Serde.Test.AllInOne>
         {
             public string ExpectedTypeName => "Serde.Test.AllInOne";
+            private sealed class FieldNameVisitor : Serde.IDeserialize<byte>, Serde.IDeserializeVisitor<byte>
+            {
+                public static byte Deserialize<D>(ref D deserializer)
+                    where D : IDeserializer => deserializer.DeserializeString<byte, FieldNameVisitor>(new FieldNameVisitor());
+                public string ExpectedTypeName => "string";
+                byte Serde.IDeserializeVisitor<byte>.VisitString(string s) => VisitUtf8Span(System.Text.Encoding.UTF8.GetBytes(s));
+                public byte VisitUtf8Span(System.ReadOnlySpan<byte> s)
+                {
+                    switch (s[0])
+                    {
+                        case (byte)'b'when s.SequenceEqual("boolField"u8):
+                            return 1;
+                        case (byte)'c'when s.SequenceEqual("charField"u8):
+                            return 2;
+                        case (byte)'b'when s.SequenceEqual("byteField"u8):
+                            return 3;
+                        case (byte)'u'when s.SequenceEqual("uShortField"u8):
+                            return 4;
+                        case (byte)'u'when s.SequenceEqual("uIntField"u8):
+                            return 5;
+                        case (byte)'u'when s.SequenceEqual("uLongField"u8):
+                            return 6;
+                        case (byte)'s'when s.SequenceEqual("sByteField"u8):
+                            return 7;
+                        case (byte)'s'when s.SequenceEqual("shortField"u8):
+                            return 8;
+                        case (byte)'i'when s.SequenceEqual("intField"u8):
+                            return 9;
+                        case (byte)'l'when s.SequenceEqual("longField"u8):
+                            return 10;
+                        case (byte)'s'when s.SequenceEqual("stringField"u8):
+                            return 11;
+                        case (byte)'n'when s.SequenceEqual("nullStringField"u8):
+                            return 12;
+                        case (byte)'u'when s.SequenceEqual("uIntArr"u8):
+                            return 13;
+                        case (byte)'n'when s.SequenceEqual("nestedArr"u8):
+                            return 14;
+                        case (byte)'i'when s.SequenceEqual("intImm"u8):
+                            return 15;
+                        case (byte)'c'when s.SequenceEqual("color"u8):
+                            return 16;
+                        default:
+                            return 0;
+                    }
+                }
+            }
+
             Serde.Test.AllInOne Serde.IDeserializeVisitor<Serde.Test.AllInOne>.VisitDictionary<D>(ref D d)
             {
                 Serde.Option<bool> boolfield = default;
@@ -52,59 +101,57 @@ namespace Serde.Test
                 Serde.Option<int[][]> nestedarr = default;
                 Serde.Option<System.Collections.Immutable.ImmutableArray<int>> intimm = default;
                 Serde.Option<Serde.Test.AllInOne.ColorEnum> color = default;
-                while (d.TryGetNextKey<string, StringWrap>(out string? key))
+                while (d.TryGetNextKey<byte, FieldNameVisitor>(out byte key))
                 {
                     switch (key)
                     {
-                        case "boolField":
+                        case 1:
                             boolfield = d.GetNextValue<bool, BoolWrap>();
                             break;
-                        case "charField":
+                        case 2:
                             charfield = d.GetNextValue<char, CharWrap>();
                             break;
-                        case "byteField":
+                        case 3:
                             bytefield = d.GetNextValue<byte, ByteWrap>();
                             break;
-                        case "uShortField":
+                        case 4:
                             ushortfield = d.GetNextValue<ushort, UInt16Wrap>();
                             break;
-                        case "uIntField":
+                        case 5:
                             uintfield = d.GetNextValue<uint, UInt32Wrap>();
                             break;
-                        case "uLongField":
+                        case 6:
                             ulongfield = d.GetNextValue<ulong, UInt64Wrap>();
                             break;
-                        case "sByteField":
+                        case 7:
                             sbytefield = d.GetNextValue<sbyte, SByteWrap>();
                             break;
-                        case "shortField":
+                        case 8:
                             shortfield = d.GetNextValue<short, Int16Wrap>();
                             break;
-                        case "intField":
+                        case 9:
                             intfield = d.GetNextValue<int, Int32Wrap>();
                             break;
-                        case "longField":
+                        case 10:
                             longfield = d.GetNextValue<long, Int64Wrap>();
                             break;
-                        case "stringField":
+                        case 11:
                             stringfield = d.GetNextValue<string, StringWrap>();
                             break;
-                        case "nullStringField":
+                        case 12:
                             nullstringfield = d.GetNextValue<string?, NullableRefWrap.DeserializeImpl<string, StringWrap>>();
                             break;
-                        case "uIntArr":
+                        case 13:
                             uintarr = d.GetNextValue<uint[], ArrayWrap.DeserializeImpl<uint, UInt32Wrap>>();
                             break;
-                        case "nestedArr":
+                        case 14:
                             nestedarr = d.GetNextValue<int[][], ArrayWrap.DeserializeImpl<int[], ArrayWrap.DeserializeImpl<int, Int32Wrap>>>();
                             break;
-                        case "intImm":
+                        case 15:
                             intimm = d.GetNextValue<System.Collections.Immutable.ImmutableArray<int>, ImmutableArrayWrap.DeserializeImpl<int, Int32Wrap>>();
                             break;
-                        case "color":
+                        case 16:
                             color = d.GetNextValue<Serde.Test.AllInOne.ColorEnum, AllInOneColorEnumWrap>();
-                            break;
-                        default:
                             break;
                     }
                 }

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.AllInOne.IDeserialize.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.AllInOne.IDeserialize.cs
@@ -35,7 +35,7 @@ namespace Serde.Test
         private sealed class SerdeVisitor : Serde.IDeserializeVisitor<Serde.Test.AllInOne>
         {
             public string ExpectedTypeName => "Serde.Test.AllInOne";
-            private sealed class FieldNameVisitor : Serde.IDeserialize<byte>, Serde.IDeserializeVisitor<byte>
+            private struct FieldNameVisitor : Serde.IDeserialize<byte>, Serde.IDeserializeVisitor<byte>
             {
                 public static byte Deserialize<D>(ref D deserializer)
                     where D : IDeserializer => deserializer.DeserializeString<byte, FieldNameVisitor>(new FieldNameVisitor());

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.AllInOne.ISerialize.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.AllInOne.ISerialize.cs
@@ -1,5 +1,6 @@
 ﻿
 #nullable enable
+using System;
 using Serde;
 
 namespace Serde.Test

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.GenericWrapperTests.CustomArrayWrapExplicitOnType.IDeserialize.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.GenericWrapperTests.CustomArrayWrapExplicitOnType.IDeserialize.cs
@@ -22,7 +22,7 @@ namespace Serde.Test
             private sealed class SerdeVisitor : Serde.IDeserializeVisitor<Serde.Test.GenericWrapperTests.CustomArrayWrapExplicitOnType>
             {
                 public string ExpectedTypeName => "Serde.Test.GenericWrapperTests.CustomArrayWrapExplicitOnType";
-                private sealed class FieldNameVisitor : Serde.IDeserialize<byte>, Serde.IDeserializeVisitor<byte>
+                private struct FieldNameVisitor : Serde.IDeserialize<byte>, Serde.IDeserializeVisitor<byte>
                 {
                     public static byte Deserialize<D>(ref D deserializer)
                         where D : IDeserializer => deserializer.DeserializeString<byte, FieldNameVisitor>(new FieldNameVisitor());

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.GenericWrapperTests.CustomArrayWrapExplicitOnType.IDeserialize.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.GenericWrapperTests.CustomArrayWrapExplicitOnType.IDeserialize.cs
@@ -1,5 +1,6 @@
 ﻿
 #nullable enable
+using System;
 using Serde;
 
 namespace Serde.Test
@@ -21,17 +22,33 @@ namespace Serde.Test
             private sealed class SerdeVisitor : Serde.IDeserializeVisitor<Serde.Test.GenericWrapperTests.CustomArrayWrapExplicitOnType>
             {
                 public string ExpectedTypeName => "Serde.Test.GenericWrapperTests.CustomArrayWrapExplicitOnType";
+                private sealed class FieldNameVisitor : Serde.IDeserialize<byte>, Serde.IDeserializeVisitor<byte>
+                {
+                    public static byte Deserialize<D>(ref D deserializer)
+                        where D : IDeserializer => deserializer.DeserializeString<byte, FieldNameVisitor>(new FieldNameVisitor());
+                    public string ExpectedTypeName => "string";
+                    byte Serde.IDeserializeVisitor<byte>.VisitString(string s) => VisitUtf8Span(System.Text.Encoding.UTF8.GetBytes(s));
+                    public byte VisitUtf8Span(System.ReadOnlySpan<byte> s)
+                    {
+                        switch (s[0])
+                        {
+                            case (byte)'a'when s.SequenceEqual("a"u8):
+                                return 1;
+                            default:
+                                return 0;
+                        }
+                    }
+                }
+
                 Serde.Test.GenericWrapperTests.CustomArrayWrapExplicitOnType Serde.IDeserializeVisitor<Serde.Test.GenericWrapperTests.CustomArrayWrapExplicitOnType>.VisitDictionary<D>(ref D d)
                 {
                     Serde.Option<Serde.Test.GenericWrapperTests.CustomImArray2<int>> a = default;
-                    while (d.TryGetNextKey<string, StringWrap>(out string? key))
+                    while (d.TryGetNextKey<byte, FieldNameVisitor>(out byte key))
                     {
                         switch (key)
                         {
-                            case "a":
+                            case 1:
                                 a = d.GetNextValue<Serde.Test.GenericWrapperTests.CustomImArray2<int>, Serde.Test.GenericWrapperTests.CustomImArray2Wrap.DeserializeImpl<int, Int32Wrap>>();
-                                break;
-                            default:
                                 break;
                         }
                     }

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.GenericWrapperTests.CustomArrayWrapExplicitOnType.ISerialize.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.GenericWrapperTests.CustomArrayWrapExplicitOnType.ISerialize.cs
@@ -1,5 +1,6 @@
 ﻿
 #nullable enable
+using System;
 using Serde;
 
 namespace Serde.Test

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.GenericWrapperTests.CustomImArrayExplicitWrapOnMember.IDeserialize.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.GenericWrapperTests.CustomImArrayExplicitWrapOnMember.IDeserialize.cs
@@ -22,7 +22,7 @@ namespace Serde.Test
             private sealed class SerdeVisitor : Serde.IDeserializeVisitor<Serde.Test.GenericWrapperTests.CustomImArrayExplicitWrapOnMember>
             {
                 public string ExpectedTypeName => "Serde.Test.GenericWrapperTests.CustomImArrayExplicitWrapOnMember";
-                private sealed class FieldNameVisitor : Serde.IDeserialize<byte>, Serde.IDeserializeVisitor<byte>
+                private struct FieldNameVisitor : Serde.IDeserialize<byte>, Serde.IDeserializeVisitor<byte>
                 {
                     public static byte Deserialize<D>(ref D deserializer)
                         where D : IDeserializer => deserializer.DeserializeString<byte, FieldNameVisitor>(new FieldNameVisitor());

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.GenericWrapperTests.CustomImArrayExplicitWrapOnMember.IDeserialize.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.GenericWrapperTests.CustomImArrayExplicitWrapOnMember.IDeserialize.cs
@@ -1,5 +1,6 @@
 ﻿
 #nullable enable
+using System;
 using Serde;
 
 namespace Serde.Test
@@ -21,17 +22,33 @@ namespace Serde.Test
             private sealed class SerdeVisitor : Serde.IDeserializeVisitor<Serde.Test.GenericWrapperTests.CustomImArrayExplicitWrapOnMember>
             {
                 public string ExpectedTypeName => "Serde.Test.GenericWrapperTests.CustomImArrayExplicitWrapOnMember";
+                private sealed class FieldNameVisitor : Serde.IDeserialize<byte>, Serde.IDeserializeVisitor<byte>
+                {
+                    public static byte Deserialize<D>(ref D deserializer)
+                        where D : IDeserializer => deserializer.DeserializeString<byte, FieldNameVisitor>(new FieldNameVisitor());
+                    public string ExpectedTypeName => "string";
+                    byte Serde.IDeserializeVisitor<byte>.VisitString(string s) => VisitUtf8Span(System.Text.Encoding.UTF8.GetBytes(s));
+                    public byte VisitUtf8Span(System.ReadOnlySpan<byte> s)
+                    {
+                        switch (s[0])
+                        {
+                            case (byte)'a'when s.SequenceEqual("a"u8):
+                                return 1;
+                            default:
+                                return 0;
+                        }
+                    }
+                }
+
                 Serde.Test.GenericWrapperTests.CustomImArrayExplicitWrapOnMember Serde.IDeserializeVisitor<Serde.Test.GenericWrapperTests.CustomImArrayExplicitWrapOnMember>.VisitDictionary<D>(ref D d)
                 {
                     Serde.Option<Serde.Test.GenericWrapperTests.CustomImArray<int>> a = default;
-                    while (d.TryGetNextKey<string, StringWrap>(out string? key))
+                    while (d.TryGetNextKey<byte, FieldNameVisitor>(out byte key))
                     {
                         switch (key)
                         {
-                            case "a":
+                            case 1:
                                 a = d.GetNextValue<Serde.Test.GenericWrapperTests.CustomImArray<int>, Serde.Test.GenericWrapperTests.CustomImArrayWrap.DeserializeImpl<int, Int32Wrap>>();
-                                break;
-                            default:
                                 break;
                         }
                     }

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.GenericWrapperTests.CustomImArrayExplicitWrapOnMember.ISerialize.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.GenericWrapperTests.CustomImArrayExplicitWrapOnMember.ISerialize.cs
@@ -1,5 +1,6 @@
 ﻿
 #nullable enable
+using System;
 using Serde;
 
 namespace Serde.Test

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonDeserializeTests.DenyUnknown.IDeserialize.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonDeserializeTests.DenyUnknown.IDeserialize.cs
@@ -7,9 +7,9 @@ namespace Serde.Test
 {
     partial class JsonDeserializeTests
     {
-        partial record struct ThrowMissing : Serde.IDeserialize<Serde.Test.JsonDeserializeTests.ThrowMissing>
+        partial record struct DenyUnknown : Serde.IDeserialize<Serde.Test.JsonDeserializeTests.DenyUnknown>
         {
-            static Serde.Test.JsonDeserializeTests.ThrowMissing Serde.IDeserialize<Serde.Test.JsonDeserializeTests.ThrowMissing>.Deserialize<D>(ref D deserializer)
+            static Serde.Test.JsonDeserializeTests.DenyUnknown Serde.IDeserialize<Serde.Test.JsonDeserializeTests.DenyUnknown>.Deserialize<D>(ref D deserializer)
             {
                 var visitor = new SerdeVisitor();
                 var fieldNames = new[]
@@ -17,12 +17,12 @@ namespace Serde.Test
                     "Present",
                     "Missing"
                 };
-                return deserializer.DeserializeType<Serde.Test.JsonDeserializeTests.ThrowMissing, SerdeVisitor>("ThrowMissing", fieldNames, visitor);
+                return deserializer.DeserializeType<Serde.Test.JsonDeserializeTests.DenyUnknown, SerdeVisitor>("DenyUnknown", fieldNames, visitor);
             }
 
-            private sealed class SerdeVisitor : Serde.IDeserializeVisitor<Serde.Test.JsonDeserializeTests.ThrowMissing>
+            private sealed class SerdeVisitor : Serde.IDeserializeVisitor<Serde.Test.JsonDeserializeTests.DenyUnknown>
             {
-                public string ExpectedTypeName => "Serde.Test.JsonDeserializeTests.ThrowMissing";
+                public string ExpectedTypeName => "Serde.Test.JsonDeserializeTests.DenyUnknown";
                 private sealed class FieldNameVisitor : Serde.IDeserialize<byte>, Serde.IDeserializeVisitor<byte>
                 {
                     public static byte Deserialize<D>(ref D deserializer)
@@ -38,12 +38,12 @@ namespace Serde.Test
                             case (byte)'m'when s.SequenceEqual("missing"u8):
                                 return 2;
                             default:
-                                return 0;
+                                throw new InvalidDeserializeValueException("Unexpected field or property name in type Serde.Test.JsonDeserializeTests.DenyUnknown: '" + System.Text.Encoding.UTF8.GetString(s) + "'");
                         }
                     }
                 }
 
-                Serde.Test.JsonDeserializeTests.ThrowMissing Serde.IDeserializeVisitor<Serde.Test.JsonDeserializeTests.ThrowMissing>.VisitDictionary<D>(ref D d)
+                Serde.Test.JsonDeserializeTests.DenyUnknown Serde.IDeserializeVisitor<Serde.Test.JsonDeserializeTests.DenyUnknown>.VisitDictionary<D>(ref D d)
                 {
                     Serde.Option<string> present = default;
                     Serde.Option<string?> missing = default;
@@ -60,10 +60,10 @@ namespace Serde.Test
                         }
                     }
 
-                    var newType = new Serde.Test.JsonDeserializeTests.ThrowMissing()
+                    var newType = new Serde.Test.JsonDeserializeTests.DenyUnknown()
                     {
                         Present = present.GetValueOrThrow("Present"),
-                        Missing = missing.GetValueOrThrow("Missing"),
+                        Missing = missing.GetValueOrDefault(null),
                     };
                     return newType;
                 }

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonDeserializeTests.DenyUnknown.IDeserialize.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonDeserializeTests.DenyUnknown.IDeserialize.cs
@@ -23,7 +23,7 @@ namespace Serde.Test
             private sealed class SerdeVisitor : Serde.IDeserializeVisitor<Serde.Test.JsonDeserializeTests.DenyUnknown>
             {
                 public string ExpectedTypeName => "Serde.Test.JsonDeserializeTests.DenyUnknown";
-                private sealed class FieldNameVisitor : Serde.IDeserialize<byte>, Serde.IDeserializeVisitor<byte>
+                private struct FieldNameVisitor : Serde.IDeserialize<byte>, Serde.IDeserializeVisitor<byte>
                 {
                     public static byte Deserialize<D>(ref D deserializer)
                         where D : IDeserializer => deserializer.DeserializeString<byte, FieldNameVisitor>(new FieldNameVisitor());

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonDeserializeTests.ExtraMembers.IDeserialize.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonDeserializeTests.ExtraMembers.IDeserialize.cs
@@ -22,7 +22,7 @@ namespace Serde.Test
             private sealed class SerdeVisitor : Serde.IDeserializeVisitor<Serde.Test.JsonDeserializeTests.ExtraMembers>
             {
                 public string ExpectedTypeName => "Serde.Test.JsonDeserializeTests.ExtraMembers";
-                private sealed class FieldNameVisitor : Serde.IDeserialize<byte>, Serde.IDeserializeVisitor<byte>
+                private struct FieldNameVisitor : Serde.IDeserialize<byte>, Serde.IDeserializeVisitor<byte>
                 {
                     public static byte Deserialize<D>(ref D deserializer)
                         where D : IDeserializer => deserializer.DeserializeString<byte, FieldNameVisitor>(new FieldNameVisitor());

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonDeserializeTests.ExtraMembers.IDeserialize.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonDeserializeTests.ExtraMembers.IDeserialize.cs
@@ -1,5 +1,6 @@
 ﻿
 #nullable enable
+using System;
 using Serde;
 
 namespace Serde.Test
@@ -21,17 +22,33 @@ namespace Serde.Test
             private sealed class SerdeVisitor : Serde.IDeserializeVisitor<Serde.Test.JsonDeserializeTests.ExtraMembers>
             {
                 public string ExpectedTypeName => "Serde.Test.JsonDeserializeTests.ExtraMembers";
+                private sealed class FieldNameVisitor : Serde.IDeserialize<byte>, Serde.IDeserializeVisitor<byte>
+                {
+                    public static byte Deserialize<D>(ref D deserializer)
+                        where D : IDeserializer => deserializer.DeserializeString<byte, FieldNameVisitor>(new FieldNameVisitor());
+                    public string ExpectedTypeName => "string";
+                    byte Serde.IDeserializeVisitor<byte>.VisitString(string s) => VisitUtf8Span(System.Text.Encoding.UTF8.GetBytes(s));
+                    public byte VisitUtf8Span(System.ReadOnlySpan<byte> s)
+                    {
+                        switch (s[0])
+                        {
+                            case (byte)'b'when s.SequenceEqual("b"u8):
+                                return 1;
+                            default:
+                                return 0;
+                        }
+                    }
+                }
+
                 Serde.Test.JsonDeserializeTests.ExtraMembers Serde.IDeserializeVisitor<Serde.Test.JsonDeserializeTests.ExtraMembers>.VisitDictionary<D>(ref D d)
                 {
                     Serde.Option<int> b = default;
-                    while (d.TryGetNextKey<string, StringWrap>(out string? key))
+                    while (d.TryGetNextKey<byte, FieldNameVisitor>(out byte key))
                     {
                         switch (key)
                         {
-                            case "b":
+                            case 1:
                                 b = d.GetNextValue<int, Int32Wrap>();
-                                break;
-                            default:
                                 break;
                         }
                     }

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonDeserializeTests.IdStruct.IDeserialize.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonDeserializeTests.IdStruct.IDeserialize.cs
@@ -22,7 +22,7 @@ namespace Serde.Test
             private sealed class SerdeVisitor : Serde.IDeserializeVisitor<Serde.Test.JsonDeserializeTests.IdStruct>
             {
                 public string ExpectedTypeName => "Serde.Test.JsonDeserializeTests.IdStruct";
-                private sealed class FieldNameVisitor : Serde.IDeserialize<byte>, Serde.IDeserializeVisitor<byte>
+                private struct FieldNameVisitor : Serde.IDeserialize<byte>, Serde.IDeserializeVisitor<byte>
                 {
                     public static byte Deserialize<D>(ref D deserializer)
                         where D : IDeserializer => deserializer.DeserializeString<byte, FieldNameVisitor>(new FieldNameVisitor());

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonDeserializeTests.IdStruct.IDeserialize.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonDeserializeTests.IdStruct.IDeserialize.cs
@@ -1,5 +1,6 @@
 ﻿
 #nullable enable
+using System;
 using Serde;
 
 namespace Serde.Test
@@ -21,17 +22,33 @@ namespace Serde.Test
             private sealed class SerdeVisitor : Serde.IDeserializeVisitor<Serde.Test.JsonDeserializeTests.IdStruct>
             {
                 public string ExpectedTypeName => "Serde.Test.JsonDeserializeTests.IdStruct";
+                private sealed class FieldNameVisitor : Serde.IDeserialize<byte>, Serde.IDeserializeVisitor<byte>
+                {
+                    public static byte Deserialize<D>(ref D deserializer)
+                        where D : IDeserializer => deserializer.DeserializeString<byte, FieldNameVisitor>(new FieldNameVisitor());
+                    public string ExpectedTypeName => "string";
+                    byte Serde.IDeserializeVisitor<byte>.VisitString(string s) => VisitUtf8Span(System.Text.Encoding.UTF8.GetBytes(s));
+                    public byte VisitUtf8Span(System.ReadOnlySpan<byte> s)
+                    {
+                        switch (s[0])
+                        {
+                            case (byte)'i'when s.SequenceEqual("id"u8):
+                                return 1;
+                            default:
+                                return 0;
+                        }
+                    }
+                }
+
                 Serde.Test.JsonDeserializeTests.IdStruct Serde.IDeserializeVisitor<Serde.Test.JsonDeserializeTests.IdStruct>.VisitDictionary<D>(ref D d)
                 {
                     Serde.Option<int> id = default;
-                    while (d.TryGetNextKey<string, StringWrap>(out string? key))
+                    while (d.TryGetNextKey<byte, FieldNameVisitor>(out byte key))
                     {
                         switch (key)
                         {
-                            case "id":
+                            case 1:
                                 id = d.GetNextValue<int, Int32Wrap>();
-                                break;
-                            default:
                                 break;
                         }
                     }

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonDeserializeTests.IdStructList.IDeserialize.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonDeserializeTests.IdStructList.IDeserialize.cs
@@ -23,7 +23,7 @@ namespace Serde.Test
             private sealed class SerdeVisitor : Serde.IDeserializeVisitor<Serde.Test.JsonDeserializeTests.IdStructList>
             {
                 public string ExpectedTypeName => "Serde.Test.JsonDeserializeTests.IdStructList";
-                private sealed class FieldNameVisitor : Serde.IDeserialize<byte>, Serde.IDeserializeVisitor<byte>
+                private struct FieldNameVisitor : Serde.IDeserialize<byte>, Serde.IDeserializeVisitor<byte>
                 {
                     public static byte Deserialize<D>(ref D deserializer)
                         where D : IDeserializer => deserializer.DeserializeString<byte, FieldNameVisitor>(new FieldNameVisitor());

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonDeserializeTests.IdStructList.IDeserialize.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonDeserializeTests.IdStructList.IDeserialize.cs
@@ -1,5 +1,6 @@
 ﻿
 #nullable enable
+using System;
 using Serde;
 
 namespace Serde.Test
@@ -22,21 +23,39 @@ namespace Serde.Test
             private sealed class SerdeVisitor : Serde.IDeserializeVisitor<Serde.Test.JsonDeserializeTests.IdStructList>
             {
                 public string ExpectedTypeName => "Serde.Test.JsonDeserializeTests.IdStructList";
+                private sealed class FieldNameVisitor : Serde.IDeserialize<byte>, Serde.IDeserializeVisitor<byte>
+                {
+                    public static byte Deserialize<D>(ref D deserializer)
+                        where D : IDeserializer => deserializer.DeserializeString<byte, FieldNameVisitor>(new FieldNameVisitor());
+                    public string ExpectedTypeName => "string";
+                    byte Serde.IDeserializeVisitor<byte>.VisitString(string s) => VisitUtf8Span(System.Text.Encoding.UTF8.GetBytes(s));
+                    public byte VisitUtf8Span(System.ReadOnlySpan<byte> s)
+                    {
+                        switch (s[0])
+                        {
+                            case (byte)'c'when s.SequenceEqual("count"u8):
+                                return 1;
+                            case (byte)'l'when s.SequenceEqual("list"u8):
+                                return 2;
+                            default:
+                                return 0;
+                        }
+                    }
+                }
+
                 Serde.Test.JsonDeserializeTests.IdStructList Serde.IDeserializeVisitor<Serde.Test.JsonDeserializeTests.IdStructList>.VisitDictionary<D>(ref D d)
                 {
                     Serde.Option<int> count = default;
                     Serde.Option<System.Collections.Generic.List<Serde.Test.JsonDeserializeTests.IdStruct>> list = default;
-                    while (d.TryGetNextKey<string, StringWrap>(out string? key))
+                    while (d.TryGetNextKey<byte, FieldNameVisitor>(out byte key))
                     {
                         switch (key)
                         {
-                            case "count":
+                            case 1:
                                 count = d.GetNextValue<int, Int32Wrap>();
                                 break;
-                            case "list":
+                            case 2:
                                 list = d.GetNextValue<System.Collections.Generic.List<Serde.Test.JsonDeserializeTests.IdStruct>, ListWrap.DeserializeImpl<Serde.Test.JsonDeserializeTests.IdStruct, Serde.Test.JsonDeserializeTests.IdStruct>>();
-                                break;
-                            default:
                                 break;
                         }
                     }

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonDeserializeTests.NullableFields.IDeserialize.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonDeserializeTests.NullableFields.IDeserialize.cs
@@ -1,5 +1,6 @@
 ﻿
 #nullable enable
+using System;
 using Serde;
 
 namespace Serde.Test
@@ -22,21 +23,39 @@ namespace Serde.Test
             private sealed class SerdeVisitor : Serde.IDeserializeVisitor<Serde.Test.JsonDeserializeTests.NullableFields>
             {
                 public string ExpectedTypeName => "Serde.Test.JsonDeserializeTests.NullableFields";
+                private sealed class FieldNameVisitor : Serde.IDeserialize<byte>, Serde.IDeserializeVisitor<byte>
+                {
+                    public static byte Deserialize<D>(ref D deserializer)
+                        where D : IDeserializer => deserializer.DeserializeString<byte, FieldNameVisitor>(new FieldNameVisitor());
+                    public string ExpectedTypeName => "string";
+                    byte Serde.IDeserializeVisitor<byte>.VisitString(string s) => VisitUtf8Span(System.Text.Encoding.UTF8.GetBytes(s));
+                    public byte VisitUtf8Span(System.ReadOnlySpan<byte> s)
+                    {
+                        switch (s[0])
+                        {
+                            case (byte)'s'when s.SequenceEqual("s"u8):
+                                return 1;
+                            case (byte)'d'when s.SequenceEqual("dict"u8):
+                                return 2;
+                            default:
+                                return 0;
+                        }
+                    }
+                }
+
                 Serde.Test.JsonDeserializeTests.NullableFields Serde.IDeserializeVisitor<Serde.Test.JsonDeserializeTests.NullableFields>.VisitDictionary<D>(ref D d)
                 {
                     Serde.Option<string?> s = default;
                     Serde.Option<System.Collections.Generic.Dictionary<string, string?>> dict = default;
-                    while (d.TryGetNextKey<string, StringWrap>(out string? key))
+                    while (d.TryGetNextKey<byte, FieldNameVisitor>(out byte key))
                     {
                         switch (key)
                         {
-                            case "s":
+                            case 1:
                                 s = d.GetNextValue<string?, NullableRefWrap.DeserializeImpl<string, StringWrap>>();
                                 break;
-                            case "dict":
+                            case 2:
                                 dict = d.GetNextValue<System.Collections.Generic.Dictionary<string, string?>, DictWrap.DeserializeImpl<string, StringWrap, string?, NullableRefWrap.DeserializeImpl<string, StringWrap>>>();
-                                break;
-                            default:
                                 break;
                         }
                     }

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonDeserializeTests.NullableFields.IDeserialize.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonDeserializeTests.NullableFields.IDeserialize.cs
@@ -23,7 +23,7 @@ namespace Serde.Test
             private sealed class SerdeVisitor : Serde.IDeserializeVisitor<Serde.Test.JsonDeserializeTests.NullableFields>
             {
                 public string ExpectedTypeName => "Serde.Test.JsonDeserializeTests.NullableFields";
-                private sealed class FieldNameVisitor : Serde.IDeserialize<byte>, Serde.IDeserializeVisitor<byte>
+                private struct FieldNameVisitor : Serde.IDeserialize<byte>, Serde.IDeserializeVisitor<byte>
                 {
                     public static byte Deserialize<D>(ref D deserializer)
                         where D : IDeserializer => deserializer.DeserializeString<byte, FieldNameVisitor>(new FieldNameVisitor());

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonDeserializeTests.SetToNull.IDeserialize.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonDeserializeTests.SetToNull.IDeserialize.cs
@@ -23,7 +23,7 @@ namespace Serde.Test
             private sealed class SerdeVisitor : Serde.IDeserializeVisitor<Serde.Test.JsonDeserializeTests.SetToNull>
             {
                 public string ExpectedTypeName => "Serde.Test.JsonDeserializeTests.SetToNull";
-                private sealed class FieldNameVisitor : Serde.IDeserialize<byte>, Serde.IDeserializeVisitor<byte>
+                private struct FieldNameVisitor : Serde.IDeserialize<byte>, Serde.IDeserializeVisitor<byte>
                 {
                     public static byte Deserialize<D>(ref D deserializer)
                         where D : IDeserializer => deserializer.DeserializeString<byte, FieldNameVisitor>(new FieldNameVisitor());

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonDeserializeTests.SetToNull.IDeserialize.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonDeserializeTests.SetToNull.IDeserialize.cs
@@ -1,5 +1,6 @@
 ﻿
 #nullable enable
+using System;
 using Serde;
 
 namespace Serde.Test
@@ -22,21 +23,39 @@ namespace Serde.Test
             private sealed class SerdeVisitor : Serde.IDeserializeVisitor<Serde.Test.JsonDeserializeTests.SetToNull>
             {
                 public string ExpectedTypeName => "Serde.Test.JsonDeserializeTests.SetToNull";
+                private sealed class FieldNameVisitor : Serde.IDeserialize<byte>, Serde.IDeserializeVisitor<byte>
+                {
+                    public static byte Deserialize<D>(ref D deserializer)
+                        where D : IDeserializer => deserializer.DeserializeString<byte, FieldNameVisitor>(new FieldNameVisitor());
+                    public string ExpectedTypeName => "string";
+                    byte Serde.IDeserializeVisitor<byte>.VisitString(string s) => VisitUtf8Span(System.Text.Encoding.UTF8.GetBytes(s));
+                    public byte VisitUtf8Span(System.ReadOnlySpan<byte> s)
+                    {
+                        switch (s[0])
+                        {
+                            case (byte)'p'when s.SequenceEqual("present"u8):
+                                return 1;
+                            case (byte)'m'when s.SequenceEqual("missing"u8):
+                                return 2;
+                            default:
+                                return 0;
+                        }
+                    }
+                }
+
                 Serde.Test.JsonDeserializeTests.SetToNull Serde.IDeserializeVisitor<Serde.Test.JsonDeserializeTests.SetToNull>.VisitDictionary<D>(ref D d)
                 {
                     Serde.Option<string> present = default;
                     Serde.Option<string?> missing = default;
-                    while (d.TryGetNextKey<string, StringWrap>(out string? key))
+                    while (d.TryGetNextKey<byte, FieldNameVisitor>(out byte key))
                     {
                         switch (key)
                         {
-                            case "present":
+                            case 1:
                                 present = d.GetNextValue<string, StringWrap>();
                                 break;
-                            case "missing":
+                            case 2:
                                 missing = d.GetNextValue<string?, NullableRefWrap.DeserializeImpl<string, StringWrap>>();
-                                break;
-                            default:
                                 break;
                         }
                     }

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonDeserializeTests.ThrowMissing.IDeserialize.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonDeserializeTests.ThrowMissing.IDeserialize.cs
@@ -23,7 +23,7 @@ namespace Serde.Test
             private sealed class SerdeVisitor : Serde.IDeserializeVisitor<Serde.Test.JsonDeserializeTests.ThrowMissing>
             {
                 public string ExpectedTypeName => "Serde.Test.JsonDeserializeTests.ThrowMissing";
-                private sealed class FieldNameVisitor : Serde.IDeserialize<byte>, Serde.IDeserializeVisitor<byte>
+                private struct FieldNameVisitor : Serde.IDeserialize<byte>, Serde.IDeserializeVisitor<byte>
                 {
                     public static byte Deserialize<D>(ref D deserializer)
                         where D : IDeserializer => deserializer.DeserializeString<byte, FieldNameVisitor>(new FieldNameVisitor());

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonSerializerTests.NullableFields.ISerialize.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonSerializerTests.NullableFields.ISerialize.cs
@@ -1,5 +1,6 @@
 ﻿
 #nullable enable
+using System;
 using Serde;
 
 namespace Serde.Test

--- a/test/Serde.Xml.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.AllInOneColorEnumWrap.IDeserialize.cs
+++ b/test/Serde.Xml.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.AllInOneColorEnumWrap.IDeserialize.cs
@@ -1,5 +1,6 @@
 ﻿
 #nullable enable
+using System;
 using Serde;
 
 namespace Serde

--- a/test/Serde.Xml.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.AllInOneColorEnumWrap.ISerialize.cs
+++ b/test/Serde.Xml.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.AllInOneColorEnumWrap.ISerialize.cs
@@ -1,5 +1,6 @@
 ﻿
 #nullable enable
+using System;
 using Serde;
 
 namespace Serde

--- a/test/Serde.Xml.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.AllInOne.IDeserialize.cs
+++ b/test/Serde.Xml.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.AllInOne.IDeserialize.cs
@@ -1,5 +1,6 @@
 ﻿
 #nullable enable
+using System;
 using Serde;
 
 namespace Serde.Test
@@ -34,6 +35,54 @@ namespace Serde.Test
         private sealed class SerdeVisitor : Serde.IDeserializeVisitor<Serde.Test.AllInOne>
         {
             public string ExpectedTypeName => "Serde.Test.AllInOne";
+            private sealed class FieldNameVisitor : Serde.IDeserialize<byte>, Serde.IDeserializeVisitor<byte>
+            {
+                public static byte Deserialize<D>(ref D deserializer)
+                    where D : IDeserializer => deserializer.DeserializeString<byte, FieldNameVisitor>(new FieldNameVisitor());
+                public string ExpectedTypeName => "string";
+                byte Serde.IDeserializeVisitor<byte>.VisitString(string s) => VisitUtf8Span(System.Text.Encoding.UTF8.GetBytes(s));
+                public byte VisitUtf8Span(System.ReadOnlySpan<byte> s)
+                {
+                    switch (s[0])
+                    {
+                        case (byte)'b'when s.SequenceEqual("boolField"u8):
+                            return 1;
+                        case (byte)'c'when s.SequenceEqual("charField"u8):
+                            return 2;
+                        case (byte)'b'when s.SequenceEqual("byteField"u8):
+                            return 3;
+                        case (byte)'u'when s.SequenceEqual("uShortField"u8):
+                            return 4;
+                        case (byte)'u'when s.SequenceEqual("uIntField"u8):
+                            return 5;
+                        case (byte)'u'when s.SequenceEqual("uLongField"u8):
+                            return 6;
+                        case (byte)'s'when s.SequenceEqual("sByteField"u8):
+                            return 7;
+                        case (byte)'s'when s.SequenceEqual("shortField"u8):
+                            return 8;
+                        case (byte)'i'when s.SequenceEqual("intField"u8):
+                            return 9;
+                        case (byte)'l'when s.SequenceEqual("longField"u8):
+                            return 10;
+                        case (byte)'s'when s.SequenceEqual("stringField"u8):
+                            return 11;
+                        case (byte)'n'when s.SequenceEqual("nullStringField"u8):
+                            return 12;
+                        case (byte)'u'when s.SequenceEqual("uIntArr"u8):
+                            return 13;
+                        case (byte)'n'when s.SequenceEqual("nestedArr"u8):
+                            return 14;
+                        case (byte)'i'when s.SequenceEqual("intImm"u8):
+                            return 15;
+                        case (byte)'c'when s.SequenceEqual("color"u8):
+                            return 16;
+                        default:
+                            return 0;
+                    }
+                }
+            }
+
             Serde.Test.AllInOne Serde.IDeserializeVisitor<Serde.Test.AllInOne>.VisitDictionary<D>(ref D d)
             {
                 Serde.Option<bool> boolfield = default;
@@ -52,59 +101,57 @@ namespace Serde.Test
                 Serde.Option<int[][]> nestedarr = default;
                 Serde.Option<System.Collections.Immutable.ImmutableArray<int>> intimm = default;
                 Serde.Option<Serde.Test.AllInOne.ColorEnum> color = default;
-                while (d.TryGetNextKey<string, StringWrap>(out string? key))
+                while (d.TryGetNextKey<byte, FieldNameVisitor>(out byte key))
                 {
                     switch (key)
                     {
-                        case "boolField":
+                        case 1:
                             boolfield = d.GetNextValue<bool, BoolWrap>();
                             break;
-                        case "charField":
+                        case 2:
                             charfield = d.GetNextValue<char, CharWrap>();
                             break;
-                        case "byteField":
+                        case 3:
                             bytefield = d.GetNextValue<byte, ByteWrap>();
                             break;
-                        case "uShortField":
+                        case 4:
                             ushortfield = d.GetNextValue<ushort, UInt16Wrap>();
                             break;
-                        case "uIntField":
+                        case 5:
                             uintfield = d.GetNextValue<uint, UInt32Wrap>();
                             break;
-                        case "uLongField":
+                        case 6:
                             ulongfield = d.GetNextValue<ulong, UInt64Wrap>();
                             break;
-                        case "sByteField":
+                        case 7:
                             sbytefield = d.GetNextValue<sbyte, SByteWrap>();
                             break;
-                        case "shortField":
+                        case 8:
                             shortfield = d.GetNextValue<short, Int16Wrap>();
                             break;
-                        case "intField":
+                        case 9:
                             intfield = d.GetNextValue<int, Int32Wrap>();
                             break;
-                        case "longField":
+                        case 10:
                             longfield = d.GetNextValue<long, Int64Wrap>();
                             break;
-                        case "stringField":
+                        case 11:
                             stringfield = d.GetNextValue<string, StringWrap>();
                             break;
-                        case "nullStringField":
+                        case 12:
                             nullstringfield = d.GetNextValue<string?, NullableRefWrap.DeserializeImpl<string, StringWrap>>();
                             break;
-                        case "uIntArr":
+                        case 13:
                             uintarr = d.GetNextValue<uint[], ArrayWrap.DeserializeImpl<uint, UInt32Wrap>>();
                             break;
-                        case "nestedArr":
+                        case 14:
                             nestedarr = d.GetNextValue<int[][], ArrayWrap.DeserializeImpl<int[], ArrayWrap.DeserializeImpl<int, Int32Wrap>>>();
                             break;
-                        case "intImm":
+                        case 15:
                             intimm = d.GetNextValue<System.Collections.Immutable.ImmutableArray<int>, ImmutableArrayWrap.DeserializeImpl<int, Int32Wrap>>();
                             break;
-                        case "color":
+                        case 16:
                             color = d.GetNextValue<Serde.Test.AllInOne.ColorEnum, AllInOneColorEnumWrap>();
-                            break;
-                        default:
                             break;
                     }
                 }

--- a/test/Serde.Xml.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.AllInOne.IDeserialize.cs
+++ b/test/Serde.Xml.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.AllInOne.IDeserialize.cs
@@ -35,7 +35,7 @@ namespace Serde.Test
         private sealed class SerdeVisitor : Serde.IDeserializeVisitor<Serde.Test.AllInOne>
         {
             public string ExpectedTypeName => "Serde.Test.AllInOne";
-            private sealed class FieldNameVisitor : Serde.IDeserialize<byte>, Serde.IDeserializeVisitor<byte>
+            private struct FieldNameVisitor : Serde.IDeserialize<byte>, Serde.IDeserializeVisitor<byte>
             {
                 public static byte Deserialize<D>(ref D deserializer)
                     where D : IDeserializer => deserializer.DeserializeString<byte, FieldNameVisitor>(new FieldNameVisitor());

--- a/test/Serde.Xml.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.AllInOne.ISerialize.cs
+++ b/test/Serde.Xml.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.AllInOne.ISerialize.cs
@@ -1,5 +1,6 @@
 ﻿
 #nullable enable
+using System;
 using Serde;
 
 namespace Serde.Test

--- a/test/Serde.Xml.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.SampleTest.Address.ISerialize.cs
+++ b/test/Serde.Xml.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.SampleTest.Address.ISerialize.cs
@@ -1,5 +1,6 @@
 ﻿
 #nullable enable
+using System;
 using Serde;
 
 namespace Serde.Test

--- a/test/Serde.Xml.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.SampleTest.OrderedItem.ISerialize.cs
+++ b/test/Serde.Xml.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.SampleTest.OrderedItem.ISerialize.cs
@@ -1,5 +1,6 @@
 ﻿
 #nullable enable
+using System;
 using Serde;
 
 namespace Serde.Test

--- a/test/Serde.Xml.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.SampleTest.PurchaseOrder.ISerialize.cs
+++ b/test/Serde.Xml.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.SampleTest.PurchaseOrder.ISerialize.cs
@@ -1,5 +1,6 @@
 ﻿
 #nullable enable
+using System;
 using Serde;
 
 namespace Serde.Test

--- a/test/Serde.Xml.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.XmlTests.BoolStruct.ISerialize.cs
+++ b/test/Serde.Xml.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.XmlTests.BoolStruct.ISerialize.cs
@@ -1,5 +1,6 @@
 ﻿
 #nullable enable
+using System;
 using Serde;
 
 namespace Serde.Test

--- a/test/Serde.Xml.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.XmlTests.MapTest1.ISerialize.cs
+++ b/test/Serde.Xml.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.XmlTests.MapTest1.ISerialize.cs
@@ -1,5 +1,6 @@
 ﻿
 #nullable enable
+using System;
 using Serde;
 
 namespace Serde.Test

--- a/test/Serde.Xml.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.XmlTests.NestedArrays.ISerialize.cs
+++ b/test/Serde.Xml.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.XmlTests.NestedArrays.ISerialize.cs
@@ -1,5 +1,6 @@
 ﻿
 #nullable enable
+using System;
 using Serde;
 
 namespace Serde.Test

--- a/test/Serde.Xml.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.XmlTests.StructWithIntField.ISerialize.cs
+++ b/test/Serde.Xml.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.XmlTests.StructWithIntField.ISerialize.cs
@@ -1,5 +1,6 @@
 ﻿
 #nullable enable
+using System;
 using Serde;
 
 namespace Serde.Test

--- a/test/Serde.Xml.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.XmlTests.TypeWithArrayField.ISerialize.cs
+++ b/test/Serde.Xml.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.XmlTests.TypeWithArrayField.ISerialize.cs
@@ -1,5 +1,6 @@
 ﻿
 #nullable enable
+using System;
 using Serde;
 
 namespace Serde.Test


### PR DESCRIPTION
Currently the custom type visitor just deserializes field names as strings, which allocates a new System.String for each field. However, the API supports passing through a ReadOnlySpan<byte> for UTF8 strings. This change should provide support using the ROS<byte> in the normal path and avoid allocation.

Before:

| Method    | Mean       | Error    | StdDev   | Gen0   | Gen1 | Allocated |
|-----------|------------|----------|----------|--------|------|:---------:|
| SerdeJson | 1,983.3 ns | 24.13 ns | 22.57 ns | 0.2708 | -    | 1712 B    |


After:

|   Method  |    Mean    |   Error  |  StdDev  |  Gen0  |  Gen1  | Allocated |
|:---------:|:----------:|:--------:|:--------:|:------:|:------:|:---------:|
| SerdeJson | 1,729.5 ns | 16.44 ns | 15.38 ns | 0.1831 | - | 1152 B |
