### PR TITLE
Implement a better union example and allow SerdeTypeOptions on enum

### DIFF
--- a/samples/unions/Unions.csproj
+++ b/samples/unions/Unions.csproj
@@ -11,4 +11,11 @@
     <ProjectReference Include="../../src/serde/Serde.csproj" />
     <ProjectReference Include="../../src/generator/SerdeGenerator.csproj" OutputItemType="Analyzer" />
   </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="StaticCs" Version="0.3.1">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
 </Project>

--- a/src/serde/Attributes.cs
+++ b/src/serde/Attributes.cs
@@ -116,7 +116,7 @@ sealed class SerdeWrapAttribute : Attribute
 /// <summary>
 /// Set options for the Serde source generator for the current type.
 /// </summary>
-[AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct, AllowMultiple = false, Inherited = false)]
+[AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct | AttributeTargets.Enum, AllowMultiple = false, Inherited = false)]
 #if !SRCGEN
 public
 #else

--- a/src/serde/ISerialize.cs
+++ b/src/serde/ISerialize.cs
@@ -8,9 +8,11 @@ public interface ISerialize
     void Serialize(ISerializer serializer);
 }
 
-public interface ISerialize<in T>
+public interface ISerialize<in T> : ISerialize
 {
     void Serialize(T value, ISerializer serializer);
+
+    void ISerialize.Serialize(ISerializer serializer) => Serialize((T)this, serializer);
 }
 
 public interface ISerializeType

--- a/test/Serde.Generation.Test/MemberFormatTests.cs
+++ b/test/Serde.Generation.Test/MemberFormatTests.cs
@@ -108,5 +108,23 @@ partial struct S
 }";
             return VerifyMultiFile(src);
         }
+
+        [Fact]
+        public Task EnumFormat()
+        {
+            var src = """
+
+using Serde;
+[GenerateSerde]
+[SerdeTypeOptions(MemberFormat = MemberFormat.None)]
+public enum ColorEnum
+{
+    Red,
+    Green,
+    Blue
+}
+""";
+            return VerifyMultiFile(src);
+        }
    }
 }

--- a/test/Serde.Generation.Test/test_output/MemberFormatTests.EnumFormat/ColorEnumWrap.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/MemberFormatTests.EnumFormat/ColorEnumWrap.IDeserialize.verified.cs
@@ -1,0 +1,32 @@
+﻿//HintName: ColorEnumWrap.IDeserialize.cs
+
+#nullable enable
+using System;
+using Serde;
+
+partial record struct ColorEnumWrap : Serde.IDeserialize<ColorEnum>
+{
+    static ColorEnum Serde.IDeserialize<ColorEnum>.Deserialize<D>(ref D deserializer)
+    {
+        var visitor = new SerdeVisitor();
+        return deserializer.DeserializeString<ColorEnum, SerdeVisitor>(visitor);
+    }
+
+    private sealed class SerdeVisitor : Serde.IDeserializeVisitor<ColorEnum>
+    {
+        public string ExpectedTypeName => "ColorEnum";
+
+        ColorEnum Serde.IDeserializeVisitor<ColorEnum>.VisitString(string s) => s switch
+        {
+            "Red" => ColorEnum.Red,
+            "Green" => ColorEnum.Green,
+            "Blue" => ColorEnum.Blue,
+            _ => throw new InvalidDeserializeValueException("Unexpected enum field name: " + s)};
+        ColorEnum Serde.IDeserializeVisitor<ColorEnum>.VisitUtf8Span(System.ReadOnlySpan<byte> s) => s switch
+        {
+            _ when System.MemoryExtensions.SequenceEqual(s, "Red"u8) => ColorEnum.Red,
+            _ when System.MemoryExtensions.SequenceEqual(s, "Green"u8) => ColorEnum.Green,
+            _ when System.MemoryExtensions.SequenceEqual(s, "Blue"u8) => ColorEnum.Blue,
+            _ => throw new InvalidDeserializeValueException("Unexpected enum field name: " + System.Text.Encoding.UTF8.GetString(s))};
+    }
+}

--- a/test/Serde.Generation.Test/test_output/MemberFormatTests.EnumFormat/ColorEnumWrap.ISerialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/MemberFormatTests.EnumFormat/ColorEnumWrap.ISerialize.verified.cs
@@ -1,0 +1,20 @@
+﻿//HintName: ColorEnumWrap.ISerialize.cs
+
+#nullable enable
+using System;
+using Serde;
+
+partial record struct ColorEnumWrap : Serde.ISerialize
+{
+    void Serde.ISerialize.Serialize(ISerializer serializer)
+    {
+        var name = Value switch
+        {
+            ColorEnum.Red => "Red",
+            ColorEnum.Green => "Green",
+            ColorEnum.Blue => "Blue",
+            _ => null
+        };
+        serializer.SerializeEnumValue("ColorEnum", name, new Int32Wrap((int)Value));
+    }
+}

--- a/test/Serde.Generation.Test/test_output/MemberFormatTests.EnumFormat/ColorEnumWrap.ISerializeWrap.verified.cs
+++ b/test/Serde.Generation.Test/test_output/MemberFormatTests.EnumFormat/ColorEnumWrap.ISerializeWrap.verified.cs
@@ -1,0 +1,6 @@
+﻿//HintName: ColorEnumWrap.ISerializeWrap.cs
+
+partial record struct ColorEnumWrap : Serde.ISerializeWrap<ColorEnum, ColorEnumWrap>
+{
+    static ColorEnumWrap Serde.ISerializeWrap<ColorEnum, ColorEnumWrap>.Create(ColorEnum value) => new(value);
+}

--- a/test/Serde.Generation.Test/test_output/MemberFormatTests.EnumFormat/ColorEnumWrap.ISerialize`1.verified.cs
+++ b/test/Serde.Generation.Test/test_output/MemberFormatTests.EnumFormat/ColorEnumWrap.ISerialize`1.verified.cs
@@ -1,0 +1,20 @@
+﻿//HintName: ColorEnumWrap.ISerialize`1.cs
+
+#nullable enable
+using System;
+using Serde;
+
+partial record struct ColorEnumWrap : Serde.ISerialize<ColorEnum>
+{
+    void ISerialize<ColorEnum>.Serialize(ColorEnum value, ISerializer serializer)
+    {
+        var name = value switch
+        {
+            ColorEnum.Red => "Red",
+            ColorEnum.Green => "Green",
+            ColorEnum.Blue => "Blue",
+            _ => null
+        };
+        serializer.SerializeEnumValue("ColorEnum", name, new Int32Wrap((int)value));
+    }
+}

--- a/test/Serde.Generation.Test/test_output/MemberFormatTests.EnumFormat/ColorEnumWrap.verified.cs
+++ b/test/Serde.Generation.Test/test_output/MemberFormatTests.EnumFormat/ColorEnumWrap.verified.cs
@@ -1,0 +1,3 @@
+﻿//HintName: ColorEnumWrap.cs
+
+readonly partial record struct ColorEnumWrap(ColorEnum Value);


### PR DESCRIPTION
Provides an example on how to write 'externally tagged unions' in serde.net and allows placing SerdeTypeOptions on enum declarations.