### PR TITLE
Fix type wrapping order

### DIFF
--- a/src/generator/TypeDeclContext.cs
+++ b/src/generator/TypeDeclContext.cs
@@ -39,6 +39,8 @@ namespace Serde
                         break;
                 }
             }
+            nsNames.Reverse();
+            parentTypeInfos.Reverse();
             NamespaceNames = nsNames;
             ParentTypeInfo = parentTypeInfos;
             TypeParameterList = typeDecl is TypeDeclarationSyntax derived

--- a/test/Serde.Generation.Test/DeserializeTests.cs
+++ b/test/Serde.Generation.Test/DeserializeTests.cs
@@ -177,6 +177,30 @@ public enum ColorULong : ulong { Red = 3, Green = 5, Blue = 7 }
             return GeneratorTestUtils.VerifyMultiFile(src);
         }
 
+        [Fact]
+        public Task NestedPartialClasses()
+        {
+            var src = """
+using Serde;
+
+partial class A
+{
+    private partial class B
+    {
+        private partial class C
+        {
+            [GenerateDeserialize]
+            private partial class D
+            {
+                public int Field;
+            }
+        }
+    }
+}
+""";
+            return VerifyDeserialize(src);
+        }
+
         private static Task VerifyDeserialize(
             string src,
             [CallerMemberName] string caller = "")

--- a/test/Serde.Generation.Test/SerializeTests.cs
+++ b/test/Serde.Generation.Test/SerializeTests.cs
@@ -560,6 +560,30 @@ public enum Rgb { Red, Green, Blue }
             return VerifyMultiFile(src);
         }
 
+        [Fact]
+        public Task NestedPartialClasses()
+        {
+            var src = """
+using Serde;
+
+partial class A
+{
+    private partial class B
+    {
+        private partial class C
+        {
+            [GenerateSerialize]
+            private partial class D
+            {
+                public int Field;
+            }
+        }
+    }
+}
+""";
+            return VerifySerialize(src);
+        }
+
         private static Task VerifySerialize(
             string src,
             [CallerMemberName] string callerName = "")

--- a/test/Serde.Generation.Test/test_output/DeserializeTests/NestedPartialClasses#A.B.C.D.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/DeserializeTests/NestedPartialClasses#A.B.C.D.IDeserialize.verified.cs
@@ -1,0 +1,78 @@
+﻿//HintName: A.B.C.D.IDeserialize.cs
+
+#nullable enable
+using System;
+using Serde;
+
+partial class A
+{
+    partial class B
+    {
+        partial class C
+        {
+            partial class D : Serde.IDeserialize<A.B.C.D>
+            {
+                static A.B.C.D Serde.IDeserialize<A.B.C.D>.Deserialize<D>(ref D deserializer)
+                {
+                    var visitor = new SerdeVisitor();
+                    var fieldNames = new[]
+                    {
+                        "Field"
+                    };
+                    return deserializer.DeserializeType<A.B.C.D, SerdeVisitor>("D", fieldNames, visitor);
+                }
+
+                private sealed class SerdeVisitor : Serde.IDeserializeVisitor<A.B.C.D>
+                {
+                    public string ExpectedTypeName => "A.B.C.D";
+
+                    private struct FieldNameVisitor : Serde.IDeserialize<byte>, Serde.IDeserializeVisitor<byte>
+                    {
+                        public static byte Deserialize<D>(ref D deserializer)
+                            where D : IDeserializer => deserializer.DeserializeString<byte, FieldNameVisitor>(new FieldNameVisitor());
+                        public string ExpectedTypeName => "string";
+
+                        byte Serde.IDeserializeVisitor<byte>.VisitString(string s) => VisitUtf8Span(System.Text.Encoding.UTF8.GetBytes(s));
+                        public byte VisitUtf8Span(System.ReadOnlySpan<byte> s)
+                        {
+                            switch (s[0])
+                            {
+                                case (byte)'f'when s.SequenceEqual("field"u8):
+                                    return 1;
+                                default:
+                                    return 0;
+                            }
+                        }
+                    }
+
+                    A.B.C.D Serde.IDeserializeVisitor<A.B.C.D>.VisitDictionary<D>(ref D d)
+                    {
+                        int _l_field = default !;
+                        byte _r_assignedValid = 0b0;
+                        while (d.TryGetNextKey<byte, FieldNameVisitor>(out byte key))
+                        {
+                            switch (key)
+                            {
+                                case 1:
+                                    _l_field = d.GetNextValue<int, Int32Wrap>();
+                                    _r_assignedValid |= ((byte)1) << 0;
+                                    break;
+                            }
+                        }
+
+                        if (_r_assignedValid != 0b1)
+                        {
+                            throw new Serde.InvalidDeserializeValueException("Not all members were assigned");
+                        }
+
+                        var newType = new A.B.C.D()
+                        {
+                            Field = _l_field,
+                        };
+                        return newType;
+                    }
+                }
+            }
+        }
+    }
+}

--- a/test/Serde.Generation.Test/test_output/SerializeTests/NestedPartialClasses#A.B.C.D.ISerialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/SerializeTests/NestedPartialClasses#A.B.C.D.ISerialize.verified.cs
@@ -1,0 +1,24 @@
+﻿//HintName: A.B.C.D.ISerialize.cs
+
+#nullable enable
+using System;
+using Serde;
+
+partial class A
+{
+    partial class B
+    {
+        partial class C
+        {
+            partial class D : Serde.ISerialize
+            {
+                void Serde.ISerialize.Serialize(ISerializer serializer)
+                {
+                    var type = serializer.SerializeType("D", 1);
+                    type.SerializeField("field"u8, new Int32Wrap(this.Field));
+                    type.End();
+                }
+            }
+        }
+    }
+}

--- a/test/Serde.Generation.Test/test_output/SerializeTests/NestedPartialClasses#A.B.C.D.ISerialize`1.verified.cs
+++ b/test/Serde.Generation.Test/test_output/SerializeTests/NestedPartialClasses#A.B.C.D.ISerialize`1.verified.cs
@@ -1,0 +1,24 @@
+﻿//HintName: A.B.C.D.ISerialize`1.cs
+
+#nullable enable
+using System;
+using Serde;
+
+partial class A
+{
+    partial class B
+    {
+        partial class C
+        {
+            partial class D : Serde.ISerialize<A.B.C.D>
+            {
+                void ISerialize<A.B.C.D>.Serialize(A.B.C.D value, ISerializer serializer)
+                {
+                    var type = serializer.SerializeType("D", 1);
+                    type.SerializeField<int, Int32Wrap>("field", value.Field);
+                    type.End();
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Types were being wrapped inside out, i.e. if you have some nested type A.B.C.D, the partial type for D was being synthesized as C.B.A.D. This fixes the order for both serialization and deserialization.