### PR TITLE
Remove constrained generic from Deserialize

### DIFF
--- a/perf/bench/SampleTypes.cs
+++ b/perf/bench/SampleTypes.cs
@@ -58,7 +58,7 @@ namespace Benchmarks
 
     public partial record LocationWrap : IDeserialize<Location>
     {
-        static Benchmarks.Location Serde.IDeserialize<Benchmarks.Location>.Deserialize<D>(ref D deserializer)
+        static Benchmarks.Location Serde.IDeserialize<Benchmarks.Location>.Deserialize(IDeserializer deserializer)
         {
             var fieldNames = new[]
             {
@@ -83,8 +83,7 @@ namespace Benchmarks
             private sealed class FieldNameVisitor : Serde.IDeserialize<byte>, Serde.IDeserializeVisitor<byte>
             {
                 public static readonly FieldNameVisitor Instance = new FieldNameVisitor();
-                public static byte Deserialize<D>(ref D deserializer)
-                    where D : IDeserializer => deserializer.DeserializeString(Instance);
+                public static byte Deserialize(IDeserializer deserializer) => deserializer.DeserializeString(Instance);
                 public string ExpectedTypeName => "string";
 
                 byte Serde.IDeserializeVisitor<byte>.VisitString(string s) => VisitUtf8Span(System.Text.Encoding.UTF8.GetBytes(s));

--- a/samples/unions/Program.cs
+++ b/samples/unions/Program.cs
@@ -55,7 +55,7 @@ partial record BaseType : ISerialize<BaseType>
 
 partial record BaseType : IDeserialize<BaseType>
 {
-    public static BaseType Deserialize<D>(ref D deserializer) where D : IDeserializer
+    public static BaseType Deserialize(IDeserializer deserializer) where D : IDeserializer
     {
         return deserializer.DeserializeDictionary<BaseType, DeserializeVisitor>(new DeserializeVisitor());
     }

--- a/src/generator/Generator.Deserialize.cs
+++ b/src/generator/Generator.Deserialize.cs
@@ -138,10 +138,8 @@ namespace Serde
                 typeSyntax,
                 explicitInterfaceSpecifier: ExplicitInterfaceSpecifier(interfaceSyntax),
                 identifier: Identifier("Deserialize"),
-                typeParameterList: TypeParameterList(SeparatedList(new[] {
-                        TypeParameter("D"),
-                    })),
-                parameterList: ParameterList(SeparatedList(new[] { Parameter("D", "deserializer", byRef: true) })),
+                typeParameterList: null,
+                parameterList: ParameterList(SeparatedList(new[] { Parameter("IDeserializer", "deserializer", byRef: false) })),
                 constraintClauses: default,
                 body: Block(stmts.ToArray()),
                 expressionBody: null
@@ -247,7 +245,7 @@ namespace Serde
 private sealed class FieldNameVisitor : Serde.IDeserialize<byte>, Serde.IDeserializeVisitor<byte>
 {
     public static readonly FieldNameVisitor Instance = new FieldNameVisitor();
-    public static byte Deserialize<D>(ref D deserializer) where D : IDeserializer
+    public static byte Deserialize(IDeserializer deserializer)
         => deserializer.DeserializeString(Instance);
 
     public string ExpectedTypeName => "string";

--- a/src/serde/IDeserialize.cs
+++ b/src/serde/IDeserialize.cs
@@ -1,7 +1,6 @@
 
 using System;
 using System.Diagnostics.CodeAnalysis;
-using System.Runtime.CompilerServices;
 
 namespace Serde
 {
@@ -12,8 +11,7 @@ namespace Serde
     /// </summary>
     public interface IDeserialize<T>
     {
-        abstract static T Deserialize<D>(ref D deserializer)
-            where D : IDeserializer;
+        abstract static T Deserialize(IDeserializer deserializer);
     }
 
     /// <summary>
@@ -50,7 +48,7 @@ namespace Serde
         T VisitDictionary<D>(ref D d) where D : IDeserializeDictionary
             => throw new InvalidDeserializeValueException("Expected type " + ExpectedTypeName);
         T VisitNull() => throw new InvalidOperationException("Expected type " + ExpectedTypeName);
-        T VisitNotNull<D>(ref D d) where D : IDeserializer => throw new InvalidOperationException("Expected type " + ExpectedTypeName);
+        T VisitNotNull(IDeserializer d) => throw new InvalidOperationException("Expected type " + ExpectedTypeName);
     }
 
     public interface IDeserializeEnumerable

--- a/src/serde/Wrappers.Dictionary.cs
+++ b/src/serde/Wrappers.Dictionary.cs
@@ -50,12 +50,13 @@ namespace Serde
             where TKeyWrap : IDeserialize<TKey>
             where TValueWrap : IDeserialize<TValue>
         {
-            static Dictionary<TKey, TValue> IDeserialize<Dictionary<TKey, TValue>>.Deserialize<D>(ref D deserializer)
+            static Dictionary<TKey, TValue> IDeserialize<Dictionary<TKey, TValue>>.Deserialize(IDeserializer deserializer)
             {
-                return deserializer.DeserializeDictionary(new Visitor());
+                return deserializer.DeserializeDictionary(Visitor.Instance);
             }
-            private struct Visitor : IDeserializeVisitor<Dictionary<TKey, TValue>>
+            private sealed class Visitor : IDeserializeVisitor<Dictionary<TKey, TValue>>
             {
+                public static readonly Visitor Instance = new Visitor();
                 public string ExpectedTypeName => "Dictionary<" + typeof(TKey).Name + ", " + typeof(TValue).Name + ">";
                 public Dictionary<TKey, TValue> VisitDictionary<D>(ref D d)
                     where D : IDeserializeDictionary

--- a/src/serde/Wrappers.List.cs
+++ b/src/serde/Wrappers.List.cs
@@ -75,11 +75,11 @@ namespace Serde
         public readonly struct DeserializeImpl<T, TWrap> : IDeserialize<T[]>
             where TWrap : IDeserialize<T>
         {
-            static T[] IDeserialize<T[]>.Deserialize<D>(ref D deserializer)
+            static T[] IDeserialize<T[]>.Deserialize(IDeserializer deserializer)
             {
                 return deserializer.DeserializeEnumerable(new SerdeVisitor());
             }
-            private struct SerdeVisitor : IDeserializeVisitor<T[]>
+            private sealed class SerdeVisitor : IDeserializeVisitor<T[]>
             {
                 string IDeserializeVisitor<T[]>.ExpectedTypeName => typeof(T[]).ToString();
 
@@ -130,11 +130,11 @@ namespace Serde
         public readonly struct DeserializeImpl<T, TWrap> : IDeserialize<List<T>>
             where TWrap : IDeserialize<T>
         {
-            static List<T> IDeserialize<List<T>>.Deserialize<D>(ref D deserializer)
+            static List<T> IDeserialize<List<T>>.Deserialize(IDeserializer deserializer)
             {
                 return deserializer.DeserializeEnumerable(new SerdeVisitor());
             }
-            private struct SerdeVisitor : IDeserializeVisitor<List<T>>
+            private sealed class SerdeVisitor : IDeserializeVisitor<List<T>>
             {
                 string IDeserializeVisitor<List<T>>.ExpectedTypeName => typeof(T[]).ToString();
 
@@ -182,7 +182,7 @@ namespace Serde
         public readonly struct DeserializeImpl<T, TWrap> : IDeserialize<ImmutableArray<T>>
             where TWrap : IDeserialize<T>
         {
-            static ImmutableArray<T> IDeserialize<ImmutableArray<T>>.Deserialize<D>(ref D deserializer)
+            static ImmutableArray<T> IDeserialize<ImmutableArray<T>>.Deserialize(IDeserializer deserializer)
             {
                 return deserializer.DeserializeEnumerable(new Visitor());
             }

--- a/src/serde/Wrappers.cs
+++ b/src/serde/Wrappers.cs
@@ -32,7 +32,7 @@ namespace Serde
         {
             serializer.SerializeBool(Value);
         }
-        static bool Serde.IDeserialize<bool>.Deserialize<D>(ref D deserializer)
+        static bool Serde.IDeserialize<bool>.Deserialize(IDeserializer deserializer)
         {
             var visitor = SerdeVisitor.Instance;
             return deserializer.DeserializeBool(visitor);
@@ -57,7 +57,7 @@ namespace Serde
         {
             serializer.SerializeChar(Value);
         }
-        static char Serde.IDeserialize<char>.Deserialize<D>(ref D deserializer)
+        static char Serde.IDeserialize<char>.Deserialize(IDeserializer deserializer)
         {
             var visitor = SerdeVisitor.Instance;
             return deserializer.DeserializeChar(visitor);
@@ -97,7 +97,7 @@ namespace Serde
         {
             serializer.SerializeByte(value);
         }
-        static byte Serde.IDeserialize<byte>.Deserialize<D>(ref D deserializer)
+        static byte Serde.IDeserialize<byte>.Deserialize(IDeserializer deserializer)
         {
             var visitor = SerdeVisitor.Instance;
             return deserializer.DeserializeByte(visitor);
@@ -131,7 +131,7 @@ namespace Serde
         {
             serializer.SerializeU16(Value);
         }
-        static ushort Serde.IDeserialize<ushort>.Deserialize<D>(ref D deserializer)
+        static ushort Serde.IDeserialize<ushort>.Deserialize(IDeserializer deserializer)
         {
             var visitor = SerdeVisitor.Instance;
             return deserializer.DeserializeU16(visitor);
@@ -163,7 +163,7 @@ namespace Serde
         {
             serializer.SerializeU32(Value);
         }
-        static uint Serde.IDeserialize<uint>.Deserialize<D>(ref D deserializer)
+        static uint Serde.IDeserialize<uint>.Deserialize(IDeserializer deserializer)
         {
             var visitor = SerdeVisitor.Instance;
             return deserializer.DeserializeU32(visitor);
@@ -195,7 +195,7 @@ namespace Serde
         {
             serializer.SerializeU64(Value);
         }
-        static ulong Serde.IDeserialize<ulong>.Deserialize<D>(ref D deserializer)
+        static ulong Serde.IDeserialize<ulong>.Deserialize(IDeserializer deserializer)
         {
             var visitor = SerdeVisitor.Instance;
             return deserializer.DeserializeU64(visitor);
@@ -227,7 +227,7 @@ namespace Serde
         {
             serializer.SerializeSByte(Value);
         }
-        static sbyte Serde.IDeserialize<sbyte>.Deserialize<D>(ref D deserializer)
+        static sbyte Serde.IDeserialize<sbyte>.Deserialize(IDeserializer deserializer)
         {
             var visitor = SerdeVisitor.Instance;
             return deserializer.DeserializeSByte(visitor);
@@ -261,7 +261,7 @@ namespace Serde
         {
             serializer.SerializeI16(Value);
         }
-        static short Serde.IDeserialize<short>.Deserialize<D>(ref D deserializer)
+        static short Serde.IDeserialize<short>.Deserialize(IDeserializer deserializer)
         {
             var visitor = SerdeVisitor.Instance;
             return deserializer.DeserializeI16(visitor);
@@ -295,7 +295,7 @@ namespace Serde
         {
             serializer.SerializeI32(value);
         }
-        static int Serde.IDeserialize<int>.Deserialize<D>(ref D deserializer)
+        static int Serde.IDeserialize<int>.Deserialize(IDeserializer deserializer)
         {
             var visitor = SerdeVisitor.Instance;
             return deserializer.DeserializeI32(visitor);
@@ -327,7 +327,7 @@ namespace Serde
         {
             serializer.SerializeI64(Value);
         }
-        static long Serde.IDeserialize<long>.Deserialize<D>(ref D deserializer)
+        static long Serde.IDeserialize<long>.Deserialize(IDeserializer deserializer)
         {
             var visitor = SerdeVisitor.Instance;
             return deserializer.DeserializeI64(visitor);
@@ -360,7 +360,7 @@ namespace Serde
         {
             serializer.SerializeDouble(value);
         }
-        static double Serde.IDeserialize<double>.Deserialize<D>(ref D deserializer)
+        static double Serde.IDeserialize<double>.Deserialize(IDeserializer deserializer)
         {
             var visitor = SerdeVisitor.Instance;
             return deserializer.DeserializeDouble(visitor);
@@ -395,7 +395,7 @@ namespace Serde
         {
             serializer.SerializeDecimal(value);
         }
-        static decimal Serde.IDeserialize<decimal>.Deserialize<D>(ref D deserializer)
+        static decimal Serde.IDeserialize<decimal>.Deserialize(IDeserializer deserializer)
         {
             var visitor = SerdeVisitor.Instance;
             return deserializer.DeserializeDecimal(visitor);
@@ -431,8 +431,7 @@ namespace Serde
         {
             serializer.SerializeString(value);
         }
-        public static string Deserialize<D>(ref D deserializer)
-            where D : IDeserializer
+        public static string Deserialize(IDeserializer deserializer)
         {
             return deserializer.DeserializeString(SerdeVisitor.Instance);
         }
@@ -485,7 +484,7 @@ namespace Serde
             where T : struct
             where TWrap : IDeserialize<T>
         {
-            public static T? Deserialize<D>(ref D deserializer) where D : IDeserializer
+            public static T? Deserialize(IDeserializer deserializer)
             {
                 return deserializer.DeserializeNullableRef(new Visitor());
             }
@@ -499,9 +498,9 @@ namespace Serde
                     return null;
                 }
 
-                T? IDeserializeVisitor<T?>.VisitNotNull<D>(ref D d)
+                T? IDeserializeVisitor<T?>.VisitNotNull(IDeserializer d)
                 {
-                    return TWrap.Deserialize(ref d);
+                    return TWrap.Deserialize(d);
                 }
             }
         }
@@ -545,12 +544,12 @@ namespace Serde
             where T : class
             where TWrap : IDeserialize<T>
         {
-            public static T? Deserialize<D>(ref D deserializer) where D : IDeserializer
+            public static T? Deserialize(IDeserializer deserializer)
             {
                 return deserializer.DeserializeNullableRef(new Visitor());
             }
 
-            private struct Visitor : IDeserializeVisitor<T?>
+            private sealed class Visitor : IDeserializeVisitor<T?>
             {
                 public string ExpectedTypeName => typeof(T).ToString() + "?";
 
@@ -559,9 +558,9 @@ namespace Serde
                     return null;
                 }
 
-                T? IDeserializeVisitor<T?>.VisitNotNull<D>(ref D d)
+                T? IDeserializeVisitor<T?>.VisitNotNull(IDeserializer d)
                 {
-                    return TWrap.Deserialize(ref d);
+                    return TWrap.Deserialize(d);
                 }
             }
         }

--- a/src/serde/json/JsonSerializer.cs
+++ b/src/serde/json/JsonSerializer.cs
@@ -54,7 +54,7 @@ namespace Serde.Json
             where D : IDeserialize<T>
         {
             var deserializer = JsonDeserializer.FromString(source);
-            return D.Deserialize(ref deserializer);
+            return D.Deserialize(deserializer);
         }
     }
 }

--- a/src/serde/json/JsonValue.Deserialize.cs
+++ b/src/serde/json/JsonValue.Deserialize.cs
@@ -7,7 +7,7 @@ namespace Serde.Json
 {
     partial record JsonValue : IDeserialize<JsonValue>
     {
-        static JsonValue IDeserialize<JsonValue>.Deserialize<D>(ref D deserializer)
+        static JsonValue IDeserialize<JsonValue>.Deserialize(IDeserializer deserializer)
         {
             return deserializer.DeserializeAny(Visitor.Instance);
         }

--- a/test/Serde.Generation.Test/WrapperTests.cs
+++ b/test/Serde.Generation.Test/WrapperTests.cs
@@ -143,7 +143,7 @@ using Serde;
 
 partial record R : Serde.IDeserialize<R>
 {
-    static R Serde.IDeserialize<R>.Deserialize<D>(ref D deserializer)
+    static R Serde.IDeserialize<R>.Deserialize(IDeserializer deserializer)
     {
         var visitor = new SerdeVisitor();
         var fieldNames = new[]

--- a/test/Serde.Generation.Test/test_output/AllInOneTest.GeneratorTest/Serde.Test.AllInOne.ColorEnumWrap.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/AllInOneTest.GeneratorTest/Serde.Test.AllInOne.ColorEnumWrap.IDeserialize.verified.cs
@@ -10,7 +10,7 @@ namespace Serde.Test
     {
         partial record struct ColorEnumWrap : Serde.IDeserialize<Serde.Test.AllInOne.ColorEnum>
         {
-            static Serde.Test.AllInOne.ColorEnum Serde.IDeserialize<Serde.Test.AllInOne.ColorEnum>.Deserialize<D>(ref D deserializer)
+            static Serde.Test.AllInOne.ColorEnum Serde.IDeserialize<Serde.Test.AllInOne.ColorEnum>.Deserialize(IDeserializer deserializer)
             {
                 var visitor = new SerdeVisitor();
                 return deserializer.DeserializeString(visitor);

--- a/test/Serde.Generation.Test/test_output/AllInOneTest.GeneratorTest/Serde.Test.AllInOne.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/AllInOneTest.GeneratorTest/Serde.Test.AllInOne.IDeserialize.verified.cs
@@ -8,7 +8,7 @@ namespace Serde.Test
 {
     partial record AllInOne : Serde.IDeserialize<Serde.Test.AllInOne>
     {
-        static Serde.Test.AllInOne Serde.IDeserialize<Serde.Test.AllInOne>.Deserialize<D>(ref D deserializer)
+        static Serde.Test.AllInOne Serde.IDeserialize<Serde.Test.AllInOne>.Deserialize(IDeserializer deserializer)
         {
             var visitor = new SerdeVisitor();
             var fieldNames = new[]
@@ -40,8 +40,7 @@ namespace Serde.Test
             private sealed class FieldNameVisitor : Serde.IDeserialize<byte>, Serde.IDeserializeVisitor<byte>
             {
                 public static readonly FieldNameVisitor Instance = new FieldNameVisitor();
-                public static byte Deserialize<D>(ref D deserializer)
-                    where D : IDeserializer => deserializer.DeserializeString(Instance);
+                public static byte Deserialize(IDeserializer deserializer) => deserializer.DeserializeString(Instance);
                 public string ExpectedTypeName => "string";
 
                 byte Serde.IDeserializeVisitor<byte>.VisitString(string s) => VisitUtf8Span(System.Text.Encoding.UTF8.GetBytes(s));

--- a/test/Serde.Generation.Test/test_output/DeserializeTests.EnumMember/C.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/DeserializeTests.EnumMember/C.IDeserialize.verified.cs
@@ -6,7 +6,7 @@ using Serde;
 
 partial class C : Serde.IDeserialize<C>
 {
-    static C Serde.IDeserialize<C>.Deserialize<D>(ref D deserializer)
+    static C Serde.IDeserialize<C>.Deserialize(IDeserializer deserializer)
     {
         var visitor = new SerdeVisitor();
         var fieldNames = new[]
@@ -26,8 +26,7 @@ partial class C : Serde.IDeserialize<C>
         private sealed class FieldNameVisitor : Serde.IDeserialize<byte>, Serde.IDeserializeVisitor<byte>
         {
             public static readonly FieldNameVisitor Instance = new FieldNameVisitor();
-            public static byte Deserialize<D>(ref D deserializer)
-                where D : IDeserializer => deserializer.DeserializeString(Instance);
+            public static byte Deserialize(IDeserializer deserializer) => deserializer.DeserializeString(Instance);
             public string ExpectedTypeName => "string";
 
             byte Serde.IDeserializeVisitor<byte>.VisitString(string s) => VisitUtf8Span(System.Text.Encoding.UTF8.GetBytes(s));

--- a/test/Serde.Generation.Test/test_output/DeserializeTests.EnumMember/ColorByteWrap.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/DeserializeTests.EnumMember/ColorByteWrap.IDeserialize.verified.cs
@@ -6,7 +6,7 @@ using Serde;
 
 partial record struct ColorByteWrap : Serde.IDeserialize<ColorByte>
 {
-    static ColorByte Serde.IDeserialize<ColorByte>.Deserialize<D>(ref D deserializer)
+    static ColorByte Serde.IDeserialize<ColorByte>.Deserialize(IDeserializer deserializer)
     {
         var visitor = new SerdeVisitor();
         return deserializer.DeserializeString(visitor);

--- a/test/Serde.Generation.Test/test_output/DeserializeTests.EnumMember/ColorIntWrap.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/DeserializeTests.EnumMember/ColorIntWrap.IDeserialize.verified.cs
@@ -6,7 +6,7 @@ using Serde;
 
 partial record struct ColorIntWrap : Serde.IDeserialize<ColorInt>
 {
-    static ColorInt Serde.IDeserialize<ColorInt>.Deserialize<D>(ref D deserializer)
+    static ColorInt Serde.IDeserialize<ColorInt>.Deserialize(IDeserializer deserializer)
     {
         var visitor = new SerdeVisitor();
         return deserializer.DeserializeString(visitor);

--- a/test/Serde.Generation.Test/test_output/DeserializeTests.EnumMember/ColorLongWrap.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/DeserializeTests.EnumMember/ColorLongWrap.IDeserialize.verified.cs
@@ -6,7 +6,7 @@ using Serde;
 
 partial record struct ColorLongWrap : Serde.IDeserialize<ColorLong>
 {
-    static ColorLong Serde.IDeserialize<ColorLong>.Deserialize<D>(ref D deserializer)
+    static ColorLong Serde.IDeserialize<ColorLong>.Deserialize(IDeserializer deserializer)
     {
         var visitor = new SerdeVisitor();
         return deserializer.DeserializeString(visitor);

--- a/test/Serde.Generation.Test/test_output/DeserializeTests.EnumMember/ColorULongWrap.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/DeserializeTests.EnumMember/ColorULongWrap.IDeserialize.verified.cs
@@ -6,7 +6,7 @@ using Serde;
 
 partial record struct ColorULongWrap : Serde.IDeserialize<ColorULong>
 {
-    static ColorULong Serde.IDeserialize<ColorULong>.Deserialize<D>(ref D deserializer)
+    static ColorULong Serde.IDeserialize<ColorULong>.Deserialize(IDeserializer deserializer)
     {
         var visitor = new SerdeVisitor();
         return deserializer.DeserializeString(visitor);

--- a/test/Serde.Generation.Test/test_output/DeserializeTests.NestedExplicitDeserializeWrapper/OptsWrap.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/DeserializeTests.NestedExplicitDeserializeWrapper/OptsWrap.IDeserialize.verified.cs
@@ -6,7 +6,7 @@ using Serde;
 
 partial record struct OptsWrap : Serde.IDeserialize<System.Runtime.InteropServices.ComTypes.BIND_OPTS>
 {
-    static System.Runtime.InteropServices.ComTypes.BIND_OPTS Serde.IDeserialize<System.Runtime.InteropServices.ComTypes.BIND_OPTS>.Deserialize<D>(ref D deserializer)
+    static System.Runtime.InteropServices.ComTypes.BIND_OPTS Serde.IDeserialize<System.Runtime.InteropServices.ComTypes.BIND_OPTS>.Deserialize(IDeserializer deserializer)
     {
         var visitor = new SerdeVisitor();
         var fieldNames = new[]
@@ -26,8 +26,7 @@ partial record struct OptsWrap : Serde.IDeserialize<System.Runtime.InteropServic
         private sealed class FieldNameVisitor : Serde.IDeserialize<byte>, Serde.IDeserializeVisitor<byte>
         {
             public static readonly FieldNameVisitor Instance = new FieldNameVisitor();
-            public static byte Deserialize<D>(ref D deserializer)
-                where D : IDeserializer => deserializer.DeserializeString(Instance);
+            public static byte Deserialize(IDeserializer deserializer) => deserializer.DeserializeString(Instance);
             public string ExpectedTypeName => "string";
 
             byte Serde.IDeserializeVisitor<byte>.VisitString(string s) => VisitUtf8Span(System.Text.Encoding.UTF8.GetBytes(s));

--- a/test/Serde.Generation.Test/test_output/DeserializeTests.NestedExplicitDeserializeWrapper/S.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/DeserializeTests.NestedExplicitDeserializeWrapper/S.IDeserialize.verified.cs
@@ -6,7 +6,7 @@ using Serde;
 
 partial struct S : Serde.IDeserialize<S>
 {
-    static S Serde.IDeserialize<S>.Deserialize<D>(ref D deserializer)
+    static S Serde.IDeserialize<S>.Deserialize(IDeserializer deserializer)
     {
         var visitor = new SerdeVisitor();
         var fieldNames = new[]
@@ -23,8 +23,7 @@ partial struct S : Serde.IDeserialize<S>
         private sealed class FieldNameVisitor : Serde.IDeserialize<byte>, Serde.IDeserializeVisitor<byte>
         {
             public static readonly FieldNameVisitor Instance = new FieldNameVisitor();
-            public static byte Deserialize<D>(ref D deserializer)
-                where D : IDeserializer => deserializer.DeserializeString(Instance);
+            public static byte Deserialize(IDeserializer deserializer) => deserializer.DeserializeString(Instance);
             public string ExpectedTypeName => "string";
 
             byte Serde.IDeserializeVisitor<byte>.VisitString(string s) => VisitUtf8Span(System.Text.Encoding.UTF8.GetBytes(s));

--- a/test/Serde.Generation.Test/test_output/DeserializeTests/Array#ArrayField.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/DeserializeTests/Array#ArrayField.IDeserialize.verified.cs
@@ -6,7 +6,7 @@ using Serde;
 
 partial class ArrayField : Serde.IDeserialize<ArrayField>
 {
-    static ArrayField Serde.IDeserialize<ArrayField>.Deserialize<D>(ref D deserializer)
+    static ArrayField Serde.IDeserialize<ArrayField>.Deserialize(IDeserializer deserializer)
     {
         var visitor = new SerdeVisitor();
         var fieldNames = new[]
@@ -23,8 +23,7 @@ partial class ArrayField : Serde.IDeserialize<ArrayField>
         private sealed class FieldNameVisitor : Serde.IDeserialize<byte>, Serde.IDeserializeVisitor<byte>
         {
             public static readonly FieldNameVisitor Instance = new FieldNameVisitor();
-            public static byte Deserialize<D>(ref D deserializer)
-                where D : IDeserializer => deserializer.DeserializeString(Instance);
+            public static byte Deserialize(IDeserializer deserializer) => deserializer.DeserializeString(Instance);
             public string ExpectedTypeName => "string";
 
             byte Serde.IDeserializeVisitor<byte>.VisitString(string s) => VisitUtf8Span(System.Text.Encoding.UTF8.GetBytes(s));

--- a/test/Serde.Generation.Test/test_output/DeserializeTests/DeserializeMissing#SetToNull.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/DeserializeTests/DeserializeMissing#SetToNull.IDeserialize.verified.cs
@@ -6,7 +6,7 @@ using Serde;
 
 partial record struct SetToNull : Serde.IDeserialize<SetToNull>
 {
-    static SetToNull Serde.IDeserialize<SetToNull>.Deserialize<D>(ref D deserializer)
+    static SetToNull Serde.IDeserialize<SetToNull>.Deserialize(IDeserializer deserializer)
     {
         var visitor = new SerdeVisitor();
         var fieldNames = new[]
@@ -25,8 +25,7 @@ partial record struct SetToNull : Serde.IDeserialize<SetToNull>
         private sealed class FieldNameVisitor : Serde.IDeserialize<byte>, Serde.IDeserializeVisitor<byte>
         {
             public static readonly FieldNameVisitor Instance = new FieldNameVisitor();
-            public static byte Deserialize<D>(ref D deserializer)
-                where D : IDeserializer => deserializer.DeserializeString(Instance);
+            public static byte Deserialize(IDeserializer deserializer) => deserializer.DeserializeString(Instance);
             public string ExpectedTypeName => "string";
 
             byte Serde.IDeserializeVisitor<byte>.VisitString(string s) => VisitUtf8Span(System.Text.Encoding.UTF8.GetBytes(s));

--- a/test/Serde.Generation.Test/test_output/DeserializeTests/DeserializeOnlyWrap#Wrap.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/DeserializeTests/DeserializeOnlyWrap#Wrap.IDeserialize.verified.cs
@@ -6,7 +6,7 @@ using Serde;
 
 partial record struct Wrap : Serde.IDeserialize<System.Runtime.InteropServices.ComTypes.BIND_OPTS>
 {
-    static System.Runtime.InteropServices.ComTypes.BIND_OPTS Serde.IDeserialize<System.Runtime.InteropServices.ComTypes.BIND_OPTS>.Deserialize<D>(ref D deserializer)
+    static System.Runtime.InteropServices.ComTypes.BIND_OPTS Serde.IDeserialize<System.Runtime.InteropServices.ComTypes.BIND_OPTS>.Deserialize(IDeserializer deserializer)
     {
         var visitor = new SerdeVisitor();
         var fieldNames = new[]
@@ -26,8 +26,7 @@ partial record struct Wrap : Serde.IDeserialize<System.Runtime.InteropServices.C
         private sealed class FieldNameVisitor : Serde.IDeserialize<byte>, Serde.IDeserializeVisitor<byte>
         {
             public static readonly FieldNameVisitor Instance = new FieldNameVisitor();
-            public static byte Deserialize<D>(ref D deserializer)
-                where D : IDeserializer => deserializer.DeserializeString(Instance);
+            public static byte Deserialize(IDeserializer deserializer) => deserializer.DeserializeString(Instance);
             public string ExpectedTypeName => "string";
 
             byte Serde.IDeserializeVisitor<byte>.VisitString(string s) => VisitUtf8Span(System.Text.Encoding.UTF8.GetBytes(s));

--- a/test/Serde.Generation.Test/test_output/DeserializeTests/MemberSkip#Rgb.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/DeserializeTests/MemberSkip#Rgb.IDeserialize.verified.cs
@@ -6,7 +6,7 @@ using Serde;
 
 partial struct Rgb : Serde.IDeserialize<Rgb>
 {
-    static Rgb Serde.IDeserialize<Rgb>.Deserialize<D>(ref D deserializer)
+    static Rgb Serde.IDeserialize<Rgb>.Deserialize(IDeserializer deserializer)
     {
         var visitor = new SerdeVisitor();
         var fieldNames = new[]
@@ -24,8 +24,7 @@ partial struct Rgb : Serde.IDeserialize<Rgb>
         private sealed class FieldNameVisitor : Serde.IDeserialize<byte>, Serde.IDeserializeVisitor<byte>
         {
             public static readonly FieldNameVisitor Instance = new FieldNameVisitor();
-            public static byte Deserialize<D>(ref D deserializer)
-                where D : IDeserializer => deserializer.DeserializeString(Instance);
+            public static byte Deserialize(IDeserializer deserializer) => deserializer.DeserializeString(Instance);
             public string ExpectedTypeName => "string";
 
             byte Serde.IDeserializeVisitor<byte>.VisitString(string s) => VisitUtf8Span(System.Text.Encoding.UTF8.GetBytes(s));

--- a/test/Serde.Generation.Test/test_output/DeserializeTests/MemberSkipDeserialize#Rgb.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/DeserializeTests/MemberSkipDeserialize#Rgb.IDeserialize.verified.cs
@@ -6,7 +6,7 @@ using Serde;
 
 partial struct Rgb : Serde.IDeserialize<Rgb>
 {
-    static Rgb Serde.IDeserialize<Rgb>.Deserialize<D>(ref D deserializer)
+    static Rgb Serde.IDeserialize<Rgb>.Deserialize(IDeserializer deserializer)
     {
         var visitor = new SerdeVisitor();
         var fieldNames = new[]
@@ -25,8 +25,7 @@ partial struct Rgb : Serde.IDeserialize<Rgb>
         private sealed class FieldNameVisitor : Serde.IDeserialize<byte>, Serde.IDeserializeVisitor<byte>
         {
             public static readonly FieldNameVisitor Instance = new FieldNameVisitor();
-            public static byte Deserialize<D>(ref D deserializer)
-                where D : IDeserializer => deserializer.DeserializeString(Instance);
+            public static byte Deserialize(IDeserializer deserializer) => deserializer.DeserializeString(Instance);
             public string ExpectedTypeName => "string";
 
             byte Serde.IDeserializeVisitor<byte>.VisitString(string s) => VisitUtf8Span(System.Text.Encoding.UTF8.GetBytes(s));

--- a/test/Serde.Generation.Test/test_output/DeserializeTests/MemberSkipSerialize#Rgb.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/DeserializeTests/MemberSkipSerialize#Rgb.IDeserialize.verified.cs
@@ -6,7 +6,7 @@ using Serde;
 
 partial struct Rgb : Serde.IDeserialize<Rgb>
 {
-    static Rgb Serde.IDeserialize<Rgb>.Deserialize<D>(ref D deserializer)
+    static Rgb Serde.IDeserialize<Rgb>.Deserialize(IDeserializer deserializer)
     {
         var visitor = new SerdeVisitor();
         var fieldNames = new[]
@@ -24,8 +24,7 @@ partial struct Rgb : Serde.IDeserialize<Rgb>
         private sealed class FieldNameVisitor : Serde.IDeserialize<byte>, Serde.IDeserializeVisitor<byte>
         {
             public static readonly FieldNameVisitor Instance = new FieldNameVisitor();
-            public static byte Deserialize<D>(ref D deserializer)
-                where D : IDeserializer => deserializer.DeserializeString(Instance);
+            public static byte Deserialize(IDeserializer deserializer) => deserializer.DeserializeString(Instance);
             public string ExpectedTypeName => "string";
 
             byte Serde.IDeserializeVisitor<byte>.VisitString(string s) => VisitUtf8Span(System.Text.Encoding.UTF8.GetBytes(s));

--- a/test/Serde.Generation.Test/test_output/DeserializeTests/NestedPartialClasses#A.B.C.D.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/DeserializeTests/NestedPartialClasses#A.B.C.D.IDeserialize.verified.cs
@@ -12,7 +12,7 @@ partial class A
         {
             partial class D : Serde.IDeserialize<A.B.C.D>
             {
-                static A.B.C.D Serde.IDeserialize<A.B.C.D>.Deserialize<D>(ref D deserializer)
+                static A.B.C.D Serde.IDeserialize<A.B.C.D>.Deserialize(IDeserializer deserializer)
                 {
                     var visitor = new SerdeVisitor();
                     var fieldNames = new[]
@@ -29,8 +29,7 @@ partial class A
                     private sealed class FieldNameVisitor : Serde.IDeserialize<byte>, Serde.IDeserializeVisitor<byte>
                     {
                         public static readonly FieldNameVisitor Instance = new FieldNameVisitor();
-                        public static byte Deserialize<D>(ref D deserializer)
-                            where D : IDeserializer => deserializer.DeserializeString(Instance);
+                        public static byte Deserialize(IDeserializer deserializer) => deserializer.DeserializeString(Instance);
                         public string ExpectedTypeName => "string";
 
                         byte Serde.IDeserializeVisitor<byte>.VisitString(string s) => VisitUtf8Span(System.Text.Encoding.UTF8.GetBytes(s));

--- a/test/Serde.Generation.Test/test_output/DeserializeTests/NullableRefField#S.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/DeserializeTests/NullableRefField#S.IDeserialize.verified.cs
@@ -6,7 +6,7 @@ using Serde;
 
 partial struct S : Serde.IDeserialize<S>
 {
-    static S Serde.IDeserialize<S>.Deserialize<D>(ref D deserializer)
+    static S Serde.IDeserialize<S>.Deserialize(IDeserializer deserializer)
     {
         var visitor = new SerdeVisitor();
         var fieldNames = new[]
@@ -23,8 +23,7 @@ partial struct S : Serde.IDeserialize<S>
         private sealed class FieldNameVisitor : Serde.IDeserialize<byte>, Serde.IDeserializeVisitor<byte>
         {
             public static readonly FieldNameVisitor Instance = new FieldNameVisitor();
-            public static byte Deserialize<D>(ref D deserializer)
-                where D : IDeserializer => deserializer.DeserializeString(Instance);
+            public static byte Deserialize(IDeserializer deserializer) => deserializer.DeserializeString(Instance);
             public string ExpectedTypeName => "string";
 
             byte Serde.IDeserializeVisitor<byte>.VisitString(string s) => VisitUtf8Span(System.Text.Encoding.UTF8.GetBytes(s));

--- a/test/Serde.Generation.Test/test_output/DeserializeTests/Rgb#Rgb.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/DeserializeTests/Rgb#Rgb.IDeserialize.verified.cs
@@ -6,7 +6,7 @@ using Serde;
 
 partial struct Rgb : Serde.IDeserialize<Rgb>
 {
-    static Rgb Serde.IDeserialize<Rgb>.Deserialize<D>(ref D deserializer)
+    static Rgb Serde.IDeserialize<Rgb>.Deserialize(IDeserializer deserializer)
     {
         var visitor = new SerdeVisitor();
         var fieldNames = new[]
@@ -25,8 +25,7 @@ partial struct Rgb : Serde.IDeserialize<Rgb>
         private sealed class FieldNameVisitor : Serde.IDeserialize<byte>, Serde.IDeserializeVisitor<byte>
         {
             public static readonly FieldNameVisitor Instance = new FieldNameVisitor();
-            public static byte Deserialize<D>(ref D deserializer)
-                where D : IDeserializer => deserializer.DeserializeString(Instance);
+            public static byte Deserialize(IDeserializer deserializer) => deserializer.DeserializeString(Instance);
             public string ExpectedTypeName => "string";
 
             byte Serde.IDeserializeVisitor<byte>.VisitString(string s) => VisitUtf8Span(System.Text.Encoding.UTF8.GetBytes(s));

--- a/test/Serde.Generation.Test/test_output/MemberFormatTests.EnumFormat/ColorEnumWrap.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/MemberFormatTests.EnumFormat/ColorEnumWrap.IDeserialize.verified.cs
@@ -6,7 +6,7 @@ using Serde;
 
 partial record struct ColorEnumWrap : Serde.IDeserialize<ColorEnum>
 {
-    static ColorEnum Serde.IDeserialize<ColorEnum>.Deserialize<D>(ref D deserializer)
+    static ColorEnum Serde.IDeserialize<ColorEnum>.Deserialize(IDeserializer deserializer)
     {
         var visitor = new SerdeVisitor();
         return deserializer.DeserializeString(visitor);

--- a/test/Serde.Generation.Test/test_output/MemberFormatTests.EnumValues/ColorEnumWrap.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/MemberFormatTests.EnumValues/ColorEnumWrap.IDeserialize.verified.cs
@@ -6,7 +6,7 @@ using Serde;
 
 partial record struct ColorEnumWrap : Serde.IDeserialize<ColorEnum>
 {
-    static ColorEnum Serde.IDeserialize<ColorEnum>.Deserialize<D>(ref D deserializer)
+    static ColorEnum Serde.IDeserialize<ColorEnum>.Deserialize(IDeserializer deserializer)
     {
         var visitor = new SerdeVisitor();
         return deserializer.DeserializeString(visitor);

--- a/test/Serde.Generation.Test/test_output/MemberFormatTests.EnumValues/S.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/MemberFormatTests.EnumValues/S.IDeserialize.verified.cs
@@ -6,7 +6,7 @@ using Serde;
 
 partial struct S : Serde.IDeserialize<S>
 {
-    static S Serde.IDeserialize<S>.Deserialize<D>(ref D deserializer)
+    static S Serde.IDeserialize<S>.Deserialize(IDeserializer deserializer)
     {
         var visitor = new SerdeVisitor();
         var fieldNames = new[]
@@ -23,8 +23,7 @@ partial struct S : Serde.IDeserialize<S>
         private sealed class FieldNameVisitor : Serde.IDeserialize<byte>, Serde.IDeserializeVisitor<byte>
         {
             public static readonly FieldNameVisitor Instance = new FieldNameVisitor();
-            public static byte Deserialize<D>(ref D deserializer)
-                where D : IDeserializer => deserializer.DeserializeString(Instance);
+            public static byte Deserialize(IDeserializer deserializer) => deserializer.DeserializeString(Instance);
             public string ExpectedTypeName => "string";
 
             byte Serde.IDeserializeVisitor<byte>.VisitString(string s) => VisitUtf8Span(System.Text.Encoding.UTF8.GetBytes(s));

--- a/test/Serde.Generation.Test/test_output/MemberFormatTests.EnumValues/S2.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/MemberFormatTests.EnumValues/S2.IDeserialize.verified.cs
@@ -6,7 +6,7 @@ using Serde;
 
 partial struct S2 : Serde.IDeserialize<S2>
 {
-    static S2 Serde.IDeserialize<S2>.Deserialize<D>(ref D deserializer)
+    static S2 Serde.IDeserialize<S2>.Deserialize(IDeserializer deserializer)
     {
         var visitor = new SerdeVisitor();
         var fieldNames = new[]
@@ -23,8 +23,7 @@ partial struct S2 : Serde.IDeserialize<S2>
         private sealed class FieldNameVisitor : Serde.IDeserialize<byte>, Serde.IDeserializeVisitor<byte>
         {
             public static readonly FieldNameVisitor Instance = new FieldNameVisitor();
-            public static byte Deserialize<D>(ref D deserializer)
-                where D : IDeserializer => deserializer.DeserializeString(Instance);
+            public static byte Deserialize(IDeserializer deserializer) => deserializer.DeserializeString(Instance);
             public string ExpectedTypeName => "string";
 
             byte Serde.IDeserializeVisitor<byte>.VisitString(string s) => VisitUtf8Span(System.Text.Encoding.UTF8.GetBytes(s));

--- a/test/Serde.Generation.Test/test_output/MemberFormatTests.KebabCase/S.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/MemberFormatTests.KebabCase/S.IDeserialize.verified.cs
@@ -6,7 +6,7 @@ using Serde;
 
 partial struct S : Serde.IDeserialize<S>
 {
-    static S Serde.IDeserialize<S>.Deserialize<D>(ref D deserializer)
+    static S Serde.IDeserialize<S>.Deserialize(IDeserializer deserializer)
     {
         var visitor = new SerdeVisitor();
         var fieldNames = new[]
@@ -24,8 +24,7 @@ partial struct S : Serde.IDeserialize<S>
         private sealed class FieldNameVisitor : Serde.IDeserialize<byte>, Serde.IDeserializeVisitor<byte>
         {
             public static readonly FieldNameVisitor Instance = new FieldNameVisitor();
-            public static byte Deserialize<D>(ref D deserializer)
-                where D : IDeserializer => deserializer.DeserializeString(Instance);
+            public static byte Deserialize(IDeserializer deserializer) => deserializer.DeserializeString(Instance);
             public string ExpectedTypeName => "string";
 
             byte Serde.IDeserializeVisitor<byte>.VisitString(string s) => VisitUtf8Span(System.Text.Encoding.UTF8.GetBytes(s));

--- a/test/Serde.Generation.Test/test_output/SerializeTests.NestedExplicitSerializeWrapper/OPTSWrap.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/SerializeTests.NestedExplicitSerializeWrapper/OPTSWrap.IDeserialize.verified.cs
@@ -6,7 +6,7 @@ using Serde;
 
 partial record struct OPTSWrap : Serde.IDeserialize<System.Runtime.InteropServices.ComTypes.BIND_OPTS>
 {
-    static System.Runtime.InteropServices.ComTypes.BIND_OPTS Serde.IDeserialize<System.Runtime.InteropServices.ComTypes.BIND_OPTS>.Deserialize<D>(ref D deserializer)
+    static System.Runtime.InteropServices.ComTypes.BIND_OPTS Serde.IDeserialize<System.Runtime.InteropServices.ComTypes.BIND_OPTS>.Deserialize(IDeserializer deserializer)
     {
         var visitor = new SerdeVisitor();
         var fieldNames = new[]
@@ -26,8 +26,7 @@ partial record struct OPTSWrap : Serde.IDeserialize<System.Runtime.InteropServic
         private sealed class FieldNameVisitor : Serde.IDeserialize<byte>, Serde.IDeserializeVisitor<byte>
         {
             public static readonly FieldNameVisitor Instance = new FieldNameVisitor();
-            public static byte Deserialize<D>(ref D deserializer)
-                where D : IDeserializer => deserializer.DeserializeString(Instance);
+            public static byte Deserialize(IDeserializer deserializer) => deserializer.DeserializeString(Instance);
             public string ExpectedTypeName => "string";
 
             byte Serde.IDeserializeVisitor<byte>.VisitString(string s) => VisitUtf8Span(System.Text.Encoding.UTF8.GetBytes(s));

--- a/test/Serde.Generation.Test/test_output/SerializeTests.NestedExplicitSerializeWrapper/S.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/SerializeTests.NestedExplicitSerializeWrapper/S.IDeserialize.verified.cs
@@ -6,7 +6,7 @@ using Serde;
 
 partial struct S : Serde.IDeserialize<S>
 {
-    static S Serde.IDeserialize<S>.Deserialize<D>(ref D deserializer)
+    static S Serde.IDeserialize<S>.Deserialize(IDeserializer deserializer)
     {
         var visitor = new SerdeVisitor();
         var fieldNames = new[]
@@ -23,8 +23,7 @@ partial struct S : Serde.IDeserialize<S>
         private sealed class FieldNameVisitor : Serde.IDeserialize<byte>, Serde.IDeserializeVisitor<byte>
         {
             public static readonly FieldNameVisitor Instance = new FieldNameVisitor();
-            public static byte Deserialize<D>(ref D deserializer)
-                where D : IDeserializer => deserializer.DeserializeString(Instance);
+            public static byte Deserialize(IDeserializer deserializer) => deserializer.DeserializeString(Instance);
             public string ExpectedTypeName => "string";
 
             byte Serde.IDeserializeVisitor<byte>.VisitString(string s) => VisitUtf8Span(System.Text.Encoding.UTF8.GetBytes(s));

--- a/test/Serde.Generation.Test/test_output/WrapperTests.GenerateSerdeWrap/OPTSWrap.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/WrapperTests.GenerateSerdeWrap/OPTSWrap.IDeserialize.verified.cs
@@ -6,7 +6,7 @@ using Serde;
 
 partial record struct OPTSWrap : Serde.IDeserialize<System.Runtime.InteropServices.ComTypes.BIND_OPTS>
 {
-    static System.Runtime.InteropServices.ComTypes.BIND_OPTS Serde.IDeserialize<System.Runtime.InteropServices.ComTypes.BIND_OPTS>.Deserialize<D>(ref D deserializer)
+    static System.Runtime.InteropServices.ComTypes.BIND_OPTS Serde.IDeserialize<System.Runtime.InteropServices.ComTypes.BIND_OPTS>.Deserialize(IDeserializer deserializer)
     {
         var visitor = new SerdeVisitor();
         var fieldNames = new[]
@@ -26,8 +26,7 @@ partial record struct OPTSWrap : Serde.IDeserialize<System.Runtime.InteropServic
         private sealed class FieldNameVisitor : Serde.IDeserialize<byte>, Serde.IDeserializeVisitor<byte>
         {
             public static readonly FieldNameVisitor Instance = new FieldNameVisitor();
-            public static byte Deserialize<D>(ref D deserializer)
-                where D : IDeserializer => deserializer.DeserializeString(Instance);
+            public static byte Deserialize(IDeserializer deserializer) => deserializer.DeserializeString(Instance);
             public string ExpectedTypeName => "string";
 
             byte Serde.IDeserializeVisitor<byte>.VisitString(string s) => VisitUtf8Span(System.Text.Encoding.UTF8.GetBytes(s));

--- a/test/Serde.Generation.Test/test_output/WrapperTests.ImmutableArrayEnumDeserialize/Test.ChannelList.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/WrapperTests.ImmutableArrayEnumDeserialize/Test.ChannelList.IDeserialize.verified.cs
@@ -8,7 +8,7 @@ namespace Test
 {
     partial record struct ChannelList : Serde.IDeserialize<Test.ChannelList>
     {
-        static Test.ChannelList Serde.IDeserialize<Test.ChannelList>.Deserialize<D>(ref D deserializer)
+        static Test.ChannelList Serde.IDeserialize<Test.ChannelList>.Deserialize(IDeserializer deserializer)
         {
             var visitor = new SerdeVisitor();
             var fieldNames = new[]
@@ -25,8 +25,7 @@ namespace Test
             private sealed class FieldNameVisitor : Serde.IDeserialize<byte>, Serde.IDeserializeVisitor<byte>
             {
                 public static readonly FieldNameVisitor Instance = new FieldNameVisitor();
-                public static byte Deserialize<D>(ref D deserializer)
-                    where D : IDeserializer => deserializer.DeserializeString(Instance);
+                public static byte Deserialize(IDeserializer deserializer) => deserializer.DeserializeString(Instance);
                 public string ExpectedTypeName => "string";
 
                 byte Serde.IDeserializeVisitor<byte>.VisitString(string s) => VisitUtf8Span(System.Text.Encoding.UTF8.GetBytes(s));

--- a/test/Serde.Generation.Test/test_output/WrapperTests.ImmutableArrayEnumDeserialize/Test.ChannelWrap.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/WrapperTests.ImmutableArrayEnumDeserialize/Test.ChannelWrap.IDeserialize.verified.cs
@@ -8,7 +8,7 @@ namespace Test
 {
     partial record struct ChannelWrap : Serde.IDeserialize<Test.Channel>
     {
-        static Test.Channel Serde.IDeserialize<Test.Channel>.Deserialize<D>(ref D deserializer)
+        static Test.Channel Serde.IDeserialize<Test.Channel>.Deserialize(IDeserializer deserializer)
         {
             var visitor = new SerdeVisitor();
             return deserializer.DeserializeString(visitor);

--- a/test/Serde.Generation.Test/test_output/WrapperTests.NestedDeserializeWrap/C.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/WrapperTests.NestedDeserializeWrap/C.IDeserialize.verified.cs
@@ -6,7 +6,7 @@ using Serde;
 
 partial class C : Serde.IDeserialize<C>
 {
-    static C Serde.IDeserialize<C>.Deserialize<D>(ref D deserializer)
+    static C Serde.IDeserialize<C>.Deserialize(IDeserializer deserializer)
     {
         var visitor = new SerdeVisitor();
         var fieldNames = new[]
@@ -23,8 +23,7 @@ partial class C : Serde.IDeserialize<C>
         private sealed class FieldNameVisitor : Serde.IDeserialize<byte>, Serde.IDeserializeVisitor<byte>
         {
             public static readonly FieldNameVisitor Instance = new FieldNameVisitor();
-            public static byte Deserialize<D>(ref D deserializer)
-                where D : IDeserializer => deserializer.DeserializeString(Instance);
+            public static byte Deserialize(IDeserializer deserializer) => deserializer.DeserializeString(Instance);
             public string ExpectedTypeName => "string";
 
             byte Serde.IDeserializeVisitor<byte>.VisitString(string s) => VisitUtf8Span(System.Text.Encoding.UTF8.GetBytes(s));

--- a/test/Serde.Generation.Test/test_output/WrapperTests.NestedDeserializeWrap/OPTSWrap.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/WrapperTests.NestedDeserializeWrap/OPTSWrap.IDeserialize.verified.cs
@@ -6,7 +6,7 @@ using Serde;
 
 partial record struct OPTSWrap : Serde.IDeserialize<System.Runtime.InteropServices.ComTypes.BIND_OPTS>
 {
-    static System.Runtime.InteropServices.ComTypes.BIND_OPTS Serde.IDeserialize<System.Runtime.InteropServices.ComTypes.BIND_OPTS>.Deserialize<D>(ref D deserializer)
+    static System.Runtime.InteropServices.ComTypes.BIND_OPTS Serde.IDeserialize<System.Runtime.InteropServices.ComTypes.BIND_OPTS>.Deserialize(IDeserializer deserializer)
     {
         var visitor = new SerdeVisitor();
         var fieldNames = new[]
@@ -26,8 +26,7 @@ partial record struct OPTSWrap : Serde.IDeserialize<System.Runtime.InteropServic
         private sealed class FieldNameVisitor : Serde.IDeserialize<byte>, Serde.IDeserializeVisitor<byte>
         {
             public static readonly FieldNameVisitor Instance = new FieldNameVisitor();
-            public static byte Deserialize<D>(ref D deserializer)
-                where D : IDeserializer => deserializer.DeserializeString(Instance);
+            public static byte Deserialize(IDeserializer deserializer) => deserializer.DeserializeString(Instance);
             public string ExpectedTypeName => "string";
 
             byte Serde.IDeserializeVisitor<byte>.VisitString(string s) => VisitUtf8Span(System.Text.Encoding.UTF8.GetBytes(s));

--- a/test/Serde.Generation.Test/test_output/WrapperTests.PointWrap/PointWrap.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/WrapperTests.PointWrap/PointWrap.IDeserialize.verified.cs
@@ -6,7 +6,7 @@ using Serde;
 
 partial struct PointWrap : Serde.IDeserialize<Point>
 {
-    static Point Serde.IDeserialize<Point>.Deserialize<D>(ref D deserializer)
+    static Point Serde.IDeserialize<Point>.Deserialize(IDeserializer deserializer)
     {
         var visitor = new SerdeVisitor();
         var fieldNames = new[]
@@ -24,8 +24,7 @@ partial struct PointWrap : Serde.IDeserialize<Point>
         private sealed class FieldNameVisitor : Serde.IDeserialize<byte>, Serde.IDeserializeVisitor<byte>
         {
             public static readonly FieldNameVisitor Instance = new FieldNameVisitor();
-            public static byte Deserialize<D>(ref D deserializer)
-                where D : IDeserializer => deserializer.DeserializeString(Instance);
+            public static byte Deserialize(IDeserializer deserializer) => deserializer.DeserializeString(Instance);
             public string ExpectedTypeName => "string";
 
             byte Serde.IDeserializeVisitor<byte>.VisitString(string s) => VisitUtf8Span(System.Text.Encoding.UTF8.GetBytes(s));

--- a/test/Serde.Generation.Test/test_output/WrapperTests.PositionalRecordDeserialize/R.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/WrapperTests.PositionalRecordDeserialize/R.IDeserialize.verified.cs
@@ -6,7 +6,7 @@ using Serde;
 
 partial record R : Serde.IDeserialize<R>
 {
-    static R Serde.IDeserialize<R>.Deserialize<D>(ref D deserializer)
+    static R Serde.IDeserialize<R>.Deserialize(IDeserializer deserializer)
     {
         var visitor = new SerdeVisitor();
         var fieldNames = new[]
@@ -24,8 +24,7 @@ partial record R : Serde.IDeserialize<R>
         private sealed class FieldNameVisitor : Serde.IDeserialize<byte>, Serde.IDeserializeVisitor<byte>
         {
             public static readonly FieldNameVisitor Instance = new FieldNameVisitor();
-            public static byte Deserialize<D>(ref D deserializer)
-                where D : IDeserializer => deserializer.DeserializeString(Instance);
+            public static byte Deserialize(IDeserializer deserializer) => deserializer.DeserializeString(Instance);
             public string ExpectedTypeName => "string";
 
             byte Serde.IDeserializeVisitor<byte>.VisitString(string s) => VisitUtf8Span(System.Text.Encoding.UTF8.GetBytes(s));

--- a/test/Serde.Generation.Test/test_output/WrapperTests.RecursiveType/Test.Parent.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/WrapperTests.RecursiveType/Test.Parent.IDeserialize.verified.cs
@@ -8,7 +8,7 @@ namespace Test
 {
     partial record Parent : Serde.IDeserialize<Test.Parent>
     {
-        static Test.Parent Serde.IDeserialize<Test.Parent>.Deserialize<D>(ref D deserializer)
+        static Test.Parent Serde.IDeserialize<Test.Parent>.Deserialize(IDeserializer deserializer)
         {
             var visitor = new SerdeVisitor();
             var fieldNames = new[]
@@ -25,8 +25,7 @@ namespace Test
             private sealed class FieldNameVisitor : Serde.IDeserialize<byte>, Serde.IDeserializeVisitor<byte>
             {
                 public static readonly FieldNameVisitor Instance = new FieldNameVisitor();
-                public static byte Deserialize<D>(ref D deserializer)
-                    where D : IDeserializer => deserializer.DeserializeString(Instance);
+                public static byte Deserialize(IDeserializer deserializer) => deserializer.DeserializeString(Instance);
                 public string ExpectedTypeName => "string";
 
                 byte Serde.IDeserializeVisitor<byte>.VisitString(string s) => VisitUtf8Span(System.Text.Encoding.UTF8.GetBytes(s));

--- a/test/Serde.Generation.Test/test_output/WrapperTests.RecursiveType/Test.RecursiveWrap.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/WrapperTests.RecursiveType/Test.RecursiveWrap.IDeserialize.verified.cs
@@ -8,7 +8,7 @@ namespace Test
 {
     partial record struct RecursiveWrap : Serde.IDeserialize<Recursive>
     {
-        static Recursive Serde.IDeserialize<Recursive>.Deserialize<D>(ref D deserializer)
+        static Recursive Serde.IDeserialize<Recursive>.Deserialize(IDeserializer deserializer)
         {
             var visitor = new SerdeVisitor();
             var fieldNames = new[]
@@ -25,8 +25,7 @@ namespace Test
             private sealed class FieldNameVisitor : Serde.IDeserialize<byte>, Serde.IDeserializeVisitor<byte>
             {
                 public static readonly FieldNameVisitor Instance = new FieldNameVisitor();
-                public static byte Deserialize<D>(ref D deserializer)
-                    where D : IDeserializer => deserializer.DeserializeString(Instance);
+                public static byte Deserialize(IDeserializer deserializer) => deserializer.DeserializeString(Instance);
                 public string ExpectedTypeName => "string";
 
                 byte Serde.IDeserializeVisitor<byte>.VisitString(string s) => VisitUtf8Span(System.Text.Encoding.UTF8.GetBytes(s));

--- a/test/Serde.Test/GenericWrapperTests.cs
+++ b/test/Serde.Test/GenericWrapperTests.cs
@@ -108,7 +108,7 @@ public sealed partial class GenericWrapperTests
         public readonly struct DeserializeImpl<T, TWrap> : IDeserialize<CustomImArray<T>>
             where TWrap : IDeserialize<T>
         {
-            public static CustomImArray<T> Deserialize<D>(ref D deserializer) where D : IDeserializer
+            public static CustomImArray<T> Deserialize(IDeserializer deserializer)
                 => deserializer.DeserializeEnumerable(new Visitor());
 
             public struct Visitor : IDeserializeVisitor<CustomImArray<T>>
@@ -157,7 +157,7 @@ public sealed partial class GenericWrapperTests
         public readonly struct DeserializeImpl<T, TWrap> : IDeserialize<CustomImArray2<T>>
             where TWrap : IDeserialize<T>
         {
-            public static CustomImArray2<T> Deserialize<D>(ref D deserializer) where D : IDeserializer
+            public static CustomImArray2<T> Deserialize(IDeserializer deserializer)
                 => deserializer.DeserializeEnumerable(new Visitor());
 
             public struct Visitor : IDeserializeVisitor<CustomImArray2<T>>

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.AllInOne.ColorEnumWrap.IDeserialize.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.AllInOne.ColorEnumWrap.IDeserialize.cs
@@ -9,7 +9,7 @@ namespace Serde.Test
     {
         partial record struct ColorEnumWrap : Serde.IDeserialize<Serde.Test.AllInOne.ColorEnum>
         {
-            static Serde.Test.AllInOne.ColorEnum Serde.IDeserialize<Serde.Test.AllInOne.ColorEnum>.Deserialize<D>(ref D deserializer)
+            static Serde.Test.AllInOne.ColorEnum Serde.IDeserialize<Serde.Test.AllInOne.ColorEnum>.Deserialize(IDeserializer deserializer)
             {
                 var visitor = new SerdeVisitor();
                 return deserializer.DeserializeString(visitor);

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.AllInOne.IDeserialize.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.AllInOne.IDeserialize.cs
@@ -7,7 +7,7 @@ namespace Serde.Test
 {
     partial record AllInOne : Serde.IDeserialize<Serde.Test.AllInOne>
     {
-        static Serde.Test.AllInOne Serde.IDeserialize<Serde.Test.AllInOne>.Deserialize<D>(ref D deserializer)
+        static Serde.Test.AllInOne Serde.IDeserialize<Serde.Test.AllInOne>.Deserialize(IDeserializer deserializer)
         {
             var visitor = new SerdeVisitor();
             var fieldNames = new[]
@@ -39,8 +39,7 @@ namespace Serde.Test
             private sealed class FieldNameVisitor : Serde.IDeserialize<byte>, Serde.IDeserializeVisitor<byte>
             {
                 public static readonly FieldNameVisitor Instance = new FieldNameVisitor();
-                public static byte Deserialize<D>(ref D deserializer)
-                    where D : IDeserializer => deserializer.DeserializeString(Instance);
+                public static byte Deserialize(IDeserializer deserializer) => deserializer.DeserializeString(Instance);
                 public string ExpectedTypeName => "string";
 
                 byte Serde.IDeserializeVisitor<byte>.VisitString(string s) => VisitUtf8Span(System.Text.Encoding.UTF8.GetBytes(s));

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.GenericWrapperTests.CustomArrayWrapExplicitOnType.IDeserialize.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.GenericWrapperTests.CustomArrayWrapExplicitOnType.IDeserialize.cs
@@ -9,7 +9,7 @@ namespace Serde.Test
     {
         partial record struct CustomArrayWrapExplicitOnType : Serde.IDeserialize<Serde.Test.GenericWrapperTests.CustomArrayWrapExplicitOnType>
         {
-            static Serde.Test.GenericWrapperTests.CustomArrayWrapExplicitOnType Serde.IDeserialize<Serde.Test.GenericWrapperTests.CustomArrayWrapExplicitOnType>.Deserialize<D>(ref D deserializer)
+            static Serde.Test.GenericWrapperTests.CustomArrayWrapExplicitOnType Serde.IDeserialize<Serde.Test.GenericWrapperTests.CustomArrayWrapExplicitOnType>.Deserialize(IDeserializer deserializer)
             {
                 var visitor = new SerdeVisitor();
                 var fieldNames = new[]
@@ -26,8 +26,7 @@ namespace Serde.Test
                 private sealed class FieldNameVisitor : Serde.IDeserialize<byte>, Serde.IDeserializeVisitor<byte>
                 {
                     public static readonly FieldNameVisitor Instance = new FieldNameVisitor();
-                    public static byte Deserialize<D>(ref D deserializer)
-                        where D : IDeserializer => deserializer.DeserializeString(Instance);
+                    public static byte Deserialize(IDeserializer deserializer) => deserializer.DeserializeString(Instance);
                     public string ExpectedTypeName => "string";
 
                     byte Serde.IDeserializeVisitor<byte>.VisitString(string s) => VisitUtf8Span(System.Text.Encoding.UTF8.GetBytes(s));

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.GenericWrapperTests.CustomImArrayExplicitWrapOnMember.IDeserialize.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.GenericWrapperTests.CustomImArrayExplicitWrapOnMember.IDeserialize.cs
@@ -9,7 +9,7 @@ namespace Serde.Test
     {
         partial record struct CustomImArrayExplicitWrapOnMember : Serde.IDeserialize<Serde.Test.GenericWrapperTests.CustomImArrayExplicitWrapOnMember>
         {
-            static Serde.Test.GenericWrapperTests.CustomImArrayExplicitWrapOnMember Serde.IDeserialize<Serde.Test.GenericWrapperTests.CustomImArrayExplicitWrapOnMember>.Deserialize<D>(ref D deserializer)
+            static Serde.Test.GenericWrapperTests.CustomImArrayExplicitWrapOnMember Serde.IDeserialize<Serde.Test.GenericWrapperTests.CustomImArrayExplicitWrapOnMember>.Deserialize(IDeserializer deserializer)
             {
                 var visitor = new SerdeVisitor();
                 var fieldNames = new[]
@@ -26,8 +26,7 @@ namespace Serde.Test
                 private sealed class FieldNameVisitor : Serde.IDeserialize<byte>, Serde.IDeserializeVisitor<byte>
                 {
                     public static readonly FieldNameVisitor Instance = new FieldNameVisitor();
-                    public static byte Deserialize<D>(ref D deserializer)
-                        where D : IDeserializer => deserializer.DeserializeString(Instance);
+                    public static byte Deserialize(IDeserializer deserializer) => deserializer.DeserializeString(Instance);
                     public string ExpectedTypeName => "string";
 
                     byte Serde.IDeserializeVisitor<byte>.VisitString(string s) => VisitUtf8Span(System.Text.Encoding.UTF8.GetBytes(s));

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonDeserializeTests.DenyUnknown.IDeserialize.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonDeserializeTests.DenyUnknown.IDeserialize.cs
@@ -9,7 +9,7 @@ namespace Serde.Test
     {
         partial record struct DenyUnknown : Serde.IDeserialize<Serde.Test.JsonDeserializeTests.DenyUnknown>
         {
-            static Serde.Test.JsonDeserializeTests.DenyUnknown Serde.IDeserialize<Serde.Test.JsonDeserializeTests.DenyUnknown>.Deserialize<D>(ref D deserializer)
+            static Serde.Test.JsonDeserializeTests.DenyUnknown Serde.IDeserialize<Serde.Test.JsonDeserializeTests.DenyUnknown>.Deserialize(IDeserializer deserializer)
             {
                 var visitor = new SerdeVisitor();
                 var fieldNames = new[]
@@ -27,8 +27,7 @@ namespace Serde.Test
                 private sealed class FieldNameVisitor : Serde.IDeserialize<byte>, Serde.IDeserializeVisitor<byte>
                 {
                     public static readonly FieldNameVisitor Instance = new FieldNameVisitor();
-                    public static byte Deserialize<D>(ref D deserializer)
-                        where D : IDeserializer => deserializer.DeserializeString(Instance);
+                    public static byte Deserialize(IDeserializer deserializer) => deserializer.DeserializeString(Instance);
                     public string ExpectedTypeName => "string";
 
                     byte Serde.IDeserializeVisitor<byte>.VisitString(string s) => VisitUtf8Span(System.Text.Encoding.UTF8.GetBytes(s));

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonDeserializeTests.ExtraMembers.IDeserialize.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonDeserializeTests.ExtraMembers.IDeserialize.cs
@@ -9,7 +9,7 @@ namespace Serde.Test
     {
         partial struct ExtraMembers : Serde.IDeserialize<Serde.Test.JsonDeserializeTests.ExtraMembers>
         {
-            static Serde.Test.JsonDeserializeTests.ExtraMembers Serde.IDeserialize<Serde.Test.JsonDeserializeTests.ExtraMembers>.Deserialize<D>(ref D deserializer)
+            static Serde.Test.JsonDeserializeTests.ExtraMembers Serde.IDeserialize<Serde.Test.JsonDeserializeTests.ExtraMembers>.Deserialize(IDeserializer deserializer)
             {
                 var visitor = new SerdeVisitor();
                 var fieldNames = new[]
@@ -26,8 +26,7 @@ namespace Serde.Test
                 private sealed class FieldNameVisitor : Serde.IDeserialize<byte>, Serde.IDeserializeVisitor<byte>
                 {
                     public static readonly FieldNameVisitor Instance = new FieldNameVisitor();
-                    public static byte Deserialize<D>(ref D deserializer)
-                        where D : IDeserializer => deserializer.DeserializeString(Instance);
+                    public static byte Deserialize(IDeserializer deserializer) => deserializer.DeserializeString(Instance);
                     public string ExpectedTypeName => "string";
 
                     byte Serde.IDeserializeVisitor<byte>.VisitString(string s) => VisitUtf8Span(System.Text.Encoding.UTF8.GetBytes(s));

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonDeserializeTests.IdStruct.IDeserialize.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonDeserializeTests.IdStruct.IDeserialize.cs
@@ -9,7 +9,7 @@ namespace Serde.Test
     {
         partial struct IdStruct : Serde.IDeserialize<Serde.Test.JsonDeserializeTests.IdStruct>
         {
-            static Serde.Test.JsonDeserializeTests.IdStruct Serde.IDeserialize<Serde.Test.JsonDeserializeTests.IdStruct>.Deserialize<D>(ref D deserializer)
+            static Serde.Test.JsonDeserializeTests.IdStruct Serde.IDeserialize<Serde.Test.JsonDeserializeTests.IdStruct>.Deserialize(IDeserializer deserializer)
             {
                 var visitor = new SerdeVisitor();
                 var fieldNames = new[]
@@ -26,8 +26,7 @@ namespace Serde.Test
                 private sealed class FieldNameVisitor : Serde.IDeserialize<byte>, Serde.IDeserializeVisitor<byte>
                 {
                     public static readonly FieldNameVisitor Instance = new FieldNameVisitor();
-                    public static byte Deserialize<D>(ref D deserializer)
-                        where D : IDeserializer => deserializer.DeserializeString(Instance);
+                    public static byte Deserialize(IDeserializer deserializer) => deserializer.DeserializeString(Instance);
                     public string ExpectedTypeName => "string";
 
                     byte Serde.IDeserializeVisitor<byte>.VisitString(string s) => VisitUtf8Span(System.Text.Encoding.UTF8.GetBytes(s));

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonDeserializeTests.IdStructList.IDeserialize.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonDeserializeTests.IdStructList.IDeserialize.cs
@@ -9,7 +9,7 @@ namespace Serde.Test
     {
         partial record struct IdStructList : Serde.IDeserialize<Serde.Test.JsonDeserializeTests.IdStructList>
         {
-            static Serde.Test.JsonDeserializeTests.IdStructList Serde.IDeserialize<Serde.Test.JsonDeserializeTests.IdStructList>.Deserialize<D>(ref D deserializer)
+            static Serde.Test.JsonDeserializeTests.IdStructList Serde.IDeserialize<Serde.Test.JsonDeserializeTests.IdStructList>.Deserialize(IDeserializer deserializer)
             {
                 var visitor = new SerdeVisitor();
                 var fieldNames = new[]
@@ -27,8 +27,7 @@ namespace Serde.Test
                 private sealed class FieldNameVisitor : Serde.IDeserialize<byte>, Serde.IDeserializeVisitor<byte>
                 {
                     public static readonly FieldNameVisitor Instance = new FieldNameVisitor();
-                    public static byte Deserialize<D>(ref D deserializer)
-                        where D : IDeserializer => deserializer.DeserializeString(Instance);
+                    public static byte Deserialize(IDeserializer deserializer) => deserializer.DeserializeString(Instance);
                     public string ExpectedTypeName => "string";
 
                     byte Serde.IDeserializeVisitor<byte>.VisitString(string s) => VisitUtf8Span(System.Text.Encoding.UTF8.GetBytes(s));

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonDeserializeTests.NullableFields.IDeserialize.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonDeserializeTests.NullableFields.IDeserialize.cs
@@ -9,7 +9,7 @@ namespace Serde.Test
     {
         partial class NullableFields : Serde.IDeserialize<Serde.Test.JsonDeserializeTests.NullableFields>
         {
-            static Serde.Test.JsonDeserializeTests.NullableFields Serde.IDeserialize<Serde.Test.JsonDeserializeTests.NullableFields>.Deserialize<D>(ref D deserializer)
+            static Serde.Test.JsonDeserializeTests.NullableFields Serde.IDeserialize<Serde.Test.JsonDeserializeTests.NullableFields>.Deserialize(IDeserializer deserializer)
             {
                 var visitor = new SerdeVisitor();
                 var fieldNames = new[]
@@ -27,8 +27,7 @@ namespace Serde.Test
                 private sealed class FieldNameVisitor : Serde.IDeserialize<byte>, Serde.IDeserializeVisitor<byte>
                 {
                     public static readonly FieldNameVisitor Instance = new FieldNameVisitor();
-                    public static byte Deserialize<D>(ref D deserializer)
-                        where D : IDeserializer => deserializer.DeserializeString(Instance);
+                    public static byte Deserialize(IDeserializer deserializer) => deserializer.DeserializeString(Instance);
                     public string ExpectedTypeName => "string";
 
                     byte Serde.IDeserializeVisitor<byte>.VisitString(string s) => VisitUtf8Span(System.Text.Encoding.UTF8.GetBytes(s));

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonDeserializeTests.SetToNull.IDeserialize.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonDeserializeTests.SetToNull.IDeserialize.cs
@@ -9,7 +9,7 @@ namespace Serde.Test
     {
         partial record struct SetToNull : Serde.IDeserialize<Serde.Test.JsonDeserializeTests.SetToNull>
         {
-            static Serde.Test.JsonDeserializeTests.SetToNull Serde.IDeserialize<Serde.Test.JsonDeserializeTests.SetToNull>.Deserialize<D>(ref D deserializer)
+            static Serde.Test.JsonDeserializeTests.SetToNull Serde.IDeserialize<Serde.Test.JsonDeserializeTests.SetToNull>.Deserialize(IDeserializer deserializer)
             {
                 var visitor = new SerdeVisitor();
                 var fieldNames = new[]
@@ -27,8 +27,7 @@ namespace Serde.Test
                 private sealed class FieldNameVisitor : Serde.IDeserialize<byte>, Serde.IDeserializeVisitor<byte>
                 {
                     public static readonly FieldNameVisitor Instance = new FieldNameVisitor();
-                    public static byte Deserialize<D>(ref D deserializer)
-                        where D : IDeserializer => deserializer.DeserializeString(Instance);
+                    public static byte Deserialize(IDeserializer deserializer) => deserializer.DeserializeString(Instance);
                     public string ExpectedTypeName => "string";
 
                     byte Serde.IDeserializeVisitor<byte>.VisitString(string s) => VisitUtf8Span(System.Text.Encoding.UTF8.GetBytes(s));

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonDeserializeTests.ThrowMissing.IDeserialize.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonDeserializeTests.ThrowMissing.IDeserialize.cs
@@ -9,7 +9,7 @@ namespace Serde.Test
     {
         partial record struct ThrowMissing : Serde.IDeserialize<Serde.Test.JsonDeserializeTests.ThrowMissing>
         {
-            static Serde.Test.JsonDeserializeTests.ThrowMissing Serde.IDeserialize<Serde.Test.JsonDeserializeTests.ThrowMissing>.Deserialize<D>(ref D deserializer)
+            static Serde.Test.JsonDeserializeTests.ThrowMissing Serde.IDeserialize<Serde.Test.JsonDeserializeTests.ThrowMissing>.Deserialize(IDeserializer deserializer)
             {
                 var visitor = new SerdeVisitor();
                 var fieldNames = new[]
@@ -27,8 +27,7 @@ namespace Serde.Test
                 private sealed class FieldNameVisitor : Serde.IDeserialize<byte>, Serde.IDeserializeVisitor<byte>
                 {
                     public static readonly FieldNameVisitor Instance = new FieldNameVisitor();
-                    public static byte Deserialize<D>(ref D deserializer)
-                        where D : IDeserializer => deserializer.DeserializeString(Instance);
+                    public static byte Deserialize(IDeserializer deserializer) => deserializer.DeserializeString(Instance);
                     public string ExpectedTypeName => "string";
 
                     byte Serde.IDeserializeVisitor<byte>.VisitString(string s) => VisitUtf8Span(System.Text.Encoding.UTF8.GetBytes(s));

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.MaxSizeType.IDeserialize.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.MaxSizeType.IDeserialize.cs
@@ -7,7 +7,7 @@ namespace Serde.Test
 {
     partial struct MaxSizeType : Serde.IDeserialize<Serde.Test.MaxSizeType>
     {
-        static Serde.Test.MaxSizeType Serde.IDeserialize<Serde.Test.MaxSizeType>.Deserialize<D>(ref D deserializer)
+        static Serde.Test.MaxSizeType Serde.IDeserialize<Serde.Test.MaxSizeType>.Deserialize(IDeserializer deserializer)
         {
             var visitor = new SerdeVisitor();
             var fieldNames = new[]
@@ -87,8 +87,7 @@ namespace Serde.Test
             private sealed class FieldNameVisitor : Serde.IDeserialize<byte>, Serde.IDeserializeVisitor<byte>
             {
                 public static readonly FieldNameVisitor Instance = new FieldNameVisitor();
-                public static byte Deserialize<D>(ref D deserializer)
-                    where D : IDeserializer => deserializer.DeserializeString(Instance);
+                public static byte Deserialize(IDeserializer deserializer) => deserializer.DeserializeString(Instance);
                 public string ExpectedTypeName => "string";
 
                 byte Serde.IDeserializeVisitor<byte>.VisitString(string s) => VisitUtf8Span(System.Text.Encoding.UTF8.GetBytes(s));

--- a/test/Serde.Xml.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.AllInOneColorEnumWrap.IDeserialize.cs
+++ b/test/Serde.Xml.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.AllInOneColorEnumWrap.IDeserialize.cs
@@ -7,7 +7,7 @@ namespace Serde
 {
     partial record struct AllInOneColorEnumWrap : Serde.IDeserialize<Serde.Test.AllInOne.ColorEnum>
     {
-        static Serde.Test.AllInOne.ColorEnum Serde.IDeserialize<Serde.Test.AllInOne.ColorEnum>.Deserialize<D>(ref D deserializer)
+        static Serde.Test.AllInOne.ColorEnum Serde.IDeserialize<Serde.Test.AllInOne.ColorEnum>.Deserialize(IDeserializer deserializer)
         {
             var visitor = new SerdeVisitor();
             return deserializer.DeserializeString<Serde.Test.AllInOne.ColorEnum, SerdeVisitor>(visitor);

--- a/test/Serde.Xml.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.AllInOne.ColorEnum.IDeserialize.cs
+++ b/test/Serde.Xml.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.AllInOne.ColorEnum.IDeserialize.cs
@@ -9,7 +9,7 @@ namespace Serde.Test
     {
         partial record struct ColorEnumWrap : Serde.IDeserialize<Serde.Test.AllInOne.ColorEnum>
         {
-            static Serde.Test.AllInOne.ColorEnum Serde.IDeserialize<Serde.Test.AllInOne.ColorEnum>.Deserialize<D>(ref D deserializer)
+            static Serde.Test.AllInOne.ColorEnum Serde.IDeserialize<Serde.Test.AllInOne.ColorEnum>.Deserialize(IDeserializer deserializer)
             {
                 var visitor = new SerdeVisitor();
                 return deserializer.DeserializeString<Serde.Test.AllInOne.ColorEnum, SerdeVisitor>(visitor);

--- a/test/Serde.Xml.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.AllInOne.ColorEnumWrap.IDeserialize.cs
+++ b/test/Serde.Xml.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.AllInOne.ColorEnumWrap.IDeserialize.cs
@@ -9,7 +9,7 @@ namespace Serde.Test
     {
         partial record struct ColorEnumWrap : Serde.IDeserialize<Serde.Test.AllInOne.ColorEnum>
         {
-            static Serde.Test.AllInOne.ColorEnum Serde.IDeserialize<Serde.Test.AllInOne.ColorEnum>.Deserialize<D>(ref D deserializer)
+            static Serde.Test.AllInOne.ColorEnum Serde.IDeserialize<Serde.Test.AllInOne.ColorEnum>.Deserialize(IDeserializer deserializer)
             {
                 var visitor = new SerdeVisitor();
                 return deserializer.DeserializeString(visitor);

--- a/test/Serde.Xml.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.AllInOne.IDeserialize.cs
+++ b/test/Serde.Xml.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.AllInOne.IDeserialize.cs
@@ -7,7 +7,7 @@ namespace Serde.Test
 {
     partial record AllInOne : Serde.IDeserialize<Serde.Test.AllInOne>
     {
-        static Serde.Test.AllInOne Serde.IDeserialize<Serde.Test.AllInOne>.Deserialize<D>(ref D deserializer)
+        static Serde.Test.AllInOne Serde.IDeserialize<Serde.Test.AllInOne>.Deserialize(IDeserializer deserializer)
         {
             var visitor = new SerdeVisitor();
             var fieldNames = new[]
@@ -39,8 +39,7 @@ namespace Serde.Test
             private sealed class FieldNameVisitor : Serde.IDeserialize<byte>, Serde.IDeserializeVisitor<byte>
             {
                 public static readonly FieldNameVisitor Instance = new FieldNameVisitor();
-                public static byte Deserialize<D>(ref D deserializer)
-                    where D : IDeserializer => deserializer.DeserializeString(Instance);
+                public static byte Deserialize(IDeserializer deserializer) => deserializer.DeserializeString(Instance);
                 public string ExpectedTypeName => "string";
 
                 byte Serde.IDeserializeVisitor<byte>.VisitString(string s) => VisitUtf8Span(System.Text.Encoding.UTF8.GetBytes(s));


### PR DESCRIPTION
The constrained generic is harder to use and doesn't gain much in performance that cannot be made up in other areas. Refs also don't play well with async, and there are size penalties that come from repeated specialization.