### PR TITLE
Allow using TypeInfo for deserializing collections

### DIFF
--- a/perf/bench/SampleTypes.cs
+++ b/perf/bench/SampleTypes.cs
@@ -58,7 +58,7 @@ namespace Benchmarks
 
     public partial record LocationWrap : IDeserialize<Location>
     {
-        private static readonly TypeInfo s_fieldMap = TypeInfo.Create([
+        private static readonly TypeInfo s_fieldMap = TypeInfo.Create(TypeInfo.TypeKind.CustomType, [
             ("id", typeof(Location).GetProperty("Id")!),
             ("address1", typeof(Location).GetProperty("Address1")!),
             ("address2", typeof(Location).GetProperty("Address2")!),

--- a/src/generator/Generator.SerdeTypeInfo.cs
+++ b/src/generator/Generator.SerdeTypeInfo.cs
@@ -103,7 +103,9 @@ internal static class SerdeTypeInfoGenerator
         var newType = $$"""
 internal static class {{typeName}}SerdeTypeInfo
 {
-    internal static readonly Serde.TypeInfo TypeInfo = Serde.TypeInfo.Create(new (string, System.Reflection.MemberInfo)[] {
+    internal static readonly Serde.TypeInfo TypeInfo = Serde.TypeInfo.Create(
+        Serde.TypeInfo.TypeKind.CustomType,
+        new (string, System.Reflection.MemberInfo)[] {
 {{string.Join("," + Environment.NewLine,
           fieldsAndProps.Select(x => $@"(""{x.GetFormattedName()}"", typeof({typeString}).Get{(x.Symbol.Kind == SymbolKind.Field ? "Field" : "Property")}(""{x.Name}"")!)"))}}
     });

--- a/src/serde/IDeserialize.cs
+++ b/src/serde/IDeserialize.cs
@@ -57,6 +57,14 @@ namespace Serde
         T VisitNotNull(IDeserializer d) => throw new InvalidOperationException("Expected type " + ExpectedTypeName);
     }
 
+    public interface IDeserializeCollection
+    {
+        int? SizeOpt { get; }
+
+        bool TryReadValue<T, D>(TypeInfo typeInfo, [MaybeNullWhen(false)] out T next)
+            where D : IDeserialize<T>;
+    }
+
     public interface IDeserializeEnumerable
     {
         bool TryGetNext<T, D>([MaybeNullWhen(false)] out T next)
@@ -93,126 +101,6 @@ namespace Serde
         V ReadValue<V, D>(int index) where D : IDeserialize<V>;
     }
 
-    /// <summary>
-    /// TypeInfo holds a variety of indexed information about a type. The most important is a map
-    /// from field names to int indices. This is an optimization for deserializing types that avoids
-    /// allocating strings for field names.
-    ///
-    /// It can also be used to get the custom attributes for a field.
-    /// </summary>
-    public sealed class TypeInfo
-    {
-        // The field names are sorted by the Utf8 representation of the field name.
-        private readonly ImmutableArray<(ReadOnlyMemory<byte> Utf8Name, int Index)> _nameToIndex;
-        private readonly ImmutableArray<PrivateFieldInfo> _indexToInfo;
-
-        private TypeInfo(
-            ImmutableArray<(ReadOnlyMemory<byte>, int)> nameToIndex,
-            ImmutableArray<PrivateFieldInfo> indexToInfo)
-        {
-            _nameToIndex = nameToIndex;
-            _indexToInfo = indexToInfo;
-        }
-
-        /// <summary>
-        /// Holds information for a field or property in the given type.
-        /// </summary>
-        private readonly record struct PrivateFieldInfo(IList<CustomAttributeData> CustomAttributesData);
-
-
-        private static readonly UTF8Encoding s_utf8 = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
-
-        /// <summary>
-        /// Create a new field mapping. The ordering of the fields is important -- it
-        /// corresponds to the index returned by <see cref="IDeserializeType.TryReadIndex" />.
-        /// </summary>
-        public static TypeInfo Create(
-            ReadOnlySpan<(string SerializeName, MemberInfo MemberInfo)> fields)
-        {
-            var nameToIndexBuilder = ImmutableArray.CreateBuilder<(ReadOnlyMemory<byte> Utf8Name, int Index)>(fields.Length);
-            var indexToInfoBuilder = ImmutableArray.CreateBuilder<PrivateFieldInfo>(fields.Length);
-            for (int index = 0; index < fields.Length; index++)
-            {
-                var (serializeName, memberInfo) = fields[index];
-                if (memberInfo is null)
-                {
-                    throw new ArgumentNullException(serializeName);
-                }
-
-                nameToIndexBuilder.Add((s_utf8.GetBytes(serializeName), index));
-                var fieldInfo = new PrivateFieldInfo(memberInfo.GetCustomAttributesData());
-                indexToInfoBuilder.Add(fieldInfo);
-            }
-
-            nameToIndexBuilder.Sort((left, right) =>
-                left.Utf8Name.Span.SequenceCompareTo(right.Utf8Name.Span));
-
-            return new TypeInfo(nameToIndexBuilder.ToImmutable(), indexToInfoBuilder.ToImmutable());
-        }
-
-        /// <summary>
-        /// Returns an index corresponding to the location of the field in the original
-        /// ReadOnlySpan passed during creation of the <see cref="TypeInfo"/>. This can be
-        /// used as a fast lookup for a field based on its UTF-8 name.
-        /// </summary>
-        public int TryGetIndex(Utf8Span utf8FieldName)
-        {
-            int mapIndex = BinarySearch(_nameToIndex.AsSpan(), utf8FieldName);
-
-            return mapIndex < 0 ? IDeserializeType.IndexNotFound : _nameToIndex[mapIndex].Index;
-        }
-
-        public IList<CustomAttributeData> GetCustomAttributeData(int index)
-        {
-            return _indexToInfo[index].CustomAttributesData;
-        }
-
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static int BinarySearch(ReadOnlySpan<(ReadOnlyMemory<byte>, int)> span, Utf8Span fieldName)
-        {
-            return BinarySearch(ref MemoryMarshal.GetReference(span), span.Length, fieldName);
-        }
-
-        // This is a copy of the BinarySearch method from System.MemoryExtensions.
-        // We can't use that version because ref structs can't yet be substituted for type arguments.
-        private static int BinarySearch(ref (ReadOnlyMemory<byte> Utf8Name, int) spanStart, int length, Utf8Span fieldName)
-        {
-            int lo = 0;
-            int hi = length - 1;
-            // If length == 0, hi == -1, and loop will not be entered
-            while (lo <= hi)
-            {
-                // PERF: `lo` or `hi` will never be negative inside the loop,
-                //       so computing median using uints is safe since we know
-                //       `length <= int.MaxValue`, and indices are >= 0
-                //       and thus cannot overflow an uint.
-                //       Saves one subtraction per loop compared to
-                //       `int i = lo + ((hi - lo) >> 1);`
-                int i = (int)(((uint)hi + (uint)lo) >> 1);
-
-                int c = fieldName.SequenceCompareTo(Unsafe.Add(ref spanStart, i).Utf8Name.Span);
-                if (c == 0)
-                {
-                    return i;
-                }
-                else if (c > 0)
-                {
-                    lo = i + 1;
-                }
-                else
-                {
-                    hi = i - 1;
-                }
-            }
-            // If none found, then a negative number that is the bitwise complement
-            // of the index of the next element that is larger than or, if there is
-            // no larger element, the bitwise complement of `length`, which
-            // is `lo` at this point.
-            return ~lo;
-        }
-    }
-
     public interface IDeserializer
     {
         T DeserializeAny<T>(IDeserializeVisitor<T> v);
@@ -235,6 +123,7 @@ namespace Serde
         T DeserializeEnumerable<T>(IDeserializeVisitor<T> v);
         T DeserializeDictionary<T>(IDeserializeVisitor<T> v);
         T DeserializeNullableRef<T>(IDeserializeVisitor<T> v);
+        IDeserializeCollection DeserializeCollection(TypeInfo typeInfo);
         IDeserializeType DeserializeType(TypeInfo typeInfo) => throw new NotImplementedException();
     }
 }

--- a/src/serde/IDeserialize.cs
+++ b/src/serde/IDeserialize.cs
@@ -123,7 +123,7 @@ namespace Serde
         T DeserializeEnumerable<T>(IDeserializeVisitor<T> v);
         T DeserializeDictionary<T>(IDeserializeVisitor<T> v);
         T DeserializeNullableRef<T>(IDeserializeVisitor<T> v);
-        IDeserializeCollection DeserializeCollection(TypeInfo typeInfo);
+        IDeserializeCollection DeserializeCollection(TypeInfo typeInfo) => throw new NotImplementedException();
         IDeserializeType DeserializeType(TypeInfo typeInfo) => throw new NotImplementedException();
     }
 }

--- a/src/serde/TypeInfo.cs
+++ b/src/serde/TypeInfo.cs
@@ -1,0 +1,145 @@
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Text;
+
+namespace Serde;
+
+/// <summary>
+/// TypeInfo holds a variety of indexed information about a type. The most important is a map
+/// from field names to int indices. This is an optimization for deserializing types that avoids
+/// allocating strings for field names.
+///
+/// It can also be used to get the custom attributes for a field.
+/// </summary>
+public sealed class TypeInfo
+{
+    public enum TypeKind
+    {
+        Primitive,
+        CustomType,
+        Enumerable,
+        Dictionary,
+    }
+
+    public TypeKind Kind { get; }
+
+    /// <summary>
+    /// Returns an index corresponding to the location of the field in the original
+    /// ReadOnlySpan passed during creation of the <see cref="TypeInfo"/>. This can be
+    /// used as a fast lookup for a field based on its UTF-8 name.
+    /// </summary>
+    public int TryGetIndex(Utf8Span utf8FieldName)
+    {
+        int mapIndex = BinarySearch(_nameToIndex.AsSpan(), utf8FieldName);
+
+        return mapIndex < 0 ? IDeserializeType.IndexNotFound : _nameToIndex[mapIndex].Index;
+    }
+
+    public IList<CustomAttributeData> GetCustomAttributeData(int index)
+    {
+        return _indexToInfo[index].CustomAttributesData;
+    }
+
+    /// <summary>
+    /// Create a new field mapping. The ordering of the fields is important -- it
+    /// corresponds to the index returned by <see cref="IDeserializeType.TryReadIndex" />.
+    /// </summary>
+    public static TypeInfo Create(
+        TypeKind typeKind,
+        ReadOnlySpan<(string SerializeName, MemberInfo MemberInfo)> fields)
+    {
+        var nameToIndexBuilder = ImmutableArray.CreateBuilder<(ReadOnlyMemory<byte> Utf8Name, int Index)>(fields.Length);
+        var indexToInfoBuilder = ImmutableArray.CreateBuilder<PrivateFieldInfo>(fields.Length);
+        for (int index = 0; index < fields.Length; index++)
+        {
+            var (serializeName, memberInfo) = fields[index];
+            if (memberInfo is null)
+            {
+                throw new ArgumentNullException(serializeName);
+            }
+
+            nameToIndexBuilder.Add((s_utf8.GetBytes(serializeName), index));
+            var fieldInfo = new PrivateFieldInfo(memberInfo.GetCustomAttributesData());
+            indexToInfoBuilder.Add(fieldInfo);
+        }
+
+        nameToIndexBuilder.Sort((left, right) =>
+            left.Utf8Name.Span.SequenceCompareTo(right.Utf8Name.Span));
+
+        return new TypeInfo(typeKind, nameToIndexBuilder.ToImmutable(), indexToInfoBuilder.ToImmutable());
+    }
+
+    #region Private implementation details
+
+    // The field names are sorted by the Utf8 representation of the field name.
+    private readonly ImmutableArray<(ReadOnlyMemory<byte> Utf8Name, int Index)> _nameToIndex;
+    private readonly ImmutableArray<PrivateFieldInfo> _indexToInfo;
+
+    /// <summary>
+    /// Holds information for a field or property in the given type.
+    /// </summary>
+    private readonly record struct PrivateFieldInfo(IList<CustomAttributeData> CustomAttributesData);
+
+    private static readonly UTF8Encoding s_utf8 = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
+
+    private TypeInfo(
+        TypeKind typeKind,
+        ImmutableArray<(ReadOnlyMemory<byte>, int)> nameToIndex,
+        ImmutableArray<PrivateFieldInfo> indexToInfo)
+    {
+        Kind = typeKind;
+        _nameToIndex = nameToIndex;
+        _indexToInfo = indexToInfo;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static int BinarySearch(ReadOnlySpan<(ReadOnlyMemory<byte>, int)> span, Utf8Span fieldName)
+    {
+        return BinarySearch(ref MemoryMarshal.GetReference(span), span.Length, fieldName);
+    }
+
+    // This is a copy of the BinarySearch method from System.MemoryExtensions.
+    // We can't use that version because ref structs can't yet be substituted for type arguments.
+    private static int BinarySearch(ref (ReadOnlyMemory<byte> Utf8Name, int) spanStart, int length, Utf8Span fieldName)
+    {
+        int lo = 0;
+        int hi = length - 1;
+        // If length == 0, hi == -1, and loop will not be entered
+        while (lo <= hi)
+        {
+            // PERF: `lo` or `hi` will never be negative inside the loop,
+            //       so computing median using uints is safe since we know
+            //       `length <= int.MaxValue`, and indices are >= 0
+            //       and thus cannot overflow an uint.
+            //       Saves one subtraction per loop compared to
+            //       `int i = lo + ((hi - lo) >> 1);`
+            int i = (int)(((uint)hi + (uint)lo) >> 1);
+
+            int c = fieldName.SequenceCompareTo(Unsafe.Add(ref spanStart, i).Utf8Name.Span);
+            if (c == 0)
+            {
+                return i;
+            }
+            else if (c > 0)
+            {
+                lo = i + 1;
+            }
+            else
+            {
+                hi = i - 1;
+            }
+        }
+        // If none found, then a negative number that is the bitwise complement
+        // of the index of the next element that is larger than or, if there is
+        // no larger element, the bitwise complement of `length`, which
+        // is `lo` at this point.
+        return ~lo;
+    }
+
+    #endregion  // Private implementation details
+}

--- a/src/serde/Wrappers.Dictionary.cs
+++ b/src/serde/Wrappers.Dictionary.cs
@@ -27,7 +27,7 @@ namespace Serde
                 _dict = dict;
             }
 
-            void ISerialize.Serialize(ISerializer serializer)
+            public void Serialize(ISerializer serializer)
             {
                 var sd = serializer.SerializeDictionary(_dict.Count);
                 foreach (var (k, v) in _dict)
@@ -38,7 +38,7 @@ namespace Serde
                 sd.End();
             }
 
-            void ISerialize<Dictionary<TKey, TValue>>.Serialize(Dictionary<TKey, TValue> value, ISerializer serializer)
+            public void Serialize(Dictionary<TKey, TValue> value, ISerializer serializer)
             {
                 var sd = serializer.SerializeDictionary(value.Count);
                 foreach (var (k, v) in value)
@@ -55,7 +55,7 @@ namespace Serde
             where TKeyWrap : IDeserialize<TKey>
             where TValueWrap : IDeserialize<TValue>
         {
-            static Dictionary<TKey, TValue> IDeserialize<Dictionary<TKey, TValue>>.Deserialize(IDeserializer deserializer)
+            public static Dictionary<TKey, TValue> Deserialize(IDeserializer deserializer)
             {
                 var typeInfo = DictSerdeTypeInfo.TypeInfo;
                 var deCollection = deserializer.DeserializeCollection(typeInfo);
@@ -98,7 +98,7 @@ namespace Serde
             public static SerializeImpl<TKey, TKeyWrap, TValue, TValueWrap> Create(IDictionary<TKey, TValue> t)
                 => new SerializeImpl<TKey, TKeyWrap, TValue, TValueWrap>(t);
 
-            void ISerialize<IDictionary<TKey, TValue>>.Serialize(IDictionary<TKey, TValue> value, ISerializer serializer)
+            public void Serialize(IDictionary<TKey, TValue> value, ISerializer serializer)
             {
                 var sd = serializer.SerializeDictionary(value.Count);
                 foreach (var (k, v) in value)
@@ -108,7 +108,7 @@ namespace Serde
                 }
                 sd.End();
             }
-            void ISerialize.Serialize(ISerializer serializer)
+            public void Serialize(ISerializer serializer)
             {
                 var sd = serializer.SerializeDictionary(Value.Count);
                 foreach (var (k, v) in Value)
@@ -133,7 +133,7 @@ namespace Serde
             public static SerializeImpl<TKey, TKeyWrap, TValue, TValueWrap> Create(IReadOnlyDictionary<TKey, TValue> t)
                 => new SerializeImpl<TKey, TKeyWrap, TValue, TValueWrap>(t);
 
-            void ISerialize.Serialize(ISerializer serializer)
+            public void Serialize(ISerializer serializer)
             {
                 var sd = serializer.SerializeDictionary(Value.Count);
                 foreach (var (k, v) in Value)

--- a/src/serde/Wrappers.Dictionary.cs
+++ b/src/serde/Wrappers.Dictionary.cs
@@ -4,6 +4,11 @@ using System.Net.Http.Headers;
 
 namespace Serde
 {
+    internal static class DictSerdeTypeInfo
+    {
+        public static readonly TypeInfo TypeInfo = TypeInfo.Create(TypeInfo.TypeKind.Dictionary, []);
+    }
+
     public static class DictWrap
     {
         public readonly struct SerializeImpl<TKey, TKeyWrap, TValue, TValueWrap>
@@ -52,35 +57,31 @@ namespace Serde
         {
             static Dictionary<TKey, TValue> IDeserialize<Dictionary<TKey, TValue>>.Deserialize(IDeserializer deserializer)
             {
-                return deserializer.DeserializeDictionary(Visitor.Instance);
-            }
-            private sealed class Visitor : IDeserializeVisitor<Dictionary<TKey, TValue>>
-            {
-                public static readonly Visitor Instance = new Visitor();
-                public string ExpectedTypeName => "Dictionary<" + typeof(TKey).Name + ", " + typeof(TValue).Name + ">";
-                public Dictionary<TKey, TValue> VisitDictionary<D>(ref D d)
-                    where D : IDeserializeDictionary
+                var typeInfo = DictSerdeTypeInfo.TypeInfo;
+                var deCollection = deserializer.DeserializeCollection(typeInfo);
+                Dictionary<TKey, TValue> dict;
+                if (deCollection.SizeOpt is int size)
                 {
-                    Dictionary<TKey, TValue> dict;
-                    if (d.SizeOpt is int size)
-                    {
-                        dict = new Dictionary<TKey, TValue>(size);
-                    }
-                    else
-                    {
-                        size = -1; // Set initial size to unknown
-                        dict = new Dictionary<TKey, TValue>();
-                    }
-                    while (d.TryGetNextEntry<TKey, TKeyWrap, TValue, TValueWrap>(out var next))
-                    {
-                        dict.Add(next.Item1, next.Item2);
-                    }
-                    if (size >= 0 && size != dict.Count)
-                    {
-                        throw new InvalidDeserializeValueException($"Expected {size} items, found {dict.Count}");
-                    }
-                    return dict;
+                    dict = new(size);
                 }
+                else
+                {
+                    size = -1; // Set initial size to unknown
+                    dict = new();
+                }
+                while (deCollection.TryReadValue<TKey, TKeyWrap>(typeInfo, out var key))
+                {
+                    if (!deCollection.TryReadValue<TValue, TValueWrap>(typeInfo, out var value))
+                    {
+                        throw new InvalidDeserializeValueException("Expected value, but reached end of collection.");
+                    }
+                    dict.Add(key, value);
+                }
+                if (size >= 0 && size != dict.Count)
+                {
+                    throw new InvalidDeserializeValueException($"Expected {size} items, found {dict.Count}");
+                }
+                return dict;
             }
         }
     }

--- a/src/serde/Wrappers.List.cs
+++ b/src/serde/Wrappers.List.cs
@@ -70,17 +70,17 @@ namespace Serde
         {
             public static SerializeImpl<T, TWrap> Create(T[] t) => new SerializeImpl<T, TWrap>(t);
 
-            void ISerialize<T[]>.Serialize(T[] value, ISerializer serializer)
+            public void Serialize(T[] value, ISerializer serializer)
                 => EnumerableHelpers.SerializeSpan<T, TWrap>(typeof(T[]).ToString(), value, serializer);
 
-            void ISerialize.Serialize(ISerializer serializer)
+            public void Serialize(ISerializer serializer)
                 => EnumerableHelpers.SerializeSpan<T, TWrap>(typeof(T[]).ToString(), Value, serializer);
         }
 
         public readonly struct DeserializeImpl<T, TWrap> : IDeserialize<T[]>
             where TWrap : IDeserialize<T>
         {
-            static T[] IDeserialize<T[]>.Deserialize(IDeserializer deserializer)
+            public static T[] Deserialize(IDeserializer deserializer)
             {
                 var typeInfo = EnumerableSerdeTypeInfo.TypeInfo;
                 var deCollection = deserializer.DeserializeCollection(typeInfo);
@@ -118,17 +118,17 @@ namespace Serde
         {
             public static SerializeImpl<T, TWrap> Create(List<T> t) => new SerializeImpl<T, TWrap>(t);
 
-            void ISerialize.Serialize(ISerializer serializer)
+            public void Serialize(ISerializer serializer)
                 => EnumerableHelpers.SerializeList<T, TWrap>(typeof(List<T>).ToString(), Value, serializer);
 
-            void ISerialize<List<T>>.Serialize(List<T> value, ISerializer serializer)
+            public void Serialize(List<T> value, ISerializer serializer)
                 => EnumerableHelpers.SerializeList<T, TWrap>(typeof(List<T>).ToString(), value, serializer);
         }
 
         public readonly struct DeserializeImpl<T, TWrap> : IDeserialize<List<T>>
             where TWrap : IDeserialize<T>
         {
-            static List<T> IDeserialize<List<T>>.Deserialize(IDeserializer deserializer)
+            public static List<T> Deserialize(IDeserializer deserializer)
             {
                 List<T> list;
                 var typeInfo = EnumerableSerdeTypeInfo.TypeInfo;
@@ -163,17 +163,17 @@ namespace Serde
         {
             public static SerializeImpl<T, TWrap> Create(ImmutableArray<T> t) => new SerializeImpl<T, TWrap>(t);
 
-            void ISerialize.Serialize(ISerializer serializer)
+            public void Serialize(ISerializer serializer)
                 => EnumerableHelpers.SerializeSpan<T, TWrap>(typeof(ImmutableArray<T>).ToString(), Value.AsSpan(), serializer);
 
-            void ISerialize<ImmutableArray<T>>.Serialize(ImmutableArray<T> value, ISerializer serializer)
+            public void Serialize(ImmutableArray<T> value, ISerializer serializer)
                 => EnumerableHelpers.SerializeSpan<T, TWrap>(typeof(ImmutableArray<T>).ToString(), value.AsSpan(), serializer);
         }
 
         public readonly struct DeserializeImpl<T, TWrap> : IDeserialize<ImmutableArray<T>>
             where TWrap : IDeserialize<T>
         {
-            static ImmutableArray<T> IDeserialize<ImmutableArray<T>>.Deserialize(IDeserializer deserializer)
+            public static ImmutableArray<T> Deserialize(IDeserializer deserializer)
             {
                 ImmutableArray<T>.Builder builder;
                 var typeInfo = EnumerableSerdeTypeInfo.TypeInfo;

--- a/test/Serde.Generation.Test/DeserializeTests.cs
+++ b/test/Serde.Generation.Test/DeserializeTests.cs
@@ -98,6 +98,7 @@ partial struct Rgb
 """;
             return VerifyDeserialize(src);
         }
+
         [Fact]
         public Task Rgb()
         {

--- a/test/Serde.Generation.Test/test_output/AllInOneTest.GeneratorTest/Serde.Test.AllInOne.ColorEnumSerdeTypeInfo.verified.cs
+++ b/test/Serde.Generation.Test/test_output/AllInOneTest.GeneratorTest/Serde.Test.AllInOne.ColorEnumSerdeTypeInfo.verified.cs
@@ -4,7 +4,9 @@ partial record AllInOne
 {
     internal static class ColorEnumSerdeTypeInfo
 {
-    internal static readonly Serde.TypeInfo TypeInfo = Serde.TypeInfo.Create(new (string, System.Reflection.MemberInfo)[] {
+    internal static readonly Serde.TypeInfo TypeInfo = Serde.TypeInfo.Create(
+        Serde.TypeInfo.TypeKind.CustomType,
+        new (string, System.Reflection.MemberInfo)[] {
 ("red", typeof(Serde.Test.AllInOne.ColorEnum).GetField("Red")!),
 ("blue", typeof(Serde.Test.AllInOne.ColorEnum).GetField("Blue")!),
 ("green", typeof(Serde.Test.AllInOne.ColorEnum).GetField("Green")!)

--- a/test/Serde.Generation.Test/test_output/AllInOneTest.GeneratorTest/Serde.Test.AllInOneSerdeTypeInfo.verified.cs
+++ b/test/Serde.Generation.Test/test_output/AllInOneTest.GeneratorTest/Serde.Test.AllInOneSerdeTypeInfo.verified.cs
@@ -2,7 +2,9 @@
 namespace Serde.Test;
 internal static class AllInOneSerdeTypeInfo
 {
-    internal static readonly Serde.TypeInfo TypeInfo = Serde.TypeInfo.Create(new (string, System.Reflection.MemberInfo)[] {
+    internal static readonly Serde.TypeInfo TypeInfo = Serde.TypeInfo.Create(
+        Serde.TypeInfo.TypeKind.CustomType,
+        new (string, System.Reflection.MemberInfo)[] {
 ("boolField", typeof(Serde.Test.AllInOne).GetField("BoolField")!),
 ("charField", typeof(Serde.Test.AllInOne).GetField("CharField")!),
 ("byteField", typeof(Serde.Test.AllInOne).GetField("ByteField")!),

--- a/test/Serde.Generation.Test/test_output/DeserializeTests.EnumMember/CSerdeTypeInfo.verified.cs
+++ b/test/Serde.Generation.Test/test_output/DeserializeTests.EnumMember/CSerdeTypeInfo.verified.cs
@@ -1,7 +1,9 @@
 ﻿//HintName: CSerdeTypeInfo.cs
 internal static class CSerdeTypeInfo
 {
-    internal static readonly Serde.TypeInfo TypeInfo = Serde.TypeInfo.Create(new (string, System.Reflection.MemberInfo)[] {
+    internal static readonly Serde.TypeInfo TypeInfo = Serde.TypeInfo.Create(
+        Serde.TypeInfo.TypeKind.CustomType,
+        new (string, System.Reflection.MemberInfo)[] {
 ("colorInt", typeof(C).GetField("ColorInt")!),
 ("colorByte", typeof(C).GetField("ColorByte")!),
 ("colorLong", typeof(C).GetField("ColorLong")!),

--- a/test/Serde.Generation.Test/test_output/DeserializeTests.EnumMember/ColorByteSerdeTypeInfo.verified.cs
+++ b/test/Serde.Generation.Test/test_output/DeserializeTests.EnumMember/ColorByteSerdeTypeInfo.verified.cs
@@ -1,7 +1,9 @@
 ﻿//HintName: ColorByteSerdeTypeInfo.cs
 internal static class ColorByteSerdeTypeInfo
 {
-    internal static readonly Serde.TypeInfo TypeInfo = Serde.TypeInfo.Create(new (string, System.Reflection.MemberInfo)[] {
+    internal static readonly Serde.TypeInfo TypeInfo = Serde.TypeInfo.Create(
+        Serde.TypeInfo.TypeKind.CustomType,
+        new (string, System.Reflection.MemberInfo)[] {
 ("red", typeof(ColorByte).GetField("Red")!),
 ("green", typeof(ColorByte).GetField("Green")!),
 ("blue", typeof(ColorByte).GetField("Blue")!)

--- a/test/Serde.Generation.Test/test_output/DeserializeTests.EnumMember/ColorIntSerdeTypeInfo.verified.cs
+++ b/test/Serde.Generation.Test/test_output/DeserializeTests.EnumMember/ColorIntSerdeTypeInfo.verified.cs
@@ -1,7 +1,9 @@
 ﻿//HintName: ColorIntSerdeTypeInfo.cs
 internal static class ColorIntSerdeTypeInfo
 {
-    internal static readonly Serde.TypeInfo TypeInfo = Serde.TypeInfo.Create(new (string, System.Reflection.MemberInfo)[] {
+    internal static readonly Serde.TypeInfo TypeInfo = Serde.TypeInfo.Create(
+        Serde.TypeInfo.TypeKind.CustomType,
+        new (string, System.Reflection.MemberInfo)[] {
 ("red", typeof(ColorInt).GetField("Red")!),
 ("green", typeof(ColorInt).GetField("Green")!),
 ("blue", typeof(ColorInt).GetField("Blue")!)

--- a/test/Serde.Generation.Test/test_output/DeserializeTests.EnumMember/ColorLongSerdeTypeInfo.verified.cs
+++ b/test/Serde.Generation.Test/test_output/DeserializeTests.EnumMember/ColorLongSerdeTypeInfo.verified.cs
@@ -1,7 +1,9 @@
 ﻿//HintName: ColorLongSerdeTypeInfo.cs
 internal static class ColorLongSerdeTypeInfo
 {
-    internal static readonly Serde.TypeInfo TypeInfo = Serde.TypeInfo.Create(new (string, System.Reflection.MemberInfo)[] {
+    internal static readonly Serde.TypeInfo TypeInfo = Serde.TypeInfo.Create(
+        Serde.TypeInfo.TypeKind.CustomType,
+        new (string, System.Reflection.MemberInfo)[] {
 ("red", typeof(ColorLong).GetField("Red")!),
 ("green", typeof(ColorLong).GetField("Green")!),
 ("blue", typeof(ColorLong).GetField("Blue")!)

--- a/test/Serde.Generation.Test/test_output/DeserializeTests.EnumMember/ColorULongSerdeTypeInfo.verified.cs
+++ b/test/Serde.Generation.Test/test_output/DeserializeTests.EnumMember/ColorULongSerdeTypeInfo.verified.cs
@@ -1,7 +1,9 @@
 ﻿//HintName: ColorULongSerdeTypeInfo.cs
 internal static class ColorULongSerdeTypeInfo
 {
-    internal static readonly Serde.TypeInfo TypeInfo = Serde.TypeInfo.Create(new (string, System.Reflection.MemberInfo)[] {
+    internal static readonly Serde.TypeInfo TypeInfo = Serde.TypeInfo.Create(
+        Serde.TypeInfo.TypeKind.CustomType,
+        new (string, System.Reflection.MemberInfo)[] {
 ("red", typeof(ColorULong).GetField("Red")!),
 ("green", typeof(ColorULong).GetField("Green")!),
 ("blue", typeof(ColorULong).GetField("Blue")!)

--- a/test/Serde.Generation.Test/test_output/DeserializeTests.NestedExplicitDeserializeWrapper/BIND_OPTSSerdeTypeInfo.verified.cs
+++ b/test/Serde.Generation.Test/test_output/DeserializeTests.NestedExplicitDeserializeWrapper/BIND_OPTSSerdeTypeInfo.verified.cs
@@ -1,7 +1,9 @@
 ﻿//HintName: BIND_OPTSSerdeTypeInfo.cs
 internal static class BIND_OPTSSerdeTypeInfo
 {
-    internal static readonly Serde.TypeInfo TypeInfo = Serde.TypeInfo.Create(new (string, System.Reflection.MemberInfo)[] {
+    internal static readonly Serde.TypeInfo TypeInfo = Serde.TypeInfo.Create(
+        Serde.TypeInfo.TypeKind.CustomType,
+        new (string, System.Reflection.MemberInfo)[] {
 ("cbStruct", typeof(System.Runtime.InteropServices.ComTypes.BIND_OPTS).GetField("cbStruct")!),
 ("dwTickCountDeadline", typeof(System.Runtime.InteropServices.ComTypes.BIND_OPTS).GetField("dwTickCountDeadline")!),
 ("grfFlags", typeof(System.Runtime.InteropServices.ComTypes.BIND_OPTS).GetField("grfFlags")!),

--- a/test/Serde.Generation.Test/test_output/DeserializeTests.NestedExplicitDeserializeWrapper/SSerdeTypeInfo.verified.cs
+++ b/test/Serde.Generation.Test/test_output/DeserializeTests.NestedExplicitDeserializeWrapper/SSerdeTypeInfo.verified.cs
@@ -1,7 +1,9 @@
 ﻿//HintName: SSerdeTypeInfo.cs
 internal static class SSerdeTypeInfo
 {
-    internal static readonly Serde.TypeInfo TypeInfo = Serde.TypeInfo.Create(new (string, System.Reflection.MemberInfo)[] {
+    internal static readonly Serde.TypeInfo TypeInfo = Serde.TypeInfo.Create(
+        Serde.TypeInfo.TypeKind.CustomType,
+        new (string, System.Reflection.MemberInfo)[] {
 ("opts", typeof(S).GetField("Opts")!)
     });
 }

--- a/test/Serde.Generation.Test/test_output/DeserializeTests/Array#ArrayFieldSerdeTypeInfo.verified.cs
+++ b/test/Serde.Generation.Test/test_output/DeserializeTests/Array#ArrayFieldSerdeTypeInfo.verified.cs
@@ -1,7 +1,9 @@
 ﻿//HintName: ArrayFieldSerdeTypeInfo.cs
 internal static class ArrayFieldSerdeTypeInfo
 {
-    internal static readonly Serde.TypeInfo TypeInfo = Serde.TypeInfo.Create(new (string, System.Reflection.MemberInfo)[] {
+    internal static readonly Serde.TypeInfo TypeInfo = Serde.TypeInfo.Create(
+        Serde.TypeInfo.TypeKind.CustomType,
+        new (string, System.Reflection.MemberInfo)[] {
 ("intArr", typeof(ArrayField).GetField("IntArr")!)
     });
 }

--- a/test/Serde.Generation.Test/test_output/DeserializeTests/DeserializeMissing#SetToNullSerdeTypeInfo.verified.cs
+++ b/test/Serde.Generation.Test/test_output/DeserializeTests/DeserializeMissing#SetToNullSerdeTypeInfo.verified.cs
@@ -1,7 +1,9 @@
 ﻿//HintName: SetToNullSerdeTypeInfo.cs
 internal static class SetToNullSerdeTypeInfo
 {
-    internal static readonly Serde.TypeInfo TypeInfo = Serde.TypeInfo.Create(new (string, System.Reflection.MemberInfo)[] {
+    internal static readonly Serde.TypeInfo TypeInfo = Serde.TypeInfo.Create(
+        Serde.TypeInfo.TypeKind.CustomType,
+        new (string, System.Reflection.MemberInfo)[] {
 ("present", typeof(SetToNull).GetProperty("Present")!),
 ("missing", typeof(SetToNull).GetProperty("Missing")!),
 ("throwMissing", typeof(SetToNull).GetProperty("ThrowMissing")!)

--- a/test/Serde.Generation.Test/test_output/DeserializeTests/DeserializeOnlyWrap#BIND_OPTSSerdeTypeInfo.verified.cs
+++ b/test/Serde.Generation.Test/test_output/DeserializeTests/DeserializeOnlyWrap#BIND_OPTSSerdeTypeInfo.verified.cs
@@ -1,7 +1,9 @@
 ﻿//HintName: BIND_OPTSSerdeTypeInfo.cs
 internal static class BIND_OPTSSerdeTypeInfo
 {
-    internal static readonly Serde.TypeInfo TypeInfo = Serde.TypeInfo.Create(new (string, System.Reflection.MemberInfo)[] {
+    internal static readonly Serde.TypeInfo TypeInfo = Serde.TypeInfo.Create(
+        Serde.TypeInfo.TypeKind.CustomType,
+        new (string, System.Reflection.MemberInfo)[] {
 ("cbStruct", typeof(System.Runtime.InteropServices.ComTypes.BIND_OPTS).GetField("cbStruct")!),
 ("dwTickCountDeadline", typeof(System.Runtime.InteropServices.ComTypes.BIND_OPTS).GetField("dwTickCountDeadline")!),
 ("grfFlags", typeof(System.Runtime.InteropServices.ComTypes.BIND_OPTS).GetField("grfFlags")!),

--- a/test/Serde.Generation.Test/test_output/DeserializeTests/MemberSkip#RgbSerdeTypeInfo.verified.cs
+++ b/test/Serde.Generation.Test/test_output/DeserializeTests/MemberSkip#RgbSerdeTypeInfo.verified.cs
@@ -1,7 +1,9 @@
 ﻿//HintName: RgbSerdeTypeInfo.cs
 internal static class RgbSerdeTypeInfo
 {
-    internal static readonly Serde.TypeInfo TypeInfo = Serde.TypeInfo.Create(new (string, System.Reflection.MemberInfo)[] {
+    internal static readonly Serde.TypeInfo TypeInfo = Serde.TypeInfo.Create(
+        Serde.TypeInfo.TypeKind.CustomType,
+        new (string, System.Reflection.MemberInfo)[] {
 ("red", typeof(Rgb).GetField("Red")!),
 ("blue", typeof(Rgb).GetField("Blue")!)
     });

--- a/test/Serde.Generation.Test/test_output/DeserializeTests/MemberSkipDeserialize#RgbSerdeTypeInfo.verified.cs
+++ b/test/Serde.Generation.Test/test_output/DeserializeTests/MemberSkipDeserialize#RgbSerdeTypeInfo.verified.cs
@@ -1,7 +1,9 @@
 ﻿//HintName: RgbSerdeTypeInfo.cs
 internal static class RgbSerdeTypeInfo
 {
-    internal static readonly Serde.TypeInfo TypeInfo = Serde.TypeInfo.Create(new (string, System.Reflection.MemberInfo)[] {
+    internal static readonly Serde.TypeInfo TypeInfo = Serde.TypeInfo.Create(
+        Serde.TypeInfo.TypeKind.CustomType,
+        new (string, System.Reflection.MemberInfo)[] {
 ("red", typeof(Rgb).GetField("Red")!),
 ("green", typeof(Rgb).GetField("Green")!),
 ("blue", typeof(Rgb).GetField("Blue")!)

--- a/test/Serde.Generation.Test/test_output/DeserializeTests/MemberSkipSerialize#RgbSerdeTypeInfo.verified.cs
+++ b/test/Serde.Generation.Test/test_output/DeserializeTests/MemberSkipSerialize#RgbSerdeTypeInfo.verified.cs
@@ -1,7 +1,9 @@
 ﻿//HintName: RgbSerdeTypeInfo.cs
 internal static class RgbSerdeTypeInfo
 {
-    internal static readonly Serde.TypeInfo TypeInfo = Serde.TypeInfo.Create(new (string, System.Reflection.MemberInfo)[] {
+    internal static readonly Serde.TypeInfo TypeInfo = Serde.TypeInfo.Create(
+        Serde.TypeInfo.TypeKind.CustomType,
+        new (string, System.Reflection.MemberInfo)[] {
 ("red", typeof(Rgb).GetField("Red")!),
 ("green", typeof(Rgb).GetField("Green")!),
 ("blue", typeof(Rgb).GetField("Blue")!)

--- a/test/Serde.Generation.Test/test_output/DeserializeTests/NestedPartialClasses#A.B.C.DSerdeTypeInfo.verified.cs
+++ b/test/Serde.Generation.Test/test_output/DeserializeTests/NestedPartialClasses#A.B.C.DSerdeTypeInfo.verified.cs
@@ -7,7 +7,9 @@ partial class A
 {
     internal static class DSerdeTypeInfo
 {
-    internal static readonly Serde.TypeInfo TypeInfo = Serde.TypeInfo.Create(new (string, System.Reflection.MemberInfo)[] {
+    internal static readonly Serde.TypeInfo TypeInfo = Serde.TypeInfo.Create(
+        Serde.TypeInfo.TypeKind.CustomType,
+        new (string, System.Reflection.MemberInfo)[] {
 ("field", typeof(A.B.C.D).GetField("Field")!)
     });
 }

--- a/test/Serde.Generation.Test/test_output/DeserializeTests/NullableRefField#SSerdeTypeInfo.verified.cs
+++ b/test/Serde.Generation.Test/test_output/DeserializeTests/NullableRefField#SSerdeTypeInfo.verified.cs
@@ -1,7 +1,9 @@
 ﻿//HintName: SSerdeTypeInfo.cs
 internal static class SSerdeTypeInfo
 {
-    internal static readonly Serde.TypeInfo TypeInfo = Serde.TypeInfo.Create(new (string, System.Reflection.MemberInfo)[] {
+    internal static readonly Serde.TypeInfo TypeInfo = Serde.TypeInfo.Create(
+        Serde.TypeInfo.TypeKind.CustomType,
+        new (string, System.Reflection.MemberInfo)[] {
 ("f", typeof(S).GetField("F")!)
     });
 }

--- a/test/Serde.Generation.Test/test_output/DeserializeTests/Rgb#RgbSerdeTypeInfo.verified.cs
+++ b/test/Serde.Generation.Test/test_output/DeserializeTests/Rgb#RgbSerdeTypeInfo.verified.cs
@@ -1,7 +1,9 @@
 ﻿//HintName: RgbSerdeTypeInfo.cs
 internal static class RgbSerdeTypeInfo
 {
-    internal static readonly Serde.TypeInfo TypeInfo = Serde.TypeInfo.Create(new (string, System.Reflection.MemberInfo)[] {
+    internal static readonly Serde.TypeInfo TypeInfo = Serde.TypeInfo.Create(
+        Serde.TypeInfo.TypeKind.CustomType,
+        new (string, System.Reflection.MemberInfo)[] {
 ("red", typeof(Rgb).GetField("Red")!),
 ("green", typeof(Rgb).GetField("Green")!),
 ("blue", typeof(Rgb).GetField("Blue")!)

--- a/test/Serde.Generation.Test/test_output/MemberFormatTests.CamelCase/SSerdeTypeInfo.verified.cs
+++ b/test/Serde.Generation.Test/test_output/MemberFormatTests.CamelCase/SSerdeTypeInfo.verified.cs
@@ -1,7 +1,9 @@
 ﻿//HintName: SSerdeTypeInfo.cs
 internal static class SSerdeTypeInfo
 {
-    internal static readonly Serde.TypeInfo TypeInfo = Serde.TypeInfo.Create(new (string, System.Reflection.MemberInfo)[] {
+    internal static readonly Serde.TypeInfo TypeInfo = Serde.TypeInfo.Create(
+        Serde.TypeInfo.TypeKind.CustomType,
+        new (string, System.Reflection.MemberInfo)[] {
 ("one", typeof(S).GetProperty("One")!),
 ("twoWord", typeof(S).GetProperty("TwoWord")!)
     });

--- a/test/Serde.Generation.Test/test_output/MemberFormatTests.Default/SSerdeTypeInfo.verified.cs
+++ b/test/Serde.Generation.Test/test_output/MemberFormatTests.Default/SSerdeTypeInfo.verified.cs
@@ -1,7 +1,9 @@
 ﻿//HintName: SSerdeTypeInfo.cs
 internal static class SSerdeTypeInfo
 {
-    internal static readonly Serde.TypeInfo TypeInfo = Serde.TypeInfo.Create(new (string, System.Reflection.MemberInfo)[] {
+    internal static readonly Serde.TypeInfo TypeInfo = Serde.TypeInfo.Create(
+        Serde.TypeInfo.TypeKind.CustomType,
+        new (string, System.Reflection.MemberInfo)[] {
 ("one", typeof(S).GetProperty("One")!),
 ("twoWord", typeof(S).GetProperty("TwoWord")!)
     });

--- a/test/Serde.Generation.Test/test_output/MemberFormatTests.EnumFormat/ColorEnumSerdeTypeInfo.verified.cs
+++ b/test/Serde.Generation.Test/test_output/MemberFormatTests.EnumFormat/ColorEnumSerdeTypeInfo.verified.cs
@@ -1,7 +1,9 @@
 ﻿//HintName: ColorEnumSerdeTypeInfo.cs
 internal static class ColorEnumSerdeTypeInfo
 {
-    internal static readonly Serde.TypeInfo TypeInfo = Serde.TypeInfo.Create(new (string, System.Reflection.MemberInfo)[] {
+    internal static readonly Serde.TypeInfo TypeInfo = Serde.TypeInfo.Create(
+        Serde.TypeInfo.TypeKind.CustomType,
+        new (string, System.Reflection.MemberInfo)[] {
 ("Red", typeof(ColorEnum).GetField("Red")!),
 ("Green", typeof(ColorEnum).GetField("Green")!),
 ("Blue", typeof(ColorEnum).GetField("Blue")!)

--- a/test/Serde.Generation.Test/test_output/MemberFormatTests.EnumValues/ColorEnumSerdeTypeInfo.verified.cs
+++ b/test/Serde.Generation.Test/test_output/MemberFormatTests.EnumValues/ColorEnumSerdeTypeInfo.verified.cs
@@ -1,7 +1,9 @@
 ﻿//HintName: ColorEnumSerdeTypeInfo.cs
 internal static class ColorEnumSerdeTypeInfo
 {
-    internal static readonly Serde.TypeInfo TypeInfo = Serde.TypeInfo.Create(new (string, System.Reflection.MemberInfo)[] {
+    internal static readonly Serde.TypeInfo TypeInfo = Serde.TypeInfo.Create(
+        Serde.TypeInfo.TypeKind.CustomType,
+        new (string, System.Reflection.MemberInfo)[] {
 ("red", typeof(ColorEnum).GetField("Red")!),
 ("green", typeof(ColorEnum).GetField("Green")!),
 ("blue", typeof(ColorEnum).GetField("Blue")!)

--- a/test/Serde.Generation.Test/test_output/MemberFormatTests.EnumValues/S2SerdeTypeInfo.verified.cs
+++ b/test/Serde.Generation.Test/test_output/MemberFormatTests.EnumValues/S2SerdeTypeInfo.verified.cs
@@ -1,7 +1,9 @@
 ﻿//HintName: S2SerdeTypeInfo.cs
 internal static class S2SerdeTypeInfo
 {
-    internal static readonly Serde.TypeInfo TypeInfo = Serde.TypeInfo.Create(new (string, System.Reflection.MemberInfo)[] {
+    internal static readonly Serde.TypeInfo TypeInfo = Serde.TypeInfo.Create(
+        Serde.TypeInfo.TypeKind.CustomType,
+        new (string, System.Reflection.MemberInfo)[] {
 ("E", typeof(S2).GetField("E")!)
     });
 }

--- a/test/Serde.Generation.Test/test_output/MemberFormatTests.EnumValues/SSerdeTypeInfo.verified.cs
+++ b/test/Serde.Generation.Test/test_output/MemberFormatTests.EnumValues/SSerdeTypeInfo.verified.cs
@@ -1,7 +1,9 @@
 ﻿//HintName: SSerdeTypeInfo.cs
 internal static class SSerdeTypeInfo
 {
-    internal static readonly Serde.TypeInfo TypeInfo = Serde.TypeInfo.Create(new (string, System.Reflection.MemberInfo)[] {
+    internal static readonly Serde.TypeInfo TypeInfo = Serde.TypeInfo.Create(
+        Serde.TypeInfo.TypeKind.CustomType,
+        new (string, System.Reflection.MemberInfo)[] {
 ("e", typeof(S).GetField("E")!)
     });
 }

--- a/test/Serde.Generation.Test/test_output/MemberFormatTests.KebabCase/SSerdeTypeInfo.verified.cs
+++ b/test/Serde.Generation.Test/test_output/MemberFormatTests.KebabCase/SSerdeTypeInfo.verified.cs
@@ -1,7 +1,9 @@
 ﻿//HintName: SSerdeTypeInfo.cs
 internal static class SSerdeTypeInfo
 {
-    internal static readonly Serde.TypeInfo TypeInfo = Serde.TypeInfo.Create(new (string, System.Reflection.MemberInfo)[] {
+    internal static readonly Serde.TypeInfo TypeInfo = Serde.TypeInfo.Create(
+        Serde.TypeInfo.TypeKind.CustomType,
+        new (string, System.Reflection.MemberInfo)[] {
 ("one", typeof(S).GetProperty("One")!),
 ("two-word", typeof(S).GetProperty("TwoWord")!)
     });

--- a/test/Serde.Generation.Test/test_output/SerializeTests.ArrayOfGenerateSerialize/TestCase15.Class0SerdeTypeInfo.verified.cs
+++ b/test/Serde.Generation.Test/test_output/SerializeTests.ArrayOfGenerateSerialize/TestCase15.Class0SerdeTypeInfo.verified.cs
@@ -3,7 +3,9 @@ partial class TestCase15
 {
     internal static class Class0SerdeTypeInfo
 {
-    internal static readonly Serde.TypeInfo TypeInfo = Serde.TypeInfo.Create(new (string, System.Reflection.MemberInfo)[] {
+    internal static readonly Serde.TypeInfo TypeInfo = Serde.TypeInfo.Create(
+        Serde.TypeInfo.TypeKind.CustomType,
+        new (string, System.Reflection.MemberInfo)[] {
 ("field0", typeof(TestCase15.Class0).GetField("Field0")!),
 ("field1", typeof(TestCase15.Class0).GetField("Field1")!)
     });

--- a/test/Serde.Generation.Test/test_output/SerializeTests.ArrayOfGenerateSerialize/TestCase15.Class1SerdeTypeInfo.verified.cs
+++ b/test/Serde.Generation.Test/test_output/SerializeTests.ArrayOfGenerateSerialize/TestCase15.Class1SerdeTypeInfo.verified.cs
@@ -3,7 +3,9 @@ partial class TestCase15
 {
     internal static class Class1SerdeTypeInfo
 {
-    internal static readonly Serde.TypeInfo TypeInfo = Serde.TypeInfo.Create(new (string, System.Reflection.MemberInfo)[] {
+    internal static readonly Serde.TypeInfo TypeInfo = Serde.TypeInfo.Create(
+        Serde.TypeInfo.TypeKind.CustomType,
+        new (string, System.Reflection.MemberInfo)[] {
 ("field0", typeof(TestCase15.Class1).GetField("Field0")!),
 ("field1", typeof(TestCase15.Class1).GetField("Field1")!)
     });

--- a/test/Serde.Generation.Test/test_output/SerializeTests.DictionaryGenerate2/C2SerdeTypeInfo.verified.cs
+++ b/test/Serde.Generation.Test/test_output/SerializeTests.DictionaryGenerate2/C2SerdeTypeInfo.verified.cs
@@ -1,7 +1,9 @@
 ﻿//HintName: C2SerdeTypeInfo.cs
 internal static class C2SerdeTypeInfo
 {
-    internal static readonly Serde.TypeInfo TypeInfo = Serde.TypeInfo.Create(new (string, System.Reflection.MemberInfo)[] {
+    internal static readonly Serde.TypeInfo TypeInfo = Serde.TypeInfo.Create(
+        Serde.TypeInfo.TypeKind.CustomType,
+        new (string, System.Reflection.MemberInfo)[] {
 ("map", typeof(C2).GetField("Map")!)
     });
 }

--- a/test/Serde.Generation.Test/test_output/SerializeTests.DictionaryGenerate2/CSerdeTypeInfo.verified.cs
+++ b/test/Serde.Generation.Test/test_output/SerializeTests.DictionaryGenerate2/CSerdeTypeInfo.verified.cs
@@ -1,7 +1,9 @@
 ﻿//HintName: CSerdeTypeInfo.cs
 internal static class CSerdeTypeInfo
 {
-    internal static readonly Serde.TypeInfo TypeInfo = Serde.TypeInfo.Create(new (string, System.Reflection.MemberInfo)[] {
+    internal static readonly Serde.TypeInfo TypeInfo = Serde.TypeInfo.Create(
+        Serde.TypeInfo.TypeKind.CustomType,
+        new (string, System.Reflection.MemberInfo)[] {
 ("x", typeof(C).GetProperty("X")!)
     });
 }

--- a/test/Serde.Generation.Test/test_output/SerializeTests.EnumMember/Some.Nested.Namespace.CSerdeTypeInfo.verified.cs
+++ b/test/Serde.Generation.Test/test_output/SerializeTests.EnumMember/Some.Nested.Namespace.CSerdeTypeInfo.verified.cs
@@ -2,7 +2,9 @@
 namespace Some.Nested.Namespace;
 internal static class CSerdeTypeInfo
 {
-    internal static readonly Serde.TypeInfo TypeInfo = Serde.TypeInfo.Create(new (string, System.Reflection.MemberInfo)[] {
+    internal static readonly Serde.TypeInfo TypeInfo = Serde.TypeInfo.Create(
+        Serde.TypeInfo.TypeKind.CustomType,
+        new (string, System.Reflection.MemberInfo)[] {
 ("colorInt", typeof(Some.Nested.Namespace.C).GetField("ColorInt")!),
 ("colorByte", typeof(Some.Nested.Namespace.C).GetField("ColorByte")!),
 ("colorLong", typeof(Some.Nested.Namespace.C).GetField("ColorLong")!),

--- a/test/Serde.Generation.Test/test_output/SerializeTests.EnumMember/Some.Nested.Namespace.ColorByteSerdeTypeInfo.verified.cs
+++ b/test/Serde.Generation.Test/test_output/SerializeTests.EnumMember/Some.Nested.Namespace.ColorByteSerdeTypeInfo.verified.cs
@@ -2,7 +2,9 @@
 namespace Some.Nested.Namespace;
 internal static class ColorByteSerdeTypeInfo
 {
-    internal static readonly Serde.TypeInfo TypeInfo = Serde.TypeInfo.Create(new (string, System.Reflection.MemberInfo)[] {
+    internal static readonly Serde.TypeInfo TypeInfo = Serde.TypeInfo.Create(
+        Serde.TypeInfo.TypeKind.CustomType,
+        new (string, System.Reflection.MemberInfo)[] {
 ("red", typeof(Some.Nested.Namespace.ColorByte).GetField("Red")!),
 ("green", typeof(Some.Nested.Namespace.ColorByte).GetField("Green")!),
 ("blue", typeof(Some.Nested.Namespace.ColorByte).GetField("Blue")!)

--- a/test/Serde.Generation.Test/test_output/SerializeTests.EnumMember/Some.Nested.Namespace.ColorIntSerdeTypeInfo.verified.cs
+++ b/test/Serde.Generation.Test/test_output/SerializeTests.EnumMember/Some.Nested.Namespace.ColorIntSerdeTypeInfo.verified.cs
@@ -2,7 +2,9 @@
 namespace Some.Nested.Namespace;
 internal static class ColorIntSerdeTypeInfo
 {
-    internal static readonly Serde.TypeInfo TypeInfo = Serde.TypeInfo.Create(new (string, System.Reflection.MemberInfo)[] {
+    internal static readonly Serde.TypeInfo TypeInfo = Serde.TypeInfo.Create(
+        Serde.TypeInfo.TypeKind.CustomType,
+        new (string, System.Reflection.MemberInfo)[] {
 ("red", typeof(Some.Nested.Namespace.ColorInt).GetField("Red")!),
 ("green", typeof(Some.Nested.Namespace.ColorInt).GetField("Green")!),
 ("blue", typeof(Some.Nested.Namespace.ColorInt).GetField("Blue")!)

--- a/test/Serde.Generation.Test/test_output/SerializeTests.EnumMember/Some.Nested.Namespace.ColorLongSerdeTypeInfo.verified.cs
+++ b/test/Serde.Generation.Test/test_output/SerializeTests.EnumMember/Some.Nested.Namespace.ColorLongSerdeTypeInfo.verified.cs
@@ -2,7 +2,9 @@
 namespace Some.Nested.Namespace;
 internal static class ColorLongSerdeTypeInfo
 {
-    internal static readonly Serde.TypeInfo TypeInfo = Serde.TypeInfo.Create(new (string, System.Reflection.MemberInfo)[] {
+    internal static readonly Serde.TypeInfo TypeInfo = Serde.TypeInfo.Create(
+        Serde.TypeInfo.TypeKind.CustomType,
+        new (string, System.Reflection.MemberInfo)[] {
 ("red", typeof(Some.Nested.Namespace.ColorLong).GetField("Red")!),
 ("green", typeof(Some.Nested.Namespace.ColorLong).GetField("Green")!),
 ("blue", typeof(Some.Nested.Namespace.ColorLong).GetField("Blue")!)

--- a/test/Serde.Generation.Test/test_output/SerializeTests.EnumMember/Some.Nested.Namespace.ColorULongSerdeTypeInfo.verified.cs
+++ b/test/Serde.Generation.Test/test_output/SerializeTests.EnumMember/Some.Nested.Namespace.ColorULongSerdeTypeInfo.verified.cs
@@ -2,7 +2,9 @@
 namespace Some.Nested.Namespace;
 internal static class ColorULongSerdeTypeInfo
 {
-    internal static readonly Serde.TypeInfo TypeInfo = Serde.TypeInfo.Create(new (string, System.Reflection.MemberInfo)[] {
+    internal static readonly Serde.TypeInfo TypeInfo = Serde.TypeInfo.Create(
+        Serde.TypeInfo.TypeKind.CustomType,
+        new (string, System.Reflection.MemberInfo)[] {
 ("red", typeof(Some.Nested.Namespace.ColorULong).GetField("Red")!),
 ("green", typeof(Some.Nested.Namespace.ColorULong).GetField("Green")!),
 ("blue", typeof(Some.Nested.Namespace.ColorULong).GetField("Blue")!)

--- a/test/Serde.Generation.Test/test_output/SerializeTests.NestedEnumWrapper/CSerdeTypeInfo.verified.cs
+++ b/test/Serde.Generation.Test/test_output/SerializeTests.NestedEnumWrapper/CSerdeTypeInfo.verified.cs
@@ -1,7 +1,9 @@
 ﻿//HintName: CSerdeTypeInfo.cs
 internal static class CSerdeTypeInfo
 {
-    internal static readonly Serde.TypeInfo TypeInfo = Serde.TypeInfo.Create(new (string, System.Reflection.MemberInfo)[] {
+    internal static readonly Serde.TypeInfo TypeInfo = Serde.TypeInfo.Create(
+        Serde.TypeInfo.TypeKind.CustomType,
+        new (string, System.Reflection.MemberInfo)[] {
 ("colorOpt", typeof(C).GetField("ColorOpt")!)
     });
 }

--- a/test/Serde.Generation.Test/test_output/SerializeTests.NestedEnumWrapper/RgbSerdeTypeInfo.verified.cs
+++ b/test/Serde.Generation.Test/test_output/SerializeTests.NestedEnumWrapper/RgbSerdeTypeInfo.verified.cs
@@ -1,7 +1,9 @@
 ﻿//HintName: RgbSerdeTypeInfo.cs
 internal static class RgbSerdeTypeInfo
 {
-    internal static readonly Serde.TypeInfo TypeInfo = Serde.TypeInfo.Create(new (string, System.Reflection.MemberInfo)[] {
+    internal static readonly Serde.TypeInfo TypeInfo = Serde.TypeInfo.Create(
+        Serde.TypeInfo.TypeKind.CustomType,
+        new (string, System.Reflection.MemberInfo)[] {
 ("red", typeof(Rgb).GetField("Red")!),
 ("green", typeof(Rgb).GetField("Green")!),
 ("blue", typeof(Rgb).GetField("Blue")!)

--- a/test/Serde.Generation.Test/test_output/SerializeTests.NestedExplicitSerializeWrapper/BIND_OPTSSerdeTypeInfo.verified.cs
+++ b/test/Serde.Generation.Test/test_output/SerializeTests.NestedExplicitSerializeWrapper/BIND_OPTSSerdeTypeInfo.verified.cs
@@ -1,7 +1,9 @@
 ﻿//HintName: BIND_OPTSSerdeTypeInfo.cs
 internal static class BIND_OPTSSerdeTypeInfo
 {
-    internal static readonly Serde.TypeInfo TypeInfo = Serde.TypeInfo.Create(new (string, System.Reflection.MemberInfo)[] {
+    internal static readonly Serde.TypeInfo TypeInfo = Serde.TypeInfo.Create(
+        Serde.TypeInfo.TypeKind.CustomType,
+        new (string, System.Reflection.MemberInfo)[] {
 ("cbStruct", typeof(System.Runtime.InteropServices.ComTypes.BIND_OPTS).GetField("cbStruct")!),
 ("dwTickCountDeadline", typeof(System.Runtime.InteropServices.ComTypes.BIND_OPTS).GetField("dwTickCountDeadline")!),
 ("grfFlags", typeof(System.Runtime.InteropServices.ComTypes.BIND_OPTS).GetField("grfFlags")!),

--- a/test/Serde.Generation.Test/test_output/SerializeTests.NestedExplicitSerializeWrapper/SSerdeTypeInfo.verified.cs
+++ b/test/Serde.Generation.Test/test_output/SerializeTests.NestedExplicitSerializeWrapper/SSerdeTypeInfo.verified.cs
@@ -1,7 +1,9 @@
 ﻿//HintName: SSerdeTypeInfo.cs
 internal static class SSerdeTypeInfo
 {
-    internal static readonly Serde.TypeInfo TypeInfo = Serde.TypeInfo.Create(new (string, System.Reflection.MemberInfo)[] {
+    internal static readonly Serde.TypeInfo TypeInfo = Serde.TypeInfo.Create(
+        Serde.TypeInfo.TypeKind.CustomType,
+        new (string, System.Reflection.MemberInfo)[] {
 ("opts", typeof(S).GetField("Opts")!)
     });
 }

--- a/test/Serde.Generation.Test/test_output/SerializeTests.SerializeOnlyWrapper/SectionSerdeTypeInfo.verified.cs
+++ b/test/Serde.Generation.Test/test_output/SerializeTests.SerializeOnlyWrapper/SectionSerdeTypeInfo.verified.cs
@@ -1,7 +1,9 @@
 ﻿//HintName: SectionSerdeTypeInfo.cs
 internal static class SectionSerdeTypeInfo
 {
-    internal static readonly Serde.TypeInfo TypeInfo = Serde.TypeInfo.Create(new (string, System.Reflection.MemberInfo)[] {
+    internal static readonly Serde.TypeInfo TypeInfo = Serde.TypeInfo.Create(
+        Serde.TypeInfo.TypeKind.CustomType,
+        new (string, System.Reflection.MemberInfo)[] {
 ("mask", typeof(System.Collections.Specialized.BitVector32.Section).GetProperty("Mask")!),
 ("offset", typeof(System.Collections.Specialized.BitVector32.Section).GetProperty("Offset")!)
     });

--- a/test/Serde.Generation.Test/test_output/SerializeTests/DictionaryGenerate#CSerdeTypeInfo.verified.cs
+++ b/test/Serde.Generation.Test/test_output/SerializeTests/DictionaryGenerate#CSerdeTypeInfo.verified.cs
@@ -1,7 +1,9 @@
 ﻿//HintName: CSerdeTypeInfo.cs
 internal static class CSerdeTypeInfo
 {
-    internal static readonly Serde.TypeInfo TypeInfo = Serde.TypeInfo.Create(new (string, System.Reflection.MemberInfo)[] {
+    internal static readonly Serde.TypeInfo TypeInfo = Serde.TypeInfo.Create(
+        Serde.TypeInfo.TypeKind.CustomType,
+        new (string, System.Reflection.MemberInfo)[] {
 ("map", typeof(C).GetField("Map")!)
     });
 }

--- a/test/Serde.Generation.Test/test_output/SerializeTests/ExplicitGenericWrapper#CSerdeTypeInfo.verified.cs
+++ b/test/Serde.Generation.Test/test_output/SerializeTests/ExplicitGenericWrapper#CSerdeTypeInfo.verified.cs
@@ -1,7 +1,9 @@
 ﻿//HintName: CSerdeTypeInfo.cs
 internal static class CSerdeTypeInfo
 {
-    internal static readonly Serde.TypeInfo TypeInfo = Serde.TypeInfo.Create(new (string, System.Reflection.MemberInfo)[] {
+    internal static readonly Serde.TypeInfo TypeInfo = Serde.TypeInfo.Create(
+        Serde.TypeInfo.TypeKind.CustomType,
+        new (string, System.Reflection.MemberInfo)[] {
 ("s", typeof(C).GetField("S")!)
     });
 }

--- a/test/Serde.Generation.Test/test_output/SerializeTests/ExplicitWrapper#CSerdeTypeInfo.verified.cs
+++ b/test/Serde.Generation.Test/test_output/SerializeTests/ExplicitWrapper#CSerdeTypeInfo.verified.cs
@@ -1,7 +1,9 @@
 ﻿//HintName: CSerdeTypeInfo.cs
 internal static class CSerdeTypeInfo
 {
-    internal static readonly Serde.TypeInfo TypeInfo = Serde.TypeInfo.Create(new (string, System.Reflection.MemberInfo)[] {
+    internal static readonly Serde.TypeInfo TypeInfo = Serde.TypeInfo.Create(
+        Serde.TypeInfo.TypeKind.CustomType,
+        new (string, System.Reflection.MemberInfo)[] {
 ("s", typeof(C).GetField("S")!)
     });
 }

--- a/test/Serde.Generation.Test/test_output/SerializeTests/IDictionaryImplGenerate#CSerdeTypeInfo.verified.cs
+++ b/test/Serde.Generation.Test/test_output/SerializeTests/IDictionaryImplGenerate#CSerdeTypeInfo.verified.cs
@@ -1,7 +1,9 @@
 ﻿//HintName: CSerdeTypeInfo.cs
 internal static class CSerdeTypeInfo
 {
-    internal static readonly Serde.TypeInfo TypeInfo = Serde.TypeInfo.Create(new (string, System.Reflection.MemberInfo)[] {
+    internal static readonly Serde.TypeInfo TypeInfo = Serde.TypeInfo.Create(
+        Serde.TypeInfo.TypeKind.CustomType,
+        new (string, System.Reflection.MemberInfo)[] {
 ("rDictionary", typeof(C).GetField("RDictionary")!)
     });
 }

--- a/test/Serde.Generation.Test/test_output/SerializeTests/MemberSkip#RgbSerdeTypeInfo.verified.cs
+++ b/test/Serde.Generation.Test/test_output/SerializeTests/MemberSkip#RgbSerdeTypeInfo.verified.cs
@@ -1,7 +1,9 @@
 ﻿//HintName: RgbSerdeTypeInfo.cs
 internal static class RgbSerdeTypeInfo
 {
-    internal static readonly Serde.TypeInfo TypeInfo = Serde.TypeInfo.Create(new (string, System.Reflection.MemberInfo)[] {
+    internal static readonly Serde.TypeInfo TypeInfo = Serde.TypeInfo.Create(
+        Serde.TypeInfo.TypeKind.CustomType,
+        new (string, System.Reflection.MemberInfo)[] {
 ("red", typeof(Rgb).GetField("Red")!),
 ("blue", typeof(Rgb).GetField("Blue")!)
     });

--- a/test/Serde.Generation.Test/test_output/SerializeTests/MemberSkipDeserialize#RgbSerdeTypeInfo.verified.cs
+++ b/test/Serde.Generation.Test/test_output/SerializeTests/MemberSkipDeserialize#RgbSerdeTypeInfo.verified.cs
@@ -1,7 +1,9 @@
 ﻿//HintName: RgbSerdeTypeInfo.cs
 internal static class RgbSerdeTypeInfo
 {
-    internal static readonly Serde.TypeInfo TypeInfo = Serde.TypeInfo.Create(new (string, System.Reflection.MemberInfo)[] {
+    internal static readonly Serde.TypeInfo TypeInfo = Serde.TypeInfo.Create(
+        Serde.TypeInfo.TypeKind.CustomType,
+        new (string, System.Reflection.MemberInfo)[] {
 ("red", typeof(Rgb).GetField("Red")!),
 ("green", typeof(Rgb).GetField("Green")!),
 ("blue", typeof(Rgb).GetField("Blue")!)

--- a/test/Serde.Generation.Test/test_output/SerializeTests/MemberSkipSerialize#RgbSerdeTypeInfo.verified.cs
+++ b/test/Serde.Generation.Test/test_output/SerializeTests/MemberSkipSerialize#RgbSerdeTypeInfo.verified.cs
@@ -1,7 +1,9 @@
 ﻿//HintName: RgbSerdeTypeInfo.cs
 internal static class RgbSerdeTypeInfo
 {
-    internal static readonly Serde.TypeInfo TypeInfo = Serde.TypeInfo.Create(new (string, System.Reflection.MemberInfo)[] {
+    internal static readonly Serde.TypeInfo TypeInfo = Serde.TypeInfo.Create(
+        Serde.TypeInfo.TypeKind.CustomType,
+        new (string, System.Reflection.MemberInfo)[] {
 ("red", typeof(Rgb).GetField("Red")!),
 ("green", typeof(Rgb).GetField("Green")!),
 ("blue", typeof(Rgb).GetField("Blue")!)

--- a/test/Serde.Generation.Test/test_output/SerializeTests/NestedArray#CSerdeTypeInfo.verified.cs
+++ b/test/Serde.Generation.Test/test_output/SerializeTests/NestedArray#CSerdeTypeInfo.verified.cs
@@ -1,7 +1,9 @@
 ﻿//HintName: CSerdeTypeInfo.cs
 internal static class CSerdeTypeInfo
 {
-    internal static readonly Serde.TypeInfo TypeInfo = Serde.TypeInfo.Create(new (string, System.Reflection.MemberInfo)[] {
+    internal static readonly Serde.TypeInfo TypeInfo = Serde.TypeInfo.Create(
+        Serde.TypeInfo.TypeKind.CustomType,
+        new (string, System.Reflection.MemberInfo)[] {
 ("nestedArr", typeof(C).GetField("NestedArr")!)
     });
 }

--- a/test/Serde.Generation.Test/test_output/SerializeTests/NestedArray2#CSerdeTypeInfo.verified.cs
+++ b/test/Serde.Generation.Test/test_output/SerializeTests/NestedArray2#CSerdeTypeInfo.verified.cs
@@ -1,7 +1,9 @@
 ﻿//HintName: CSerdeTypeInfo.cs
 internal static class CSerdeTypeInfo
 {
-    internal static readonly Serde.TypeInfo TypeInfo = Serde.TypeInfo.Create(new (string, System.Reflection.MemberInfo)[] {
+    internal static readonly Serde.TypeInfo TypeInfo = Serde.TypeInfo.Create(
+        Serde.TypeInfo.TypeKind.CustomType,
+        new (string, System.Reflection.MemberInfo)[] {
 ("nestedArr", typeof(C).GetField("NestedArr")!)
     });
 }

--- a/test/Serde.Generation.Test/test_output/SerializeTests/NestedPartialClasses#A.B.C.DSerdeTypeInfo.verified.cs
+++ b/test/Serde.Generation.Test/test_output/SerializeTests/NestedPartialClasses#A.B.C.DSerdeTypeInfo.verified.cs
@@ -7,7 +7,9 @@ partial class A
 {
     internal static class DSerdeTypeInfo
 {
-    internal static readonly Serde.TypeInfo TypeInfo = Serde.TypeInfo.Create(new (string, System.Reflection.MemberInfo)[] {
+    internal static readonly Serde.TypeInfo TypeInfo = Serde.TypeInfo.Create(
+        Serde.TypeInfo.TypeKind.CustomType,
+        new (string, System.Reflection.MemberInfo)[] {
 ("field", typeof(A.B.C.D).GetField("Field")!)
     });
 }

--- a/test/Serde.Generation.Test/test_output/SerializeTests/NullableFields#SSerdeTypeInfo.verified.cs
+++ b/test/Serde.Generation.Test/test_output/SerializeTests/NullableFields#SSerdeTypeInfo.verified.cs
@@ -1,7 +1,9 @@
 ﻿//HintName: SSerdeTypeInfo.cs
 internal static class SSerdeTypeInfo
 {
-    internal static readonly Serde.TypeInfo TypeInfo = Serde.TypeInfo.Create(new (string, System.Reflection.MemberInfo)[] {
+    internal static readonly Serde.TypeInfo TypeInfo = Serde.TypeInfo.Create(
+        Serde.TypeInfo.TypeKind.CustomType,
+        new (string, System.Reflection.MemberInfo)[] {
 ("fI", typeof(S<,,>).GetField("FI")!),
 ("f1", typeof(S<,,>).GetField("F1")!),
 ("f2", typeof(S<,,>).GetField("F2")!),

--- a/test/Serde.Generation.Test/test_output/SerializeTests/NullableRefFields#SSerdeTypeInfo.verified.cs
+++ b/test/Serde.Generation.Test/test_output/SerializeTests/NullableRefFields#SSerdeTypeInfo.verified.cs
@@ -1,7 +1,9 @@
 ﻿//HintName: SSerdeTypeInfo.cs
 internal static class SSerdeTypeInfo
 {
-    internal static readonly Serde.TypeInfo TypeInfo = Serde.TypeInfo.Create(new (string, System.Reflection.MemberInfo)[] {
+    internal static readonly Serde.TypeInfo TypeInfo = Serde.TypeInfo.Create(
+        Serde.TypeInfo.TypeKind.CustomType,
+        new (string, System.Reflection.MemberInfo)[] {
 ("fS", typeof(S<,,,,>).GetField("FS")!),
 ("f1", typeof(S<,,,,>).GetField("F1")!),
 ("f2", typeof(S<,,,,>).GetField("F2")!),

--- a/test/Serde.Generation.Test/test_output/SerializeTests/Rgb#RgbSerdeTypeInfo.verified.cs
+++ b/test/Serde.Generation.Test/test_output/SerializeTests/Rgb#RgbSerdeTypeInfo.verified.cs
@@ -1,7 +1,9 @@
 ﻿//HintName: RgbSerdeTypeInfo.cs
 internal static class RgbSerdeTypeInfo
 {
-    internal static readonly Serde.TypeInfo TypeInfo = Serde.TypeInfo.Create(new (string, System.Reflection.MemberInfo)[] {
+    internal static readonly Serde.TypeInfo TypeInfo = Serde.TypeInfo.Create(
+        Serde.TypeInfo.TypeKind.CustomType,
+        new (string, System.Reflection.MemberInfo)[] {
 ("red", typeof(Rgb).GetField("Red")!),
 ("green", typeof(Rgb).GetField("Green")!),
 ("blue", typeof(Rgb).GetField("Blue")!)

--- a/test/Serde.Generation.Test/test_output/SerializeTests/TypeDoesntImplementISerialize#S1SerdeTypeInfo.verified.cs
+++ b/test/Serde.Generation.Test/test_output/SerializeTests/TypeDoesntImplementISerialize#S1SerdeTypeInfo.verified.cs
@@ -1,7 +1,9 @@
 ﻿//HintName: S1SerdeTypeInfo.cs
 internal static class S1SerdeTypeInfo
 {
-    internal static readonly Serde.TypeInfo TypeInfo = Serde.TypeInfo.Create(new (string, System.Reflection.MemberInfo)[] {
+    internal static readonly Serde.TypeInfo TypeInfo = Serde.TypeInfo.Create(
+        Serde.TypeInfo.TypeKind.CustomType,
+        new (string, System.Reflection.MemberInfo)[] {
 ("x", typeof(S1).GetField("X")!)
     });
 }

--- a/test/Serde.Generation.Test/test_output/SerializeTests/TypeWithArray#CSerdeTypeInfo.verified.cs
+++ b/test/Serde.Generation.Test/test_output/SerializeTests/TypeWithArray#CSerdeTypeInfo.verified.cs
@@ -1,7 +1,9 @@
 ﻿//HintName: CSerdeTypeInfo.cs
 internal static class CSerdeTypeInfo
 {
-    internal static readonly Serde.TypeInfo TypeInfo = Serde.TypeInfo.Create(new (string, System.Reflection.MemberInfo)[] {
+    internal static readonly Serde.TypeInfo TypeInfo = Serde.TypeInfo.Create(
+        Serde.TypeInfo.TypeKind.CustomType,
+        new (string, System.Reflection.MemberInfo)[] {
 ("intArr", typeof(C).GetField("IntArr")!)
     });
 }

--- a/test/Serde.Generation.Test/test_output/SerializeTests/WrongGenericWrapperForm#CSerdeTypeInfo.verified.cs
+++ b/test/Serde.Generation.Test/test_output/SerializeTests/WrongGenericWrapperForm#CSerdeTypeInfo.verified.cs
@@ -1,7 +1,9 @@
 ﻿//HintName: CSerdeTypeInfo.cs
 internal static class CSerdeTypeInfo
 {
-    internal static readonly Serde.TypeInfo TypeInfo = Serde.TypeInfo.Create(new (string, System.Reflection.MemberInfo)[] {
+    internal static readonly Serde.TypeInfo TypeInfo = Serde.TypeInfo.Create(
+        Serde.TypeInfo.TypeKind.CustomType,
+        new (string, System.Reflection.MemberInfo)[] {
 ("s", typeof(C).GetField("S")!)
     });
 }

--- a/test/Serde.Generation.Test/test_output/WrapperTests.AttributeWrapperTest/AddressSerdeTypeInfo.verified.cs
+++ b/test/Serde.Generation.Test/test_output/WrapperTests.AttributeWrapperTest/AddressSerdeTypeInfo.verified.cs
@@ -1,7 +1,9 @@
 ﻿//HintName: AddressSerdeTypeInfo.cs
 internal static class AddressSerdeTypeInfo
 {
-    internal static readonly Serde.TypeInfo TypeInfo = Serde.TypeInfo.Create(new (string, System.Reflection.MemberInfo)[] {
+    internal static readonly Serde.TypeInfo TypeInfo = Serde.TypeInfo.Create(
+        Serde.TypeInfo.TypeKind.CustomType,
+        new (string, System.Reflection.MemberInfo)[] {
 ("name", typeof(Address).GetField("Name")!),
 ("line1", typeof(Address).GetField("Line1")!),
 ("city", typeof(Address).GetField("City")!),

--- a/test/Serde.Generation.Test/test_output/WrapperTests.GenerateSerdeWrap/BIND_OPTSSerdeTypeInfo.verified.cs
+++ b/test/Serde.Generation.Test/test_output/WrapperTests.GenerateSerdeWrap/BIND_OPTSSerdeTypeInfo.verified.cs
@@ -1,7 +1,9 @@
 ﻿//HintName: BIND_OPTSSerdeTypeInfo.cs
 internal static class BIND_OPTSSerdeTypeInfo
 {
-    internal static readonly Serde.TypeInfo TypeInfo = Serde.TypeInfo.Create(new (string, System.Reflection.MemberInfo)[] {
+    internal static readonly Serde.TypeInfo TypeInfo = Serde.TypeInfo.Create(
+        Serde.TypeInfo.TypeKind.CustomType,
+        new (string, System.Reflection.MemberInfo)[] {
 ("cbStruct", typeof(System.Runtime.InteropServices.ComTypes.BIND_OPTS).GetField("cbStruct")!),
 ("dwTickCountDeadline", typeof(System.Runtime.InteropServices.ComTypes.BIND_OPTS).GetField("dwTickCountDeadline")!),
 ("grfFlags", typeof(System.Runtime.InteropServices.ComTypes.BIND_OPTS).GetField("grfFlags")!),

--- a/test/Serde.Generation.Test/test_output/WrapperTests.ImmutableArrayEnumDeserialize/Test.ChannelListSerdeTypeInfo.verified.cs
+++ b/test/Serde.Generation.Test/test_output/WrapperTests.ImmutableArrayEnumDeserialize/Test.ChannelListSerdeTypeInfo.verified.cs
@@ -2,7 +2,9 @@
 namespace Test;
 internal static class ChannelListSerdeTypeInfo
 {
-    internal static readonly Serde.TypeInfo TypeInfo = Serde.TypeInfo.Create(new (string, System.Reflection.MemberInfo)[] {
+    internal static readonly Serde.TypeInfo TypeInfo = Serde.TypeInfo.Create(
+        Serde.TypeInfo.TypeKind.CustomType,
+        new (string, System.Reflection.MemberInfo)[] {
 ("channels", typeof(Test.ChannelList).GetProperty("Channels")!)
     });
 }

--- a/test/Serde.Generation.Test/test_output/WrapperTests.ImmutableArrayEnumDeserialize/Test.ChannelSerdeTypeInfo.verified.cs
+++ b/test/Serde.Generation.Test/test_output/WrapperTests.ImmutableArrayEnumDeserialize/Test.ChannelSerdeTypeInfo.verified.cs
@@ -2,7 +2,9 @@
 namespace Test;
 internal static class ChannelSerdeTypeInfo
 {
-    internal static readonly Serde.TypeInfo TypeInfo = Serde.TypeInfo.Create(new (string, System.Reflection.MemberInfo)[] {
+    internal static readonly Serde.TypeInfo TypeInfo = Serde.TypeInfo.Create(
+        Serde.TypeInfo.TypeKind.CustomType,
+        new (string, System.Reflection.MemberInfo)[] {
 ("a", typeof(Test.Channel).GetField("A")!),
 ("b", typeof(Test.Channel).GetField("B")!),
 ("c", typeof(Test.Channel).GetField("C")!)

--- a/test/Serde.Generation.Test/test_output/WrapperTests.NestedDeserializeWrap/BIND_OPTSSerdeTypeInfo.verified.cs
+++ b/test/Serde.Generation.Test/test_output/WrapperTests.NestedDeserializeWrap/BIND_OPTSSerdeTypeInfo.verified.cs
@@ -1,7 +1,9 @@
 ﻿//HintName: BIND_OPTSSerdeTypeInfo.cs
 internal static class BIND_OPTSSerdeTypeInfo
 {
-    internal static readonly Serde.TypeInfo TypeInfo = Serde.TypeInfo.Create(new (string, System.Reflection.MemberInfo)[] {
+    internal static readonly Serde.TypeInfo TypeInfo = Serde.TypeInfo.Create(
+        Serde.TypeInfo.TypeKind.CustomType,
+        new (string, System.Reflection.MemberInfo)[] {
 ("cbStruct", typeof(System.Runtime.InteropServices.ComTypes.BIND_OPTS).GetField("cbStruct")!),
 ("dwTickCountDeadline", typeof(System.Runtime.InteropServices.ComTypes.BIND_OPTS).GetField("dwTickCountDeadline")!),
 ("grfFlags", typeof(System.Runtime.InteropServices.ComTypes.BIND_OPTS).GetField("grfFlags")!),

--- a/test/Serde.Generation.Test/test_output/WrapperTests.NestedDeserializeWrap/CSerdeTypeInfo.verified.cs
+++ b/test/Serde.Generation.Test/test_output/WrapperTests.NestedDeserializeWrap/CSerdeTypeInfo.verified.cs
@@ -1,7 +1,9 @@
 ﻿//HintName: CSerdeTypeInfo.cs
 internal static class CSerdeTypeInfo
 {
-    internal static readonly Serde.TypeInfo TypeInfo = Serde.TypeInfo.Create(new (string, System.Reflection.MemberInfo)[] {
+    internal static readonly Serde.TypeInfo TypeInfo = Serde.TypeInfo.Create(
+        Serde.TypeInfo.TypeKind.CustomType,
+        new (string, System.Reflection.MemberInfo)[] {
 ("s", typeof(C).GetField("S")!)
     });
 }

--- a/test/Serde.Generation.Test/test_output/WrapperTests.NestedExplicitWrapper/Outer.SectionSerdeTypeInfo.verified.cs
+++ b/test/Serde.Generation.Test/test_output/WrapperTests.NestedExplicitWrapper/Outer.SectionSerdeTypeInfo.verified.cs
@@ -3,7 +3,9 @@ partial class Outer
 {
     internal static class SectionSerdeTypeInfo
 {
-    internal static readonly Serde.TypeInfo TypeInfo = Serde.TypeInfo.Create(new (string, System.Reflection.MemberInfo)[] {
+    internal static readonly Serde.TypeInfo TypeInfo = Serde.TypeInfo.Create(
+        Serde.TypeInfo.TypeKind.CustomType,
+        new (string, System.Reflection.MemberInfo)[] {
 ("mask", typeof(System.Collections.Specialized.BitVector32.Section).GetProperty("Mask")!),
 ("offset", typeof(System.Collections.Specialized.BitVector32.Section).GetProperty("Offset")!)
     });

--- a/test/Serde.Generation.Test/test_output/WrapperTests.NestedExplicitWrapper/SSerdeTypeInfo.verified.cs
+++ b/test/Serde.Generation.Test/test_output/WrapperTests.NestedExplicitWrapper/SSerdeTypeInfo.verified.cs
@@ -1,7 +1,9 @@
 ﻿//HintName: SSerdeTypeInfo.cs
 internal static class SSerdeTypeInfo
 {
-    internal static readonly Serde.TypeInfo TypeInfo = Serde.TypeInfo.Create(new (string, System.Reflection.MemberInfo)[] {
+    internal static readonly Serde.TypeInfo TypeInfo = Serde.TypeInfo.Create(
+        Serde.TypeInfo.TypeKind.CustomType,
+        new (string, System.Reflection.MemberInfo)[] {
 ("sections", typeof(S).GetField("Sections")!)
     });
 }

--- a/test/Serde.Generation.Test/test_output/WrapperTests.PointWrap/PointSerdeTypeInfo.verified.cs
+++ b/test/Serde.Generation.Test/test_output/WrapperTests.PointWrap/PointSerdeTypeInfo.verified.cs
@@ -1,7 +1,9 @@
 ﻿//HintName: PointSerdeTypeInfo.cs
 internal static class PointSerdeTypeInfo
 {
-    internal static readonly Serde.TypeInfo TypeInfo = Serde.TypeInfo.Create(new (string, System.Reflection.MemberInfo)[] {
+    internal static readonly Serde.TypeInfo TypeInfo = Serde.TypeInfo.Create(
+        Serde.TypeInfo.TypeKind.CustomType,
+        new (string, System.Reflection.MemberInfo)[] {
 ("x", typeof(Point).GetField("X")!),
 ("y", typeof(Point).GetField("Y")!)
     });

--- a/test/Serde.Generation.Test/test_output/WrapperTests.PositionalRecordDeserialize/RSerdeTypeInfo.verified.cs
+++ b/test/Serde.Generation.Test/test_output/WrapperTests.PositionalRecordDeserialize/RSerdeTypeInfo.verified.cs
@@ -1,7 +1,9 @@
 ﻿//HintName: RSerdeTypeInfo.cs
 internal static class RSerdeTypeInfo
 {
-    internal static readonly Serde.TypeInfo TypeInfo = Serde.TypeInfo.Create(new (string, System.Reflection.MemberInfo)[] {
+    internal static readonly Serde.TypeInfo TypeInfo = Serde.TypeInfo.Create(
+        Serde.TypeInfo.TypeKind.CustomType,
+        new (string, System.Reflection.MemberInfo)[] {
 ("a", typeof(R).GetProperty("A")!),
 ("b", typeof(R).GetProperty("B")!)
     });

--- a/test/Serde.Generation.Test/test_output/WrapperTests.RecursiveType/Test.ParentSerdeTypeInfo.verified.cs
+++ b/test/Serde.Generation.Test/test_output/WrapperTests.RecursiveType/Test.ParentSerdeTypeInfo.verified.cs
@@ -2,7 +2,9 @@
 namespace Test;
 internal static class ParentSerdeTypeInfo
 {
-    internal static readonly Serde.TypeInfo TypeInfo = Serde.TypeInfo.Create(new (string, System.Reflection.MemberInfo)[] {
+    internal static readonly Serde.TypeInfo TypeInfo = Serde.TypeInfo.Create(
+        Serde.TypeInfo.TypeKind.CustomType,
+        new (string, System.Reflection.MemberInfo)[] {
 ("r", typeof(Test.Parent).GetProperty("R")!)
     });
 }

--- a/test/Serde.Generation.Test/test_output/WrapperTests.RecursiveType/Test.RecursiveSerdeTypeInfo.verified.cs
+++ b/test/Serde.Generation.Test/test_output/WrapperTests.RecursiveType/Test.RecursiveSerdeTypeInfo.verified.cs
@@ -2,7 +2,9 @@
 namespace Test;
 internal static class RecursiveSerdeTypeInfo
 {
-    internal static readonly Serde.TypeInfo TypeInfo = Serde.TypeInfo.Create(new (string, System.Reflection.MemberInfo)[] {
+    internal static readonly Serde.TypeInfo TypeInfo = Serde.TypeInfo.Create(
+        Serde.TypeInfo.TypeKind.CustomType,
+        new (string, System.Reflection.MemberInfo)[] {
 ("next", typeof(Recursive).GetProperty("Next")!)
     });
 }

--- a/test/Serde.Test/CustomImplTests.cs
+++ b/test/Serde.Test/CustomImplTests.cs
@@ -12,7 +12,7 @@ public sealed partial class CustomImplTests
     {
         public int Red, Green, Blue;
 
-        private static readonly TypeInfo s_fieldMap = TypeInfo.Create([
+        private static readonly TypeInfo s_fieldMap = TypeInfo.Create(TypeInfo.TypeKind.CustomType, [
             ("red", typeof(RgbWithFieldMap).GetField("Red")!),
             ("green", typeof(RgbWithFieldMap).GetField("Green")!),
             ("blue", typeof(RgbWithFieldMap).GetField("Blue")!)

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.AllInOne.ColorEnumSerdeTypeInfo.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.AllInOne.ColorEnumSerdeTypeInfo.cs
@@ -3,7 +3,9 @@ partial record AllInOne
 {
     internal static class ColorEnumSerdeTypeInfo
 {
-    internal static readonly Serde.TypeInfo TypeInfo = Serde.TypeInfo.Create(new (string, System.Reflection.MemberInfo)[] {
+    internal static readonly Serde.TypeInfo TypeInfo = Serde.TypeInfo.Create(
+        Serde.TypeInfo.TypeKind.CustomType,
+        new (string, System.Reflection.MemberInfo)[] {
 ("red", typeof(Serde.Test.AllInOne.ColorEnum).GetField("Red")!),
 ("blue", typeof(Serde.Test.AllInOne.ColorEnum).GetField("Blue")!),
 ("green", typeof(Serde.Test.AllInOne.ColorEnum).GetField("Green")!)

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.AllInOneSerdeTypeInfo.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.AllInOneSerdeTypeInfo.cs
@@ -1,7 +1,9 @@
 ﻿namespace Serde.Test;
 internal static class AllInOneSerdeTypeInfo
 {
-    internal static readonly Serde.TypeInfo TypeInfo = Serde.TypeInfo.Create(new (string, System.Reflection.MemberInfo)[] {
+    internal static readonly Serde.TypeInfo TypeInfo = Serde.TypeInfo.Create(
+        Serde.TypeInfo.TypeKind.CustomType,
+        new (string, System.Reflection.MemberInfo)[] {
 ("boolField", typeof(Serde.Test.AllInOne).GetField("BoolField")!),
 ("charField", typeof(Serde.Test.AllInOne).GetField("CharField")!),
 ("byteField", typeof(Serde.Test.AllInOne).GetField("ByteField")!),

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.CustomImplTests.RgbWithFieldMapSerdeTypeInfo.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.CustomImplTests.RgbWithFieldMapSerdeTypeInfo.cs
@@ -3,7 +3,9 @@ partial class CustomImplTests
 {
     internal static class RgbWithFieldMapSerdeTypeInfo
 {
-    internal static readonly Serde.TypeInfo TypeInfo = Serde.TypeInfo.Create(new (string, System.Reflection.MemberInfo)[] {
+    internal static readonly Serde.TypeInfo TypeInfo = Serde.TypeInfo.Create(
+        Serde.TypeInfo.TypeKind.CustomType,
+        new (string, System.Reflection.MemberInfo)[] {
 ("red", typeof(Serde.Test.CustomImplTests.RgbWithFieldMap).GetField("Red")!),
 ("green", typeof(Serde.Test.CustomImplTests.RgbWithFieldMap).GetField("Green")!),
 ("blue", typeof(Serde.Test.CustomImplTests.RgbWithFieldMap).GetField("Blue")!)

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.GenericWrapperTests.CustomArrayWrapExplicitOnTypeSerdeTypeInfo.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.GenericWrapperTests.CustomArrayWrapExplicitOnTypeSerdeTypeInfo.cs
@@ -3,7 +3,9 @@ partial class GenericWrapperTests
 {
     internal static class CustomArrayWrapExplicitOnTypeSerdeTypeInfo
 {
-    internal static readonly Serde.TypeInfo TypeInfo = Serde.TypeInfo.Create(new (string, System.Reflection.MemberInfo)[] {
+    internal static readonly Serde.TypeInfo TypeInfo = Serde.TypeInfo.Create(
+        Serde.TypeInfo.TypeKind.CustomType,
+        new (string, System.Reflection.MemberInfo)[] {
 ("a", typeof(Serde.Test.GenericWrapperTests.CustomArrayWrapExplicitOnType).GetField("A")!)
     });
 }

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.GenericWrapperTests.CustomImArrayExplicitWrapOnMemberSerdeTypeInfo.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.GenericWrapperTests.CustomImArrayExplicitWrapOnMemberSerdeTypeInfo.cs
@@ -3,7 +3,9 @@ partial class GenericWrapperTests
 {
     internal static class CustomImArrayExplicitWrapOnMemberSerdeTypeInfo
 {
-    internal static readonly Serde.TypeInfo TypeInfo = Serde.TypeInfo.Create(new (string, System.Reflection.MemberInfo)[] {
+    internal static readonly Serde.TypeInfo TypeInfo = Serde.TypeInfo.Create(
+        Serde.TypeInfo.TypeKind.CustomType,
+        new (string, System.Reflection.MemberInfo)[] {
 ("a", typeof(Serde.Test.GenericWrapperTests.CustomImArrayExplicitWrapOnMember).GetField("A")!)
     });
 }

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonDeserializeTests.DenyUnknownSerdeTypeInfo.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonDeserializeTests.DenyUnknownSerdeTypeInfo.cs
@@ -3,7 +3,9 @@ partial class JsonDeserializeTests
 {
     internal static class DenyUnknownSerdeTypeInfo
 {
-    internal static readonly Serde.TypeInfo TypeInfo = Serde.TypeInfo.Create(new (string, System.Reflection.MemberInfo)[] {
+    internal static readonly Serde.TypeInfo TypeInfo = Serde.TypeInfo.Create(
+        Serde.TypeInfo.TypeKind.CustomType,
+        new (string, System.Reflection.MemberInfo)[] {
 ("present", typeof(Serde.Test.JsonDeserializeTests.DenyUnknown).GetProperty("Present")!),
 ("missing", typeof(Serde.Test.JsonDeserializeTests.DenyUnknown).GetProperty("Missing")!)
     });

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonDeserializeTests.ExtraMembersSerdeTypeInfo.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonDeserializeTests.ExtraMembersSerdeTypeInfo.cs
@@ -3,7 +3,9 @@ partial class JsonDeserializeTests
 {
     internal static class ExtraMembersSerdeTypeInfo
 {
-    internal static readonly Serde.TypeInfo TypeInfo = Serde.TypeInfo.Create(new (string, System.Reflection.MemberInfo)[] {
+    internal static readonly Serde.TypeInfo TypeInfo = Serde.TypeInfo.Create(
+        Serde.TypeInfo.TypeKind.CustomType,
+        new (string, System.Reflection.MemberInfo)[] {
 ("b", typeof(Serde.Test.JsonDeserializeTests.ExtraMembers).GetField("b")!)
     });
 }

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonDeserializeTests.IdStructListSerdeTypeInfo.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonDeserializeTests.IdStructListSerdeTypeInfo.cs
@@ -3,7 +3,9 @@ partial class JsonDeserializeTests
 {
     internal static class IdStructListSerdeTypeInfo
 {
-    internal static readonly Serde.TypeInfo TypeInfo = Serde.TypeInfo.Create(new (string, System.Reflection.MemberInfo)[] {
+    internal static readonly Serde.TypeInfo TypeInfo = Serde.TypeInfo.Create(
+        Serde.TypeInfo.TypeKind.CustomType,
+        new (string, System.Reflection.MemberInfo)[] {
 ("count", typeof(Serde.Test.JsonDeserializeTests.IdStructList).GetProperty("Count")!),
 ("list", typeof(Serde.Test.JsonDeserializeTests.IdStructList).GetProperty("List")!)
     });

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonDeserializeTests.IdStructSerdeTypeInfo.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonDeserializeTests.IdStructSerdeTypeInfo.cs
@@ -3,7 +3,9 @@ partial class JsonDeserializeTests
 {
     internal static class IdStructSerdeTypeInfo
 {
-    internal static readonly Serde.TypeInfo TypeInfo = Serde.TypeInfo.Create(new (string, System.Reflection.MemberInfo)[] {
+    internal static readonly Serde.TypeInfo TypeInfo = Serde.TypeInfo.Create(
+        Serde.TypeInfo.TypeKind.CustomType,
+        new (string, System.Reflection.MemberInfo)[] {
 ("id", typeof(Serde.Test.JsonDeserializeTests.IdStruct).GetField("Id")!)
     });
 }

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonDeserializeTests.NullableFieldsSerdeTypeInfo.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonDeserializeTests.NullableFieldsSerdeTypeInfo.cs
@@ -3,7 +3,9 @@ partial class JsonDeserializeTests
 {
     internal static class NullableFieldsSerdeTypeInfo
 {
-    internal static readonly Serde.TypeInfo TypeInfo = Serde.TypeInfo.Create(new (string, System.Reflection.MemberInfo)[] {
+    internal static readonly Serde.TypeInfo TypeInfo = Serde.TypeInfo.Create(
+        Serde.TypeInfo.TypeKind.CustomType,
+        new (string, System.Reflection.MemberInfo)[] {
 ("s", typeof(Serde.Test.JsonDeserializeTests.NullableFields).GetField("S")!),
 ("dict", typeof(Serde.Test.JsonDeserializeTests.NullableFields).GetField("Dict")!)
     });

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonDeserializeTests.SetToNullSerdeTypeInfo.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonDeserializeTests.SetToNullSerdeTypeInfo.cs
@@ -3,7 +3,9 @@ partial class JsonDeserializeTests
 {
     internal static class SetToNullSerdeTypeInfo
 {
-    internal static readonly Serde.TypeInfo TypeInfo = Serde.TypeInfo.Create(new (string, System.Reflection.MemberInfo)[] {
+    internal static readonly Serde.TypeInfo TypeInfo = Serde.TypeInfo.Create(
+        Serde.TypeInfo.TypeKind.CustomType,
+        new (string, System.Reflection.MemberInfo)[] {
 ("present", typeof(Serde.Test.JsonDeserializeTests.SetToNull).GetProperty("Present")!),
 ("missing", typeof(Serde.Test.JsonDeserializeTests.SetToNull).GetProperty("Missing")!)
     });

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonDeserializeTests.SkipDeserializeSerdeTypeInfo.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonDeserializeTests.SkipDeserializeSerdeTypeInfo.cs
@@ -3,7 +3,9 @@ partial class JsonDeserializeTests
 {
     internal static class SkipDeserializeSerdeTypeInfo
 {
-    internal static readonly Serde.TypeInfo TypeInfo = Serde.TypeInfo.Create(new (string, System.Reflection.MemberInfo)[] {
+    internal static readonly Serde.TypeInfo TypeInfo = Serde.TypeInfo.Create(
+        Serde.TypeInfo.TypeKind.CustomType,
+        new (string, System.Reflection.MemberInfo)[] {
 ("required", typeof(Serde.Test.JsonDeserializeTests.SkipDeserialize).GetProperty("Required")!),
 ("skip", typeof(Serde.Test.JsonDeserializeTests.SkipDeserialize).GetProperty("Skip")!)
     });

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonDeserializeTests.ThrowMissingSerdeTypeInfo.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonDeserializeTests.ThrowMissingSerdeTypeInfo.cs
@@ -3,7 +3,9 @@ partial class JsonDeserializeTests
 {
     internal static class ThrowMissingSerdeTypeInfo
 {
-    internal static readonly Serde.TypeInfo TypeInfo = Serde.TypeInfo.Create(new (string, System.Reflection.MemberInfo)[] {
+    internal static readonly Serde.TypeInfo TypeInfo = Serde.TypeInfo.Create(
+        Serde.TypeInfo.TypeKind.CustomType,
+        new (string, System.Reflection.MemberInfo)[] {
 ("present", typeof(Serde.Test.JsonDeserializeTests.ThrowMissing).GetProperty("Present")!),
 ("missing", typeof(Serde.Test.JsonDeserializeTests.ThrowMissing).GetProperty("Missing")!)
     });

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonSerializerTests.NullableFieldsSerdeTypeInfo.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonSerializerTests.NullableFieldsSerdeTypeInfo.cs
@@ -3,7 +3,9 @@ partial class JsonSerializerTests
 {
     internal static class NullableFieldsSerdeTypeInfo
 {
-    internal static readonly Serde.TypeInfo TypeInfo = Serde.TypeInfo.Create(new (string, System.Reflection.MemberInfo)[] {
+    internal static readonly Serde.TypeInfo TypeInfo = Serde.TypeInfo.Create(
+        Serde.TypeInfo.TypeKind.CustomType,
+        new (string, System.Reflection.MemberInfo)[] {
 ("s", typeof(Serde.Test.JsonSerializerTests.NullableFields).GetField("S")!),
 ("d", typeof(Serde.Test.JsonSerializerTests.NullableFields).GetField("D")!)
     });

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.MaxSizeTypeSerdeTypeInfo.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.MaxSizeTypeSerdeTypeInfo.cs
@@ -1,7 +1,9 @@
 ﻿namespace Serde.Test;
 internal static class MaxSizeTypeSerdeTypeInfo
 {
-    internal static readonly Serde.TypeInfo TypeInfo = Serde.TypeInfo.Create(new (string, System.Reflection.MemberInfo)[] {
+    internal static readonly Serde.TypeInfo TypeInfo = Serde.TypeInfo.Create(
+        Serde.TypeInfo.TypeKind.CustomType,
+        new (string, System.Reflection.MemberInfo)[] {
 ("field1", typeof(Serde.Test.MaxSizeType).GetProperty("Field1")!),
 ("field2", typeof(Serde.Test.MaxSizeType).GetProperty("Field2")!),
 ("field3", typeof(Serde.Test.MaxSizeType).GetProperty("Field3")!),

--- a/test/Serde.Xml.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.AllInOne.ColorEnumSerdeTypeInfo.cs
+++ b/test/Serde.Xml.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.AllInOne.ColorEnumSerdeTypeInfo.cs
@@ -3,7 +3,9 @@ partial record AllInOne
 {
     internal static class ColorEnumSerdeTypeInfo
 {
-    internal static readonly Serde.TypeInfo TypeInfo = Serde.TypeInfo.Create(new (string, System.Reflection.MemberInfo)[] {
+    internal static readonly Serde.TypeInfo TypeInfo = Serde.TypeInfo.Create(
+        Serde.TypeInfo.TypeKind.CustomType,
+        new (string, System.Reflection.MemberInfo)[] {
 ("red", typeof(Serde.Test.AllInOne.ColorEnum).GetField("Red")!),
 ("blue", typeof(Serde.Test.AllInOne.ColorEnum).GetField("Blue")!),
 ("green", typeof(Serde.Test.AllInOne.ColorEnum).GetField("Green")!)

--- a/test/Serde.Xml.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.AllInOneSerdeTypeInfo.cs
+++ b/test/Serde.Xml.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.AllInOneSerdeTypeInfo.cs
@@ -1,7 +1,9 @@
 ﻿namespace Serde.Test;
 internal static class AllInOneSerdeTypeInfo
 {
-    internal static readonly Serde.TypeInfo TypeInfo = Serde.TypeInfo.Create(new (string, System.Reflection.MemberInfo)[] {
+    internal static readonly Serde.TypeInfo TypeInfo = Serde.TypeInfo.Create(
+        Serde.TypeInfo.TypeKind.CustomType,
+        new (string, System.Reflection.MemberInfo)[] {
 ("boolField", typeof(Serde.Test.AllInOne).GetField("BoolField")!),
 ("charField", typeof(Serde.Test.AllInOne).GetField("CharField")!),
 ("byteField", typeof(Serde.Test.AllInOne).GetField("ByteField")!),

--- a/test/Serde.Xml.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.SampleTest.AddressSerdeTypeInfo.cs
+++ b/test/Serde.Xml.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.SampleTest.AddressSerdeTypeInfo.cs
@@ -3,7 +3,9 @@ partial class SampleTest
 {
     internal static class AddressSerdeTypeInfo
 {
-    internal static readonly Serde.TypeInfo TypeInfo = Serde.TypeInfo.Create(new (string, System.Reflection.MemberInfo)[] {
+    internal static readonly Serde.TypeInfo TypeInfo = Serde.TypeInfo.Create(
+        Serde.TypeInfo.TypeKind.CustomType,
+        new (string, System.Reflection.MemberInfo)[] {
 ("Name", typeof(Serde.Test.SampleTest.Address).GetField("Name")!),
 ("Line1", typeof(Serde.Test.SampleTest.Address).GetField("Line1")!),
 ("City", typeof(Serde.Test.SampleTest.Address).GetField("City")!),

--- a/test/Serde.Xml.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.SampleTest.OrderedItemSerdeTypeInfo.cs
+++ b/test/Serde.Xml.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.SampleTest.OrderedItemSerdeTypeInfo.cs
@@ -3,7 +3,9 @@ partial class SampleTest
 {
     internal static class OrderedItemSerdeTypeInfo
 {
-    internal static readonly Serde.TypeInfo TypeInfo = Serde.TypeInfo.Create(new (string, System.Reflection.MemberInfo)[] {
+    internal static readonly Serde.TypeInfo TypeInfo = Serde.TypeInfo.Create(
+        Serde.TypeInfo.TypeKind.CustomType,
+        new (string, System.Reflection.MemberInfo)[] {
 ("ItemName", typeof(Serde.Test.SampleTest.OrderedItem).GetField("ItemName")!),
 ("Description", typeof(Serde.Test.SampleTest.OrderedItem).GetField("Description")!),
 ("UnitPrice", typeof(Serde.Test.SampleTest.OrderedItem).GetField("UnitPrice")!),

--- a/test/Serde.Xml.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.SampleTest.PurchaseOrderSerdeTypeInfo.cs
+++ b/test/Serde.Xml.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.SampleTest.PurchaseOrderSerdeTypeInfo.cs
@@ -3,7 +3,9 @@ partial class SampleTest
 {
     internal static class PurchaseOrderSerdeTypeInfo
 {
-    internal static readonly Serde.TypeInfo TypeInfo = Serde.TypeInfo.Create(new (string, System.Reflection.MemberInfo)[] {
+    internal static readonly Serde.TypeInfo TypeInfo = Serde.TypeInfo.Create(
+        Serde.TypeInfo.TypeKind.CustomType,
+        new (string, System.Reflection.MemberInfo)[] {
 ("ShipTo", typeof(Serde.Test.SampleTest.PurchaseOrder).GetField("ShipTo")!),
 ("OrderDate", typeof(Serde.Test.SampleTest.PurchaseOrder).GetField("OrderDate")!),
 ("Items", typeof(Serde.Test.SampleTest.PurchaseOrder).GetField("OrderedItems")!),

--- a/test/Serde.Xml.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.XmlTests.BoolStructSerdeTypeInfo.cs
+++ b/test/Serde.Xml.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.XmlTests.BoolStructSerdeTypeInfo.cs
@@ -3,7 +3,9 @@ partial class XmlTests
 {
     internal static class BoolStructSerdeTypeInfo
 {
-    internal static readonly Serde.TypeInfo TypeInfo = Serde.TypeInfo.Create(new (string, System.Reflection.MemberInfo)[] {
+    internal static readonly Serde.TypeInfo TypeInfo = Serde.TypeInfo.Create(
+        Serde.TypeInfo.TypeKind.CustomType,
+        new (string, System.Reflection.MemberInfo)[] {
 ("BoolField", typeof(Serde.Test.XmlTests.BoolStruct).GetField("BoolField")!)
     });
 }

--- a/test/Serde.Xml.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.XmlTests.MapTest1SerdeTypeInfo.cs
+++ b/test/Serde.Xml.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.XmlTests.MapTest1SerdeTypeInfo.cs
@@ -3,7 +3,9 @@ partial class XmlTests
 {
     internal static class MapTest1SerdeTypeInfo
 {
-    internal static readonly Serde.TypeInfo TypeInfo = Serde.TypeInfo.Create(new (string, System.Reflection.MemberInfo)[] {
+    internal static readonly Serde.TypeInfo TypeInfo = Serde.TypeInfo.Create(
+        Serde.TypeInfo.TypeKind.CustomType,
+        new (string, System.Reflection.MemberInfo)[] {
 ("MapField", typeof(Serde.Test.XmlTests.MapTest1).GetField("MapField")!)
     });
 }

--- a/test/Serde.Xml.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.XmlTests.NestedArraysSerdeTypeInfo.cs
+++ b/test/Serde.Xml.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.XmlTests.NestedArraysSerdeTypeInfo.cs
@@ -3,7 +3,9 @@ partial class XmlTests
 {
     internal static class NestedArraysSerdeTypeInfo
 {
-    internal static readonly Serde.TypeInfo TypeInfo = Serde.TypeInfo.Create(new (string, System.Reflection.MemberInfo)[] {
+    internal static readonly Serde.TypeInfo TypeInfo = Serde.TypeInfo.Create(
+        Serde.TypeInfo.TypeKind.CustomType,
+        new (string, System.Reflection.MemberInfo)[] {
 ("A", typeof(Serde.Test.XmlTests.NestedArrays).GetField("A")!)
     });
 }

--- a/test/Serde.Xml.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.XmlTests.StructWithIntFieldSerdeTypeInfo.cs
+++ b/test/Serde.Xml.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.XmlTests.StructWithIntFieldSerdeTypeInfo.cs
@@ -3,7 +3,9 @@ partial class XmlTests
 {
     internal static class StructWithIntFieldSerdeTypeInfo
 {
-    internal static readonly Serde.TypeInfo TypeInfo = Serde.TypeInfo.Create(new (string, System.Reflection.MemberInfo)[] {
+    internal static readonly Serde.TypeInfo TypeInfo = Serde.TypeInfo.Create(
+        Serde.TypeInfo.TypeKind.CustomType,
+        new (string, System.Reflection.MemberInfo)[] {
 ("X", typeof(Serde.Test.XmlTests.StructWithIntField).GetProperty("X")!)
     });
 }

--- a/test/Serde.Xml.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.XmlTests.TypeWithArrayFieldSerdeTypeInfo.cs
+++ b/test/Serde.Xml.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.XmlTests.TypeWithArrayFieldSerdeTypeInfo.cs
@@ -3,7 +3,9 @@ partial class XmlTests
 {
     internal static class TypeWithArrayFieldSerdeTypeInfo
 {
-    internal static readonly Serde.TypeInfo TypeInfo = Serde.TypeInfo.Create(new (string, System.Reflection.MemberInfo)[] {
+    internal static readonly Serde.TypeInfo TypeInfo = Serde.TypeInfo.Create(
+        Serde.TypeInfo.TypeKind.CustomType,
+        new (string, System.Reflection.MemberInfo)[] {
 ("ArrayField", typeof(Serde.Test.XmlTests.TypeWithArrayField).GetField("ArrayField")!)
     });
 }


### PR DESCRIPTION
Offers a simple replacement for both enumerables and dictionaries. TypeInfo now needs to track the kind of Type it's describing -- enumerables, dictionaries, primitive types, and custom types should all be handled differently.