### PR TITLE
Rename ISerdeInfo methods

### DIFF
--- a/src/serde-xml/XmlSerializer.cs
+++ b/src/serde-xml/XmlSerializer.cs
@@ -70,7 +70,7 @@ public sealed partial class XmlSerializer : ISerializer
 
     void ISerializer.SerializeEnumValue<T, U>(ISerdeInfo serdeInfo, int index, T value, U serialize)
     {
-        var name = serdeInfo.GetStringSerializeName(index);
+        var name = serdeInfo.GetFieldStringName(index);
         SerializeString(name);
     }
 
@@ -231,8 +231,8 @@ public sealed partial class XmlSerializer : ISerializer
         public void SerializeField<T, U>(ISerdeInfo typeInfo, int fieldIndex, T value, U impl)
             where U : ISerialize<T>
         {
-            var name = typeInfo.GetStringSerializeName(fieldIndex);
-            foreach (var attr in typeInfo.GetCustomAttributeData(fieldIndex))
+            var name = typeInfo.GetFieldStringName(fieldIndex);
+            foreach (var attr in typeInfo.GetFieldAttributes(fieldIndex))
             {
                 if (attr.AttributeType == typeof(XmlAttributeAttribute))
                 {

--- a/src/serde/ISerdeInfo.cs
+++ b/src/serde/ISerdeInfo.cs
@@ -1,7 +1,7 @@
 
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
-using System.Reflection.Metadata;
 
 namespace Serde;
 
@@ -21,25 +21,28 @@ public interface ISerdeInfo
     /// <summary>
     /// Get the field name as a string for the field at the given index. The index must be valid.
     /// </summary>
-    string GetStringSerializeName(int index);
+    string GetFieldStringName(int index);
 
     /// <summary>
     /// Get the field name as a UTF8 string for the field at the given index. The index must be valid.
     /// </summary>
-    Utf8Span GetSerializeName(int index);
+    Utf8Span GetFieldName(int index);
 
     /// <summary>
     /// Get the attributes for the field at the given index. The index must be valid. This list may be
     /// modified from the original set of attributes in source code or metadata to reflect only the
     /// attributes that are relevant to serialization or deserialization.
     /// </summary>
-    IList<CustomAttributeData> GetCustomAttributeData(int index);
+    IList<CustomAttributeData> GetFieldAttributes(int index);
 
     /// <summary>
     /// Search the fields for one with the given name and return its index. Returns
     /// <see cref="IDeserializeType.IndexNotFound"/> if not found.
     /// </summary>
     int TryGetIndex(Utf8Span fieldName);
+
+    [Experimental("SerdeExperimentalFieldInfo")]
+    ISerdeInfo GetFieldInfo(int index);
 
     public enum TypeKind
     {

--- a/src/serde/SerdeInfo.cs
+++ b/src/serde/SerdeInfo.cs
@@ -50,13 +50,16 @@ internal sealed record CollectionInfo(
 {
     public int FieldCount => 0;
 
-    public IList<CustomAttributeData> GetCustomAttributeData(int index)
+    public IList<CustomAttributeData> GetFieldAttributes(int index)
         => throw GetAOOR(index);
 
-    public Utf8Span GetSerializeName(int index)
+    public ISerdeInfo GetFieldInfo(int index)
         => throw GetAOOR(index);
 
-    public string GetStringSerializeName(int index)
+    public Utf8Span GetFieldName(int index)
+        => throw GetAOOR(index);
+
+    public string GetFieldStringName(int index)
         => throw GetAOOR(index);
 
     public int TryGetIndex(Utf8Span fieldName) => IDeserializeType.IndexNotFound;
@@ -75,16 +78,21 @@ internal sealed record WrapperSerdeInfo(
     public ISerdeInfo.TypeKind Kind => ISerdeInfo.TypeKind.CustomType;
     public int FieldCount => 1;
 
-    public Utf8Span GetSerializeName(int index)
-        => index == 0 ? "Value"u8 : throw new ArgumentOutOfRangeException(nameof(index));
+    public Utf8Span GetFieldName(int index)
+        => index == 0 ? "Value"u8 : throw GetOOR(index);
 
-    public string GetStringSerializeName(int index)
-        => index == 0 ? "Value" : throw new ArgumentOutOfRangeException(nameof(index));
+    public string GetFieldStringName(int index)
+        => index == 0 ? "Value" : throw GetOOR(index);
 
-    public IList<CustomAttributeData> GetCustomAttributeData(int index)
-        => index == 0 ? [] : throw new ArgumentOutOfRangeException(nameof(index));
+    public IList<CustomAttributeData> GetFieldAttributes(int index)
+        => index == 0 ? [] : throw GetOOR(index);
 
     public int TryGetIndex(Utf8Span fieldName) => fieldName == "Value"u8 ? 0 : IDeserializeType.IndexNotFound;
+
+    public ISerdeInfo GetFieldInfo(int index) => index == 0 ? WrappedInfo : throw GetOOR(index);
+
+    private ArgumentOutOfRangeException GetOOR(int index)
+        => new ArgumentOutOfRangeException(nameof(index), index, $"{TypeName} has only one field.");
 }
 
 /// <summary>
@@ -183,17 +191,17 @@ file sealed record TypeWithFieldsInfo : ISerdeInfo
     [Experimental("SerdeExperimentalFieldInfo")]
     public ISerdeInfo GetFieldInfo(int index) => _indexToInfo[index].FieldSerdeInfo;
 
-    public IList<CustomAttributeData> GetCustomAttributeData(int index)
+    public IList<CustomAttributeData> GetFieldAttributes(int index)
     {
         return _indexToInfo[index].CustomAttributesData;
     }
 
-    public ReadOnlySpan<byte> GetSerializeName(int index)
+    public ReadOnlySpan<byte> GetFieldName(int index)
     {
         return _nameToIndex[_indexToInfo[index].Utf8NameIndex].Utf8Name.Span;
     }
 
-    public string GetStringSerializeName(int index)
+    public string GetFieldStringName(int index)
     {
         return _indexToInfo[index].StringName;
     }

--- a/src/serde/Wrappers.cs
+++ b/src/serde/Wrappers.cs
@@ -11,17 +11,20 @@ namespace Serde
     {
         public ISerdeInfo.TypeKind Kind => ISerdeInfo.TypeKind.Primitive;
         public int FieldCount => 0;
-        public Utf8Span GetSerializeName(int index)
+        public Utf8Span GetFieldName(int index)
             => throw GetOOR(index);
-        public string GetStringSerializeName(int index)
+        public string GetFieldStringName(int index)
             => throw GetOOR(index);
-        public IList<System.Reflection.CustomAttributeData> GetCustomAttributeData(int index)
+        public IList<System.Reflection.CustomAttributeData> GetFieldAttributes(int index)
+            => throw GetOOR(index);
+
+        public int TryGetIndex(Utf8Span fieldName) => IDeserializeType.IndexNotFound;
+
+        public ISerdeInfo GetFieldInfo(int index)
             => throw GetOOR(index);
 
         private ArgumentOutOfRangeException GetOOR(int index)
             => new ArgumentOutOfRangeException(nameof(index), index, $"{TypeName} has no fields or properties.");
-
-        public int TryGetIndex(Utf8Span fieldName) => IDeserializeType.IndexNotFound;
     }
 
     public readonly struct IdWrap<T> : ISerialize<T>

--- a/src/serde/json/JsonSerializer.Serialize.cs
+++ b/src/serde/json/JsonSerializer.Serialize.cs
@@ -64,7 +64,7 @@ namespace Serde.Json
 
         void ISerializer.SerializeEnumValue<T, U>(ISerdeInfo typeInfo, int index, T value, U serialize)
         {
-            var valueName = typeInfo.GetSerializeName(index);
+            var valueName = typeInfo.GetFieldName(index);
             _writer.WriteStringValue(valueName);
         }
 
@@ -196,7 +196,7 @@ namespace Serde.Json
     {
         void ISerializeType.SerializeField<T, U>(ISerdeInfo typeInfo, int fieldIndex, T value, U serialize)
         {
-            _writer.WritePropertyName(typeInfo.GetSerializeName(fieldIndex));
+            _writer.WritePropertyName(typeInfo.GetFieldName(fieldIndex));
             serialize.Serialize(value, this);
         }
 

--- a/src/serde/json/JsonValue.cs
+++ b/src/serde/json/JsonValue.cs
@@ -39,11 +39,13 @@ namespace Serde.Json
                 SerdeInfoProvider.GetInfo<JsonValue.Null>(),
             ];
 
-            public IList<CustomAttributeData> GetCustomAttributeData(int index) => throw GetOOR(index);
+            public IList<CustomAttributeData> GetFieldAttributes(int index) => throw GetOOR(index);
 
-            public Utf8Span GetSerializeName(int index) => throw GetOOR(index);
+            public ISerdeInfo GetFieldInfo(int index) => throw GetOOR(index);
 
-            public string GetStringSerializeName(int index) => throw GetOOR(index);
+            public Utf8Span GetFieldName(int index) => throw GetOOR(index);
+
+            public string GetFieldStringName(int index) => throw GetOOR(index);
 
             public int TryGetIndex(Utf8Span fieldName) => IDeserializeType.IndexNotFound;
 

--- a/test/Serde.Test/CollectionSerdeInfo.cs
+++ b/test/Serde.Test/CollectionSerdeInfo.cs
@@ -11,13 +11,15 @@ internal sealed record CollectionSerdeInfo(
 {
     public int FieldCount => 0;
 
-    public IList<CustomAttributeData> GetCustomAttributeData(int index)
+    public IList<CustomAttributeData> GetFieldAttributes(int index)
         => throw GetAOOR(index);
 
-    public ReadOnlySpan<byte> GetSerializeName(int index)
+    public ISerdeInfo GetFieldInfo(int index) => throw GetAOOR(index);
+
+    public ReadOnlySpan<byte> GetFieldName(int index)
         => throw GetAOOR(index);
 
-    public string GetStringSerializeName(int index)
+    public string GetFieldStringName(int index)
         => throw GetAOOR(index);
 
     public int TryGetIndex(ReadOnlySpan<byte> fieldName) => IDeserializeType.IndexNotFound;


### PR DESCRIPTION
Some of the methods for accessing field information were confusingly named. The new names all mention 'field' in the method name to differentiate.