### PR TITLE
Open up InvalidDeserializeValueException 

### DIFF
--- a/perf/bench/SampleTypes.cs
+++ b/perf/bench/SampleTypes.cs
@@ -133,7 +133,7 @@ namespace Benchmarks
 
             if (_r_assignedValid != 0b111111111)
             {
-                throw new Serde.InvalidDeserializeValueException("Not all members were assigned");
+                throw new Serde.DeserializeException("Not all members were assigned");
             }
 
             var newType = new Benchmarks.Location()

--- a/perf/bench/SampleTypes.cs
+++ b/perf/bench/SampleTypes.cs
@@ -133,7 +133,7 @@ namespace Benchmarks
 
             if (_r_assignedValid != 0b111111111)
             {
-                throw new Serde.DeserializeException("Not all members were assigned");
+                throw Serde.DeserializeException.UnassignedMember();
             }
 
             var newType = new Benchmarks.Location()

--- a/src/serde/IDeserialize.cs
+++ b/src/serde/IDeserialize.cs
@@ -26,9 +26,17 @@ namespace Serde
     /// </summary>
     public class DeserializeException : Exception
     {
-        public DeserializeException(string msg)
+        internal DeserializeException(string msg)
         : base(msg)
         { }
+
+        public static DeserializeException UnassignedMember() => throw new DeserializeException("Not all members were assigned.");
+
+        public static DeserializeException UnknownMember(string name, ISerdeInfo info)
+            => new DeserializeException($"Could not find member named '{name ?? "<null>"}' in type '{info.Name}'.");
+
+        public static DeserializeException WrongItemCount(int expected, int actual)
+            => new DeserializeException($"Expected {expected} items, got {actual}.");
     }
 
     public interface IDeserializeVisitor<T>

--- a/src/serde/IDeserialize.cs
+++ b/src/serde/IDeserialize.cs
@@ -24,9 +24,9 @@ namespace Serde
     /// Thrown from implementations of <see cref="IDeserializer" />. Indicates that an unexpected
     /// value was seen in the input which cannot be converted to the target type.
     /// </summary>
-    public sealed class InvalidDeserializeValueException : Exception
+    public class DeserializeException : Exception
     {
-        public InvalidDeserializeValueException(string msg)
+        public DeserializeException(string msg)
         : base(msg)
         { }
     }
@@ -34,25 +34,25 @@ namespace Serde
     public interface IDeserializeVisitor<T>
     {
         string ExpectedTypeName { get; }
-        T VisitBool(bool b) => throw new InvalidDeserializeValueException("Expected type " + ExpectedTypeName);
+        T VisitBool(bool b) => throw new DeserializeException("Expected type " + ExpectedTypeName);
         T VisitChar(char c) => VisitString(c.ToString());
         T VisitByte(byte b) => VisitU64(b);
         T VisitU16(ushort u16) => VisitU64(u16);
         T VisitU32(uint u32) => VisitU64(u32);
-        T VisitU64(ulong u64) => throw new InvalidDeserializeValueException("Expected type " + ExpectedTypeName);
+        T VisitU64(ulong u64) => throw new DeserializeException("Expected type " + ExpectedTypeName);
         T VisitSByte(sbyte b) => VisitI64(b);
         T VisitI16(short i16) => VisitI64(i16);
         T VisitI32(int i32) => VisitI64(i32);
-        T VisitI64(long i64) => throw new InvalidDeserializeValueException("Expected type " + ExpectedTypeName);
+        T VisitI64(long i64) => throw new DeserializeException("Expected type " + ExpectedTypeName);
         T VisitFloat(float f) => VisitDouble(f);
-        T VisitDouble(double d) => throw new InvalidDeserializeValueException("Expected type " + ExpectedTypeName);
-        T VisitDecimal(decimal d) => throw new InvalidDeserializeValueException("Expected type " + ExpectedTypeName);
-        T VisitString(string s) => throw new InvalidDeserializeValueException("Expected type " + ExpectedTypeName);
-        T VisitUtf8Span(ReadOnlySpan<byte> s) => throw new InvalidDeserializeValueException("Expected type " + ExpectedTypeName);
+        T VisitDouble(double d) => throw new DeserializeException("Expected type " + ExpectedTypeName);
+        T VisitDecimal(decimal d) => throw new DeserializeException("Expected type " + ExpectedTypeName);
+        T VisitString(string s) => throw new DeserializeException("Expected type " + ExpectedTypeName);
+        T VisitUtf8Span(ReadOnlySpan<byte> s) => throw new DeserializeException("Expected type " + ExpectedTypeName);
         T VisitEnumerable<D>(ref D d) where D : IDeserializeEnumerable
-            => throw new InvalidDeserializeValueException("Expected type " + ExpectedTypeName);
+            => throw new DeserializeException("Expected type " + ExpectedTypeName);
         T VisitDictionary<D>(ref D d) where D : IDeserializeDictionary
-            => throw new InvalidDeserializeValueException("Expected type " + ExpectedTypeName);
+            => throw new DeserializeException("Expected type " + ExpectedTypeName);
         T VisitNull() => throw new InvalidOperationException("Expected type " + ExpectedTypeName);
         T VisitNotNull(IDeserializer d) => throw new InvalidOperationException("Expected type " + ExpectedTypeName);
     }

--- a/src/serde/Wrappers.Dictionary.cs
+++ b/src/serde/Wrappers.Dictionary.cs
@@ -52,13 +52,13 @@ namespace Serde
                 {
                     if (!deCollection.TryReadValue<TValue, TValueWrap>(typeInfo, out var value))
                     {
-                        throw new InvalidDeserializeValueException("Expected value, but reached end of collection.");
+                        throw new DeserializeException("Expected value, but reached end of collection.");
                     }
                     dict.Add(key, value);
                 }
                 if (size >= 0 && size != dict.Count)
                 {
-                    throw new InvalidDeserializeValueException($"Expected {size} items, found {dict.Count}");
+                    throw new DeserializeException($"Expected {size} items, found {dict.Count}");
                 }
                 return dict;
             }

--- a/src/serde/Wrappers.List.cs
+++ b/src/serde/Wrappers.List.cs
@@ -58,7 +58,7 @@ namespace Serde
                     {
                         if (!deCollection.TryReadValue<T, TWrap>(typeInfo, out var value))
                         {
-                            throw new InvalidDeserializeValueException($"Expected array of size {size}, but only received {i} items");
+                            throw new DeserializeException($"Expected array of size {size}, but only received {i} items");
                         }
                         array[i] = value;
                     }
@@ -116,7 +116,7 @@ namespace Serde
                 }
                 if (size >= 0 && list.Count != size)
                 {
-                    throw new InvalidDeserializeValueException($"Expected enumerable of size {size}, but only received {list.Count} items");
+                    throw new DeserializeException($"Expected enumerable of size {size}, but only received {list.Count} items");
                 }
                 return list;
             }
@@ -163,7 +163,7 @@ namespace Serde
                 }
                 if (size >= 0 && builder.Count != size)
                 {
-                    throw new InvalidDeserializeValueException($"Expected {size} items, found {builder.Count}");
+                    throw new DeserializeException($"Expected {size} items, found {builder.Count}");
                 }
                 return builder.ToImmutable();
             }

--- a/src/serde/Wrappers.cs
+++ b/src/serde/Wrappers.cs
@@ -62,7 +62,7 @@ public readonly partial record struct CharWrap(char Value)
             {
                 return s[0];
             }
-            throw new InvalidDeserializeValueException("Expected type " + ExpectedTypeName);
+            throw new DeserializeException("Expected type " + ExpectedTypeName);
         }
         char IDeserializeVisitor<char>.VisitUtf8Span(Utf8Span s)
         {

--- a/src/serde/json/JsonDeserializer.cs
+++ b/src/serde/json/JsonDeserializer.cs
@@ -60,7 +60,7 @@ namespace Serde.Json
                     break;
 
                 default:
-                    throw new InvalidDeserializeValueException($"Could not deserialize '{reader.TokenType}");
+                    throw new DeserializeException($"Could not deserialize '{reader.TokenType}");
             }
             return result;
         }
@@ -80,7 +80,7 @@ namespace Serde.Json
 
             if (reader.TokenType != JsonTokenType.StartObject)
             {
-                throw new InvalidDeserializeValueException("Expected object start");
+                throw new DeserializeException("Expected object start");
             }
 
             var map = new DeDictionary(this);
@@ -100,7 +100,7 @@ namespace Serde.Json
             if (typeInfo.Kind == InfoKind.Dictionary && reader.TokenType != JsonTokenType.StartObject
                 || typeInfo.Kind == InfoKind.Enumerable && reader.TokenType != JsonTokenType.StartArray)
             {
-                throw new InvalidDeserializeValueException("Expected object start");
+                throw new DeserializeException("Expected object start");
             }
 
             return new DeCollection(this);
@@ -125,13 +125,13 @@ namespace Serde.Json
                     case JsonTokenType.EndArray:
                         if (typeInfo.Kind != InfoKind.Enumerable)
                         {
-                            throw new InvalidDeserializeValueException($"Unexpected end of array in type kind: {typeInfo.Kind}");
+                            throw new DeserializeException($"Unexpected end of array in type kind: {typeInfo.Kind}");
                         }
                         break;
                     case JsonTokenType.EndObject:
                         if (typeInfo.Kind != InfoKind.Dictionary)
                         {
-                            throw new InvalidDeserializeValueException($"Unexpected end of object in type kind: {typeInfo.Kind}");
+                            throw new DeserializeException($"Unexpected end of object in type kind: {typeInfo.Kind}");
                         }
                         break;
                     default:
@@ -171,7 +171,7 @@ namespace Serde.Json
 
             if (reader.TokenType != JsonTokenType.StartArray)
             {
-                throw new InvalidDeserializeValueException("Expected array start");
+                throw new DeserializeException("Expected array start");
             }
 
             var enumerable = new DeEnumerable(this);
@@ -311,7 +311,7 @@ namespace Serde.Json
 
                 if (reader.TokenType != JsonTokenType.StartObject)
                 {
-                    throw new InvalidDeserializeValueException("Expected object start");
+                    throw new DeserializeException("Expected object start");
                 }
             }
             else if (fieldMap.Kind != InfoKind.Enum)
@@ -422,7 +422,7 @@ namespace Serde.Json
         {
             if (!reader.Read())
             {
-                throw new InvalidDeserializeValueException("Unexpected end of stream");
+                throw new DeserializeException("Unexpected end of stream");
             }
         }
     }

--- a/test/Serde.Generation.Test/test_output/AllInOneTest.GeneratorTest/Serde.Test.AllInOne.ColorEnumWrap.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/AllInOneTest.GeneratorTest/Serde.Test.AllInOne.ColorEnumWrap.IDeserialize.verified.cs
@@ -17,7 +17,7 @@ namespace Serde.Test
                 int index;
                 if ((index = de.TryReadIndex(serdeInfo, out var errorName)) == IDeserializeType.IndexNotFound)
                 {
-                    throw new InvalidDeserializeValueException($"Unexpected value: {errorName}");
+                    throw Serde.DeserializeException.UnknownMember(errorName!, serdeInfo);
                 }
 
                 return index switch
@@ -25,7 +25,7 @@ namespace Serde.Test
                     0 => Serde.Test.AllInOne.ColorEnum.Red,
                     1 => Serde.Test.AllInOne.ColorEnum.Blue,
                     2 => Serde.Test.AllInOne.ColorEnum.Green,
-                    _ => throw new InvalidDeserializeValueException($"Unexpected index: {index}")};
+                    _ => throw new InvalidOperationException($"Unexpected index: {index}")};
             }
         }
     }

--- a/test/Serde.Generation.Test/test_output/AllInOneTest.GeneratorTest/Serde.Test.AllInOne.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/AllInOneTest.GeneratorTest/Serde.Test.AllInOne.IDeserialize.verified.cs
@@ -107,7 +107,7 @@ namespace Serde.Test
 
             if ((_r_assignedValid & 0b1111011111111111) != 0b1111011111111111)
             {
-                throw new Serde.InvalidDeserializeValueException("Not all members were assigned");
+                throw Serde.DeserializeException.UnassignedMember();
             }
 
             var newType = new Serde.Test.AllInOne()

--- a/test/Serde.Generation.Test/test_output/DeserializeTests.EnumMember/C.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/DeserializeTests.EnumMember/C.IDeserialize.verified.cs
@@ -45,7 +45,7 @@ partial class C : Serde.IDeserialize<C>
 
         if ((_r_assignedValid & 0b1111) != 0b1111)
         {
-            throw new Serde.InvalidDeserializeValueException("Not all members were assigned");
+            throw Serde.DeserializeException.UnassignedMember();
         }
 
         var newType = new C()

--- a/test/Serde.Generation.Test/test_output/DeserializeTests.EnumMember/ColorByteWrap.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/DeserializeTests.EnumMember/ColorByteWrap.IDeserialize.verified.cs
@@ -13,7 +13,7 @@ partial struct ColorByteWrap : Serde.IDeserialize<ColorByte>
         int index;
         if ((index = de.TryReadIndex(serdeInfo, out var errorName)) == IDeserializeType.IndexNotFound)
         {
-            throw new InvalidDeserializeValueException($"Unexpected value: {errorName}");
+            throw Serde.DeserializeException.UnknownMember(errorName!, serdeInfo);
         }
 
         return index switch
@@ -21,6 +21,6 @@ partial struct ColorByteWrap : Serde.IDeserialize<ColorByte>
             0 => ColorByte.Red,
             1 => ColorByte.Green,
             2 => ColorByte.Blue,
-            _ => throw new InvalidDeserializeValueException($"Unexpected index: {index}")};
+            _ => throw new InvalidOperationException($"Unexpected index: {index}")};
     }
 }

--- a/test/Serde.Generation.Test/test_output/DeserializeTests.EnumMember/ColorIntWrap.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/DeserializeTests.EnumMember/ColorIntWrap.IDeserialize.verified.cs
@@ -13,7 +13,7 @@ partial struct ColorIntWrap : Serde.IDeserialize<ColorInt>
         int index;
         if ((index = de.TryReadIndex(serdeInfo, out var errorName)) == IDeserializeType.IndexNotFound)
         {
-            throw new InvalidDeserializeValueException($"Unexpected value: {errorName}");
+            throw Serde.DeserializeException.UnknownMember(errorName!, serdeInfo);
         }
 
         return index switch
@@ -21,6 +21,6 @@ partial struct ColorIntWrap : Serde.IDeserialize<ColorInt>
             0 => ColorInt.Red,
             1 => ColorInt.Green,
             2 => ColorInt.Blue,
-            _ => throw new InvalidDeserializeValueException($"Unexpected index: {index}")};
+            _ => throw new InvalidOperationException($"Unexpected index: {index}")};
     }
 }

--- a/test/Serde.Generation.Test/test_output/DeserializeTests.EnumMember/ColorLongWrap.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/DeserializeTests.EnumMember/ColorLongWrap.IDeserialize.verified.cs
@@ -13,7 +13,7 @@ partial struct ColorLongWrap : Serde.IDeserialize<ColorLong>
         int index;
         if ((index = de.TryReadIndex(serdeInfo, out var errorName)) == IDeserializeType.IndexNotFound)
         {
-            throw new InvalidDeserializeValueException($"Unexpected value: {errorName}");
+            throw Serde.DeserializeException.UnknownMember(errorName!, serdeInfo);
         }
 
         return index switch
@@ -21,6 +21,6 @@ partial struct ColorLongWrap : Serde.IDeserialize<ColorLong>
             0 => ColorLong.Red,
             1 => ColorLong.Green,
             2 => ColorLong.Blue,
-            _ => throw new InvalidDeserializeValueException($"Unexpected index: {index}")};
+            _ => throw new InvalidOperationException($"Unexpected index: {index}")};
     }
 }

--- a/test/Serde.Generation.Test/test_output/DeserializeTests.EnumMember/ColorULongWrap.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/DeserializeTests.EnumMember/ColorULongWrap.IDeserialize.verified.cs
@@ -13,7 +13,7 @@ partial struct ColorULongWrap : Serde.IDeserialize<ColorULong>
         int index;
         if ((index = de.TryReadIndex(serdeInfo, out var errorName)) == IDeserializeType.IndexNotFound)
         {
-            throw new InvalidDeserializeValueException($"Unexpected value: {errorName}");
+            throw Serde.DeserializeException.UnknownMember(errorName!, serdeInfo);
         }
 
         return index switch
@@ -21,6 +21,6 @@ partial struct ColorULongWrap : Serde.IDeserialize<ColorULong>
             0 => ColorULong.Red,
             1 => ColorULong.Green,
             2 => ColorULong.Blue,
-            _ => throw new InvalidDeserializeValueException($"Unexpected index: {index}")};
+            _ => throw new InvalidOperationException($"Unexpected index: {index}")};
     }
 }

--- a/test/Serde.Generation.Test/test_output/DeserializeTests.NestedExplicitDeserializeWrapper/OptsWrap.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/DeserializeTests.NestedExplicitDeserializeWrapper/OptsWrap.IDeserialize.verified.cs
@@ -45,7 +45,7 @@ partial record struct OptsWrap : Serde.IDeserialize<System.Runtime.InteropServic
 
         if ((_r_assignedValid & 0b1111) != 0b1111)
         {
-            throw new Serde.InvalidDeserializeValueException("Not all members were assigned");
+            throw Serde.DeserializeException.UnassignedMember();
         }
 
         var newType = new System.Runtime.InteropServices.ComTypes.BIND_OPTS()

--- a/test/Serde.Generation.Test/test_output/DeserializeTests.NestedExplicitDeserializeWrapper/S.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/DeserializeTests.NestedExplicitDeserializeWrapper/S.IDeserialize.verified.cs
@@ -30,7 +30,7 @@ partial struct S : Serde.IDeserialize<S>
 
         if ((_r_assignedValid & 0b1) != 0b1)
         {
-            throw new Serde.InvalidDeserializeValueException("Not all members were assigned");
+            throw Serde.DeserializeException.UnassignedMember();
         }
 
         var newType = new S()

--- a/test/Serde.Generation.Test/test_output/DeserializeTests/Array#ArrayField.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/DeserializeTests/Array#ArrayField.IDeserialize.verified.cs
@@ -30,7 +30,7 @@ partial class ArrayField : Serde.IDeserialize<ArrayField>
 
         if ((_r_assignedValid & 0b1) != 0b1)
         {
-            throw new Serde.InvalidDeserializeValueException("Not all members were assigned");
+            throw Serde.DeserializeException.UnassignedMember();
         }
 
         var newType = new ArrayField()

--- a/test/Serde.Generation.Test/test_output/DeserializeTests/DeserializeMissing#SetToNull.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/DeserializeTests/DeserializeMissing#SetToNull.IDeserialize.verified.cs
@@ -40,7 +40,7 @@ partial record struct SetToNull : Serde.IDeserialize<SetToNull>
 
         if ((_r_assignedValid & 0b101) != 0b101)
         {
-            throw new Serde.InvalidDeserializeValueException("Not all members were assigned");
+            throw Serde.DeserializeException.UnassignedMember();
         }
 
         var newType = new SetToNull()

--- a/test/Serde.Generation.Test/test_output/DeserializeTests/DeserializeOnlyWrap#Wrap.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/DeserializeTests/DeserializeOnlyWrap#Wrap.IDeserialize.verified.cs
@@ -45,7 +45,7 @@ partial record struct Wrap : Serde.IDeserialize<System.Runtime.InteropServices.C
 
         if ((_r_assignedValid & 0b1111) != 0b1111)
         {
-            throw new Serde.InvalidDeserializeValueException("Not all members were assigned");
+            throw Serde.DeserializeException.UnassignedMember();
         }
 
         var newType = new System.Runtime.InteropServices.ComTypes.BIND_OPTS()

--- a/test/Serde.Generation.Test/test_output/DeserializeTests/MemberSkip#Rgb.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/DeserializeTests/MemberSkip#Rgb.IDeserialize.verified.cs
@@ -35,7 +35,7 @@ partial struct Rgb : Serde.IDeserialize<Rgb>
 
         if ((_r_assignedValid & 0b11) != 0b11)
         {
-            throw new Serde.InvalidDeserializeValueException("Not all members were assigned");
+            throw Serde.DeserializeException.UnassignedMember();
         }
 
         var newType = new Rgb()

--- a/test/Serde.Generation.Test/test_output/DeserializeTests/MemberSkipDeserialize#Rgb.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/DeserializeTests/MemberSkipDeserialize#Rgb.IDeserialize.verified.cs
@@ -36,7 +36,7 @@ partial struct Rgb : Serde.IDeserialize<Rgb>
 
         if ((_r_assignedValid & 0b101) != 0b101)
         {
-            throw new Serde.InvalidDeserializeValueException("Not all members were assigned");
+            throw Serde.DeserializeException.UnassignedMember();
         }
 
         var newType = new Rgb()

--- a/test/Serde.Generation.Test/test_output/DeserializeTests/MemberSkipSerialize#Rgb.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/DeserializeTests/MemberSkipSerialize#Rgb.IDeserialize.verified.cs
@@ -40,7 +40,7 @@ partial struct Rgb : Serde.IDeserialize<Rgb>
 
         if ((_r_assignedValid & 0b111) != 0b111)
         {
-            throw new Serde.InvalidDeserializeValueException("Not all members were assigned");
+            throw Serde.DeserializeException.UnassignedMember();
         }
 
         var newType = new Rgb()

--- a/test/Serde.Generation.Test/test_output/DeserializeTests/NestedPartialClasses#A.B.C.D.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/DeserializeTests/NestedPartialClasses#A.B.C.D.IDeserialize.verified.cs
@@ -36,7 +36,7 @@ partial class A
 
                     if ((_r_assignedValid & 0b1) != 0b1)
                     {
-                        throw new Serde.InvalidDeserializeValueException("Not all members were assigned");
+                        throw Serde.DeserializeException.UnassignedMember();
                     }
 
                     var newType = new A.B.C.D()

--- a/test/Serde.Generation.Test/test_output/DeserializeTests/NullableRefField#S.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/DeserializeTests/NullableRefField#S.IDeserialize.verified.cs
@@ -30,7 +30,7 @@ partial struct S : Serde.IDeserialize<S>
 
         if ((_r_assignedValid & 0b0) != 0b0)
         {
-            throw new Serde.InvalidDeserializeValueException("Not all members were assigned");
+            throw Serde.DeserializeException.UnassignedMember();
         }
 
         var newType = new S()

--- a/test/Serde.Generation.Test/test_output/DeserializeTests/Rgb#Rgb.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/DeserializeTests/Rgb#Rgb.IDeserialize.verified.cs
@@ -40,7 +40,7 @@ partial struct Rgb : Serde.IDeserialize<Rgb>
 
         if ((_r_assignedValid & 0b111) != 0b111)
         {
-            throw new Serde.InvalidDeserializeValueException("Not all members were assigned");
+            throw Serde.DeserializeException.UnassignedMember();
         }
 
         var newType = new Rgb()

--- a/test/Serde.Generation.Test/test_output/MemberFormatTests.EnumFormat/ColorEnumWrap.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/MemberFormatTests.EnumFormat/ColorEnumWrap.IDeserialize.verified.cs
@@ -13,7 +13,7 @@ partial struct ColorEnumWrap : Serde.IDeserialize<ColorEnum>
         int index;
         if ((index = de.TryReadIndex(serdeInfo, out var errorName)) == IDeserializeType.IndexNotFound)
         {
-            throw new InvalidDeserializeValueException($"Unexpected value: {errorName}");
+            throw Serde.DeserializeException.UnknownMember(errorName!, serdeInfo);
         }
 
         return index switch
@@ -21,6 +21,6 @@ partial struct ColorEnumWrap : Serde.IDeserialize<ColorEnum>
             0 => ColorEnum.Red,
             1 => ColorEnum.Green,
             2 => ColorEnum.Blue,
-            _ => throw new InvalidDeserializeValueException($"Unexpected index: {index}")};
+            _ => throw new InvalidOperationException($"Unexpected index: {index}")};
     }
 }

--- a/test/Serde.Generation.Test/test_output/MemberFormatTests.EnumValues/ColorEnumWrap.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/MemberFormatTests.EnumValues/ColorEnumWrap.IDeserialize.verified.cs
@@ -13,7 +13,7 @@ partial struct ColorEnumWrap : Serde.IDeserialize<ColorEnum>
         int index;
         if ((index = de.TryReadIndex(serdeInfo, out var errorName)) == IDeserializeType.IndexNotFound)
         {
-            throw new InvalidDeserializeValueException($"Unexpected value: {errorName}");
+            throw Serde.DeserializeException.UnknownMember(errorName!, serdeInfo);
         }
 
         return index switch
@@ -21,6 +21,6 @@ partial struct ColorEnumWrap : Serde.IDeserialize<ColorEnum>
             0 => ColorEnum.Red,
             1 => ColorEnum.Green,
             2 => ColorEnum.Blue,
-            _ => throw new InvalidDeserializeValueException($"Unexpected index: {index}")};
+            _ => throw new InvalidOperationException($"Unexpected index: {index}")};
     }
 }

--- a/test/Serde.Generation.Test/test_output/MemberFormatTests.EnumValues/S.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/MemberFormatTests.EnumValues/S.IDeserialize.verified.cs
@@ -30,7 +30,7 @@ partial struct S : Serde.IDeserialize<S>
 
         if ((_r_assignedValid & 0b1) != 0b1)
         {
-            throw new Serde.InvalidDeserializeValueException("Not all members were assigned");
+            throw Serde.DeserializeException.UnassignedMember();
         }
 
         var newType = new S()

--- a/test/Serde.Generation.Test/test_output/MemberFormatTests.EnumValues/S2.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/MemberFormatTests.EnumValues/S2.IDeserialize.verified.cs
@@ -30,7 +30,7 @@ partial struct S2 : Serde.IDeserialize<S2>
 
         if ((_r_assignedValid & 0b1) != 0b1)
         {
-            throw new Serde.InvalidDeserializeValueException("Not all members were assigned");
+            throw Serde.DeserializeException.UnassignedMember();
         }
 
         var newType = new S2()

--- a/test/Serde.Generation.Test/test_output/MemberFormatTests.KebabCase/S.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/MemberFormatTests.KebabCase/S.IDeserialize.verified.cs
@@ -35,7 +35,7 @@ partial struct S : Serde.IDeserialize<S>
 
         if ((_r_assignedValid & 0b11) != 0b11)
         {
-            throw new Serde.InvalidDeserializeValueException("Not all members were assigned");
+            throw Serde.DeserializeException.UnassignedMember();
         }
 
         var newType = new S()

--- a/test/Serde.Generation.Test/test_output/SerializeTests.NestedExplicitSerializeWrapper/OPTSWrap.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/SerializeTests.NestedExplicitSerializeWrapper/OPTSWrap.IDeserialize.verified.cs
@@ -45,7 +45,7 @@ partial record struct OPTSWrap : Serde.IDeserialize<System.Runtime.InteropServic
 
         if ((_r_assignedValid & 0b1111) != 0b1111)
         {
-            throw new Serde.InvalidDeserializeValueException("Not all members were assigned");
+            throw Serde.DeserializeException.UnassignedMember();
         }
 
         var newType = new System.Runtime.InteropServices.ComTypes.BIND_OPTS()

--- a/test/Serde.Generation.Test/test_output/SerializeTests.NestedExplicitSerializeWrapper/S.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/SerializeTests.NestedExplicitSerializeWrapper/S.IDeserialize.verified.cs
@@ -30,7 +30,7 @@ partial struct S : Serde.IDeserialize<S>
 
         if ((_r_assignedValid & 0b1) != 0b1)
         {
-            throw new Serde.InvalidDeserializeValueException("Not all members were assigned");
+            throw Serde.DeserializeException.UnassignedMember();
         }
 
         var newType = new S()

--- a/test/Serde.Generation.Test/test_output/WrapperTests.ExplicitInvalidGenericWrapper/Container.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/WrapperTests.ExplicitInvalidGenericWrapper/Container.IDeserialize.verified.cs
@@ -30,7 +30,7 @@ partial record Container : Serde.IDeserialize<Container>
 
         if ((_r_assignedValid & 0b0) != 0b0)
         {
-            throw new Serde.InvalidDeserializeValueException("Not all members were assigned");
+            throw Serde.DeserializeException.UnassignedMember();
         }
 
         var newType = new Container()

--- a/test/Serde.Generation.Test/test_output/WrapperTests.ExplicitInvalidGenericWrapper/Original.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/WrapperTests.ExplicitInvalidGenericWrapper/Original.IDeserialize.verified.cs
@@ -30,7 +30,7 @@ partial record struct Original : Serde.IDeserialize<Original>
 
         if ((_r_assignedValid & 0b1) != 0b1)
         {
-            throw new Serde.InvalidDeserializeValueException("Not all members were assigned");
+            throw Serde.DeserializeException.UnassignedMember();
         }
 
         var newType = new Original()

--- a/test/Serde.Generation.Test/test_output/WrapperTests.ExplicitNullableProxy/Container.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/WrapperTests.ExplicitNullableProxy/Container.IDeserialize.verified.cs
@@ -30,7 +30,7 @@ partial record Container : Serde.IDeserialize<Container>
 
         if ((_r_assignedValid & 0b0) != 0b0)
         {
-            throw new Serde.InvalidDeserializeValueException("Not all members were assigned");
+            throw Serde.DeserializeException.UnassignedMember();
         }
 
         var newType = new Container()

--- a/test/Serde.Generation.Test/test_output/WrapperTests.ExplicitNullableProxy/Original.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/WrapperTests.ExplicitNullableProxy/Original.IDeserialize.verified.cs
@@ -30,7 +30,7 @@ partial record struct Original : Serde.IDeserialize<Original>
 
         if ((_r_assignedValid & 0b1) != 0b1)
         {
-            throw new Serde.InvalidDeserializeValueException("Not all members were assigned");
+            throw Serde.DeserializeException.UnassignedMember();
         }
 
         var newType = new Original()

--- a/test/Serde.Generation.Test/test_output/WrapperTests.GenerateSerdeWrap/OPTSWrap.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/WrapperTests.GenerateSerdeWrap/OPTSWrap.IDeserialize.verified.cs
@@ -45,7 +45,7 @@ partial record struct OPTSWrap : Serde.IDeserialize<System.Runtime.InteropServic
 
         if ((_r_assignedValid & 0b1111) != 0b1111)
         {
-            throw new Serde.InvalidDeserializeValueException("Not all members were assigned");
+            throw Serde.DeserializeException.UnassignedMember();
         }
 
         var newType = new System.Runtime.InteropServices.ComTypes.BIND_OPTS()

--- a/test/Serde.Generation.Test/test_output/WrapperTests.ImmutableArrayEnumDeserialize/Test.ChannelList.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/WrapperTests.ImmutableArrayEnumDeserialize/Test.ChannelList.IDeserialize.verified.cs
@@ -32,7 +32,7 @@ namespace Test
 
             if ((_r_assignedValid & 0b1) != 0b1)
             {
-                throw new Serde.InvalidDeserializeValueException("Not all members were assigned");
+                throw Serde.DeserializeException.UnassignedMember();
             }
 
             var newType = new Test.ChannelList()

--- a/test/Serde.Generation.Test/test_output/WrapperTests.ImmutableArrayEnumDeserialize/Test.ChannelWrap.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/WrapperTests.ImmutableArrayEnumDeserialize/Test.ChannelWrap.IDeserialize.verified.cs
@@ -15,7 +15,7 @@ namespace Test
             int index;
             if ((index = de.TryReadIndex(serdeInfo, out var errorName)) == IDeserializeType.IndexNotFound)
             {
-                throw new InvalidDeserializeValueException($"Unexpected value: {errorName}");
+                throw Serde.DeserializeException.UnknownMember(errorName!, serdeInfo);
             }
 
             return index switch
@@ -23,7 +23,7 @@ namespace Test
                 0 => Test.Channel.A,
                 1 => Test.Channel.B,
                 2 => Test.Channel.C,
-                _ => throw new InvalidDeserializeValueException($"Unexpected index: {index}")};
+                _ => throw new InvalidOperationException($"Unexpected index: {index}")};
         }
     }
 }

--- a/test/Serde.Generation.Test/test_output/WrapperTests.NestedDeserializeWrap/C.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/WrapperTests.NestedDeserializeWrap/C.IDeserialize.verified.cs
@@ -30,7 +30,7 @@ partial class C : Serde.IDeserialize<C>
 
         if ((_r_assignedValid & 0b1) != 0b1)
         {
-            throw new Serde.InvalidDeserializeValueException("Not all members were assigned");
+            throw Serde.DeserializeException.UnassignedMember();
         }
 
         var newType = new C()

--- a/test/Serde.Generation.Test/test_output/WrapperTests.NestedDeserializeWrap/OPTSWrap.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/WrapperTests.NestedDeserializeWrap/OPTSWrap.IDeserialize.verified.cs
@@ -45,7 +45,7 @@ partial record struct OPTSWrap : Serde.IDeserialize<System.Runtime.InteropServic
 
         if ((_r_assignedValid & 0b1111) != 0b1111)
         {
-            throw new Serde.InvalidDeserializeValueException("Not all members were assigned");
+            throw Serde.DeserializeException.UnassignedMember();
         }
 
         var newType = new System.Runtime.InteropServices.ComTypes.BIND_OPTS()

--- a/test/Serde.Generation.Test/test_output/WrapperTests.PointWrap/PointWrap.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/WrapperTests.PointWrap/PointWrap.IDeserialize.verified.cs
@@ -35,7 +35,7 @@ partial struct PointWrap : Serde.IDeserialize<Point>
 
         if ((_r_assignedValid & 0b11) != 0b11)
         {
-            throw new Serde.InvalidDeserializeValueException("Not all members were assigned");
+            throw Serde.DeserializeException.UnassignedMember();
         }
 
         var newType = new Point()

--- a/test/Serde.Generation.Test/test_output/WrapperTests.PositionalRecordDeserialize/R.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/WrapperTests.PositionalRecordDeserialize/R.IDeserialize.verified.cs
@@ -35,7 +35,7 @@ partial record R : Serde.IDeserialize<R>
 
         if ((_r_assignedValid & 0b11) != 0b11)
         {
-            throw new Serde.InvalidDeserializeValueException("Not all members were assigned");
+            throw Serde.DeserializeException.UnassignedMember();
         }
 
         var newType = new R(_l_a, _l_b)

--- a/test/Serde.Generation.Test/test_output/WrapperTests.RecursiveType/Test.Parent.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/WrapperTests.RecursiveType/Test.Parent.IDeserialize.verified.cs
@@ -32,7 +32,7 @@ namespace Test
 
             if ((_r_assignedValid & 0b1) != 0b1)
             {
-                throw new Serde.InvalidDeserializeValueException("Not all members were assigned");
+                throw Serde.DeserializeException.UnassignedMember();
             }
 
             var newType = new Test.Parent()

--- a/test/Serde.Generation.Test/test_output/WrapperTests.RecursiveType/Test.RecursiveWrap.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/WrapperTests.RecursiveType/Test.RecursiveWrap.IDeserialize.verified.cs
@@ -32,7 +32,7 @@ namespace Test
 
             if ((_r_assignedValid & 0b0) != 0b0)
             {
-                throw new Serde.InvalidDeserializeValueException("Not all members were assigned");
+                throw Serde.DeserializeException.UnassignedMember();
             }
 
             var newType = new Recursive()

--- a/test/Serde.Test/GenericWrapperTests.cs
+++ b/test/Serde.Test/GenericWrapperTests.cs
@@ -129,7 +129,7 @@ public sealed partial class GenericWrapperTests
                 }
                 if (size >= 0 && builder.Count != size)
                 {
-                    throw new DeserializeException($"Expected {size} items, found {builder.Count}");
+                    throw DeserializeException.WrongItemCount(size, builder.Count);
                 }
                 return new CustomImArray<T>(builder.ToImmutable());
             }
@@ -176,7 +176,7 @@ public sealed partial class GenericWrapperTests
                 }
                 if (size >= 0 && builder.Count != size)
                 {
-                    throw new DeserializeException($"Expected {size} items, found {builder.Count}");
+                    throw DeserializeException.WrongItemCount(size, builder.Count);
                 }
                 return new CustomImArray2<T>(builder.ToImmutable());
             }

--- a/test/Serde.Test/GenericWrapperTests.cs
+++ b/test/Serde.Test/GenericWrapperTests.cs
@@ -129,7 +129,7 @@ public sealed partial class GenericWrapperTests
                 }
                 if (size >= 0 && builder.Count != size)
                 {
-                    throw new InvalidDeserializeValueException($"Expected {size} items, found {builder.Count}");
+                    throw new DeserializeException($"Expected {size} items, found {builder.Count}");
                 }
                 return new CustomImArray<T>(builder.ToImmutable());
             }
@@ -176,7 +176,7 @@ public sealed partial class GenericWrapperTests
                 }
                 if (size >= 0 && builder.Count != size)
                 {
-                    throw new InvalidDeserializeValueException($"Expected {size} items, found {builder.Count}");
+                    throw new DeserializeException($"Expected {size} items, found {builder.Count}");
                 }
                 return new CustomImArray2<T>(builder.ToImmutable());
             }

--- a/test/Serde.Test/JsonDeserializeTests.cs
+++ b/test/Serde.Test/JsonDeserializeTests.cs
@@ -219,7 +219,7 @@ namespace Serde.Test
     ""present"": ""abc"",
     ""extra"": ""def""
 }";
-            Assert.Throws<InvalidDeserializeValueException>(() => JsonSerializer.Deserialize<ThrowMissing>(src));
+            Assert.Throws<DeserializeException>(() => JsonSerializer.Deserialize<ThrowMissing>(src));
         }
 
         [GenerateDeserialize]
@@ -251,7 +251,7 @@ namespace Serde.Test
     ""present"": ""abc"",
     ""extra"": ""def""
 }";
-            Assert.Throws<InvalidDeserializeValueException>(() => JsonSerializer.Deserialize<DenyUnknown>(src));
+            Assert.Throws<DeserializeException>(() => JsonSerializer.Deserialize<DenyUnknown>(src));
         }
 
         [GenerateDeserialize]
@@ -340,13 +340,13 @@ namespace Serde.Test
                 int index;
                 if ((index = de.TryReadIndex(typeInfo, out var errorName)) == IDeserializeType.IndexNotFound)
                 {
-                    throw new InvalidDeserializeValueException($"Unexpected value: {errorName}");
+                    throw new DeserializeException($"Unexpected value: {errorName}");
                 }
                 return index switch {
                     0 => ColorEnum.Red,
                     1 => ColorEnum.Green,
                     2 => ColorEnum.Blue,
-                    _ => throw new InvalidDeserializeValueException($"Unexpected index: {index}")
+                    _ => throw new DeserializeException($"Unexpected index: {index}")
                 };
             }
         }

--- a/test/Serde.Test/JsonDeserializeTests.cs
+++ b/test/Serde.Test/JsonDeserializeTests.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using Serde.Json;
 using Xunit;
 using static Serde.Json.JsonValue;
+using Array = Serde.Json.JsonValue.Array;
 
 namespace Serde.Test
 {
@@ -340,13 +341,13 @@ namespace Serde.Test
                 int index;
                 if ((index = de.TryReadIndex(typeInfo, out var errorName)) == IDeserializeType.IndexNotFound)
                 {
-                    throw new DeserializeException($"Unexpected value: {errorName}");
+                    throw DeserializeException.UnknownMember(errorName!, typeInfo);
                 }
                 return index switch {
                     0 => ColorEnum.Red,
                     1 => ColorEnum.Green,
                     2 => ColorEnum.Blue,
-                    _ => throw new DeserializeException($"Unexpected index: {index}")
+                    _ => throw new System.InvalidOperationException($"Unexpected index: {index}")
                 };
             }
         }

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.AllInOne.ColorEnumWrap.IDeserialize.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.AllInOne.ColorEnumWrap.IDeserialize.cs
@@ -16,7 +16,7 @@ namespace Serde.Test
                 int index;
                 if ((index = de.TryReadIndex(serdeInfo, out var errorName)) == IDeserializeType.IndexNotFound)
                 {
-                    throw new InvalidDeserializeValueException($"Unexpected value: {errorName}");
+                    throw Serde.DeserializeException.UnknownMember(errorName!, serdeInfo);
                 }
 
                 return index switch
@@ -24,7 +24,7 @@ namespace Serde.Test
                     0 => Serde.Test.AllInOne.ColorEnum.Red,
                     1 => Serde.Test.AllInOne.ColorEnum.Blue,
                     2 => Serde.Test.AllInOne.ColorEnum.Green,
-                    _ => throw new InvalidDeserializeValueException($"Unexpected index: {index}")};
+                    _ => throw new InvalidOperationException($"Unexpected index: {index}")};
             }
         }
     }

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.AllInOne.IDeserialize.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.AllInOne.IDeserialize.cs
@@ -106,7 +106,7 @@ namespace Serde.Test
 
             if ((_r_assignedValid & 0b1111011111111111) != 0b1111011111111111)
             {
-                throw new Serde.InvalidDeserializeValueException("Not all members were assigned");
+                throw Serde.DeserializeException.UnassignedMember();
             }
 
             var newType = new Serde.Test.AllInOne()

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.GenericWrapperTests.CustomArrayWrapExplicitOnType.IDeserialize.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.GenericWrapperTests.CustomArrayWrapExplicitOnType.IDeserialize.cs
@@ -33,7 +33,7 @@ namespace Serde.Test
 
                 if ((_r_assignedValid & 0b1) != 0b1)
                 {
-                    throw new Serde.InvalidDeserializeValueException("Not all members were assigned");
+                    throw Serde.DeserializeException.UnassignedMember();
                 }
 
                 var newType = new Serde.Test.GenericWrapperTests.CustomArrayWrapExplicitOnType()

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.GenericWrapperTests.CustomImArrayExplicitWrapOnMember.IDeserialize.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.GenericWrapperTests.CustomImArrayExplicitWrapOnMember.IDeserialize.cs
@@ -33,7 +33,7 @@ namespace Serde.Test
 
                 if ((_r_assignedValid & 0b1) != 0b1)
                 {
-                    throw new Serde.InvalidDeserializeValueException("Not all members were assigned");
+                    throw Serde.DeserializeException.UnassignedMember();
                 }
 
                 var newType = new Serde.Test.GenericWrapperTests.CustomImArrayExplicitWrapOnMember()

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonDeserializeTests.DenyUnknown.IDeserialize.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonDeserializeTests.DenyUnknown.IDeserialize.cs
@@ -30,7 +30,7 @@ namespace Serde.Test
                             _r_assignedValid |= ((byte)1) << 1;
                             break;
                         case Serde.IDeserializeType.IndexNotFound:
-                            throw new InvalidDeserializeValueException("Unexpected field or property name in type DenyUnknown: '" + _l_errorName + "'");
+                            throw Serde.DeserializeException.UnknownMember(_l_errorName!, _l_serdeInfo);
                         default:
                             throw new InvalidOperationException("Unexpected index: " + _l_index_);
                     }
@@ -38,7 +38,7 @@ namespace Serde.Test
 
                 if ((_r_assignedValid & 0b1) != 0b1)
                 {
-                    throw new Serde.InvalidDeserializeValueException("Not all members were assigned");
+                    throw Serde.DeserializeException.UnassignedMember();
                 }
 
                 var newType = new Serde.Test.JsonDeserializeTests.DenyUnknown()

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonDeserializeTests.ExtraMembers.IDeserialize.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonDeserializeTests.ExtraMembers.IDeserialize.cs
@@ -33,7 +33,7 @@ namespace Serde.Test
 
                 if ((_r_assignedValid & 0b1) != 0b1)
                 {
-                    throw new Serde.InvalidDeserializeValueException("Not all members were assigned");
+                    throw Serde.DeserializeException.UnassignedMember();
                 }
 
                 var newType = new Serde.Test.JsonDeserializeTests.ExtraMembers()

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonDeserializeTests.IdStruct.IDeserialize.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonDeserializeTests.IdStruct.IDeserialize.cs
@@ -33,7 +33,7 @@ namespace Serde.Test
 
                 if ((_r_assignedValid & 0b1) != 0b1)
                 {
-                    throw new Serde.InvalidDeserializeValueException("Not all members were assigned");
+                    throw Serde.DeserializeException.UnassignedMember();
                 }
 
                 var newType = new Serde.Test.JsonDeserializeTests.IdStruct()

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonDeserializeTests.IdStructList.IDeserialize.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonDeserializeTests.IdStructList.IDeserialize.cs
@@ -38,7 +38,7 @@ namespace Serde.Test
 
                 if ((_r_assignedValid & 0b11) != 0b11)
                 {
-                    throw new Serde.InvalidDeserializeValueException("Not all members were assigned");
+                    throw Serde.DeserializeException.UnassignedMember();
                 }
 
                 var newType = new Serde.Test.JsonDeserializeTests.IdStructList()

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonDeserializeTests.NullableFields.IDeserialize.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonDeserializeTests.NullableFields.IDeserialize.cs
@@ -38,7 +38,7 @@ namespace Serde.Test
 
                 if ((_r_assignedValid & 0b10) != 0b10)
                 {
-                    throw new Serde.InvalidDeserializeValueException("Not all members were assigned");
+                    throw Serde.DeserializeException.UnassignedMember();
                 }
 
                 var newType = new Serde.Test.JsonDeserializeTests.NullableFields()

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonDeserializeTests.SetToNull.IDeserialize.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonDeserializeTests.SetToNull.IDeserialize.cs
@@ -38,7 +38,7 @@ namespace Serde.Test
 
                 if ((_r_assignedValid & 0b1) != 0b1)
                 {
-                    throw new Serde.InvalidDeserializeValueException("Not all members were assigned");
+                    throw Serde.DeserializeException.UnassignedMember();
                 }
 
                 var newType = new Serde.Test.JsonDeserializeTests.SetToNull()

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonDeserializeTests.SkipDeserialize.IDeserialize.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonDeserializeTests.SkipDeserialize.IDeserialize.cs
@@ -34,7 +34,7 @@ namespace Serde.Test
 
                 if ((_r_assignedValid & 0b1) != 0b1)
                 {
-                    throw new Serde.InvalidDeserializeValueException("Not all members were assigned");
+                    throw Serde.DeserializeException.UnassignedMember();
                 }
 
                 var newType = new Serde.Test.JsonDeserializeTests.SkipDeserialize()

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonDeserializeTests.ThrowMissing.IDeserialize.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonDeserializeTests.ThrowMissing.IDeserialize.cs
@@ -38,7 +38,7 @@ namespace Serde.Test
 
                 if ((_r_assignedValid & 0b11) != 0b11)
                 {
-                    throw new Serde.InvalidDeserializeValueException("Not all members were assigned");
+                    throw Serde.DeserializeException.UnassignedMember();
                 }
 
                 var newType = new Serde.Test.JsonDeserializeTests.ThrowMissing()

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonDeserializeTests.ThrowMissingFalse.IDeserialize.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonDeserializeTests.ThrowMissingFalse.IDeserialize.cs
@@ -38,7 +38,7 @@ namespace Serde.Test
 
                 if ((_r_assignedValid & 0b1) != 0b1)
                 {
-                    throw new Serde.InvalidDeserializeValueException("Not all members were assigned");
+                    throw Serde.DeserializeException.UnassignedMember();
                 }
 
                 var newType = new Serde.Test.JsonDeserializeTests.ThrowMissingFalse()

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.MaxSizeType.IDeserialize.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.MaxSizeType.IDeserialize.cs
@@ -346,7 +346,7 @@ namespace Serde.Test
 
             if ((_r_assignedValid & 0b1111111111111111111111111111111111111111111111111111111111111111) != 0b1111111111111111111111111111111111111111111111111111111111111111)
             {
-                throw new Serde.InvalidDeserializeValueException("Not all members were assigned");
+                throw Serde.DeserializeException.UnassignedMember();
             }
 
             var newType = new Serde.Test.MaxSizeType()

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.SerdeInfoTests.EmptyRecord.IDeserialize.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.SerdeInfoTests.EmptyRecord.IDeserialize.cs
@@ -28,7 +28,7 @@ namespace Serde.Test
 
                 if ((_r_assignedValid & 0b0) != 0b0)
                 {
-                    throw new Serde.InvalidDeserializeValueException("Not all members were assigned");
+                    throw Serde.DeserializeException.UnassignedMember();
                 }
 
                 var newType = new Serde.Test.SerdeInfoTests.EmptyRecord()

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.SerdeInfoTests.RgbProxy.IDeserialize.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.SerdeInfoTests.RgbProxy.IDeserialize.cs
@@ -43,7 +43,7 @@ namespace Serde.Test
 
                 if ((_r_assignedValid & 0b111) != 0b111)
                 {
-                    throw new Serde.InvalidDeserializeValueException("Not all members were assigned");
+                    throw Serde.DeserializeException.UnassignedMember();
                 }
 
                 var newType = new Serde.Test.SerdeInfoTests.Rgb()

--- a/test/Serde.Xml.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.AllInOne.ColorEnumWrap.IDeserialize.cs
+++ b/test/Serde.Xml.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.AllInOne.ColorEnumWrap.IDeserialize.cs
@@ -16,7 +16,7 @@ namespace Serde.Test
                 int index;
                 if ((index = de.TryReadIndex(serdeInfo, out var errorName)) == IDeserializeType.IndexNotFound)
                 {
-                    throw new InvalidDeserializeValueException($"Unexpected value: {errorName}");
+                    throw Serde.DeserializeException.UnknownMember(errorName!, serdeInfo);
                 }
 
                 return index switch
@@ -24,7 +24,7 @@ namespace Serde.Test
                     0 => Serde.Test.AllInOne.ColorEnum.Red,
                     1 => Serde.Test.AllInOne.ColorEnum.Blue,
                     2 => Serde.Test.AllInOne.ColorEnum.Green,
-                    _ => throw new InvalidDeserializeValueException($"Unexpected index: {index}")};
+                    _ => throw new InvalidOperationException($"Unexpected index: {index}")};
             }
         }
     }

--- a/test/Serde.Xml.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.AllInOne.IDeserialize.cs
+++ b/test/Serde.Xml.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.AllInOne.IDeserialize.cs
@@ -106,7 +106,7 @@ namespace Serde.Test
 
             if ((_r_assignedValid & 0b1111011111111111) != 0b1111011111111111)
             {
-                throw new Serde.InvalidDeserializeValueException("Not all members were assigned");
+                throw Serde.DeserializeException.UnassignedMember();
             }
 
             var newType = new Serde.Test.AllInOne()


### PR DESCRIPTION
Renames InvalidDeserializeValueException to DeserializeException and
unseals it. This will allow formats to define their own custom subtypes
of the exception.

Some helper methods have also been added to DeserializeException for
throwing common errors, including ones thrown by the source generator.