### PR TITLE
Rewrite UTF-8 JSON reader

### DIFF
--- a/perf/bench/Program.cs
+++ b/perf/bench/Program.cs
@@ -20,10 +20,13 @@ var loc2 = Serde.Json.JsonSerializer.Deserialize<Location, LocationWrap>(Locatio
 Console.WriteLine("Checking correctness of serialization: " + (loc1 == loc2));
 if (loc1 != loc2)
 {
-    throw new InvalidOperationException(@"""
+    throw new InvalidOperationException($"""
 Serialization is not correct
-STJ: {json1}
-Serde: {json2}
+STJ:
+{loc1}
+
+Serde:
+{loc2}
 """);
 }
 

--- a/src/generator/Generator.Deserialize.cs
+++ b/src/generator/Generator.Deserialize.cs
@@ -231,7 +231,10 @@ static {{typeFqn}} Serde.IDeserialize<{{typeFqn}}>.Deserialize(IDeserializer des
                     ? $"""
                     throw Serde.DeserializeException.UnknownMember(_l_errorName!, {typeInfoLocalName});
                     """
-                    : "break;";
+                    : """
+                    typeDeserialize.SkipValue();
+                    break;
+                    """;
                 foreach (var i in skippedIndices)
                 {
                     casesBuilder.AppendLine($"""

--- a/src/serde/IDeserialize.cs
+++ b/src/serde/IDeserialize.cs
@@ -107,9 +107,11 @@ namespace Serde
         int TryReadIndex(ISerdeInfo map, out string? errorName);
 
         V ReadValue<V, D>(int index) where D : IDeserialize<V>;
+
+        void SkipValue();
     }
 
-    public interface IDeserializer
+    public interface IDeserializer : IDisposable
     {
         T DeserializeAny<T>(IDeserializeVisitor<T> v);
         T DeserializeBool<T>(IDeserializeVisitor<T> v);

--- a/src/serde/ISerdeInfo.cs
+++ b/src/serde/ISerdeInfo.cs
@@ -70,7 +70,11 @@ public enum InfoKind
     /// Represents a closed union of types. Any type that returns this value from <see
     /// cref="ISerdeInfo.Kind"/> must also implement <see cref="IUnionSerdeInfo"/>.
     /// </summary>
-    Union
+    Union,
+    /// <summary>
+    /// Only used for skipping a value during deserialization.
+    /// </summary>
+    Skip
 }
 
 /// <summary>

--- a/src/serde/Wrappers.Dictionary.cs
+++ b/src/serde/Wrappers.Dictionary.cs
@@ -1,67 +1,116 @@
 using System.Collections.Generic;
+using System.Collections.Immutable;
 
-namespace Serde
+namespace Serde;
+
+internal static class DictSerdeInfo<TKey, TValue> where TKey : notnull
 {
-    internal static class DictSerdeInfo<TKey, TValue> where TKey : notnull
+    public static readonly ISerdeInfo Instance = SerdeInfo.MakeDictionary(typeof(Dictionary<TKey, TValue>).ToString());
+}
+
+public static class DictWrap
+{
+    public readonly struct SerializeImpl<TKey, TKeyWrap, TValue, TValueWrap> : ISerialize<Dictionary<TKey, TValue>>
+        where TKey : notnull
+        where TKeyWrap : struct, ISerialize<TKey>
+        where TValueWrap : struct, ISerialize<TValue>
     {
-        public static readonly ISerdeInfo Instance = SerdeInfo.MakeDictionary(typeof(Dictionary<TKey, TValue>).ToString());
+        public static ISerdeInfo SerdeInfo => DictSerdeInfo<TKey, TValue>.Instance;
+        public void Serialize(Dictionary<TKey, TValue> value, ISerializer serializer)
+        {
+            var typeInfo = DictSerdeInfo<TKey, TValue>.Instance;
+            var sd = serializer.SerializeCollection(typeInfo, value.Count);
+            foreach (var (k, v) in value)
+            {
+                sd.SerializeElement(k, default(TKeyWrap));
+                sd.SerializeElement(v, default(TValueWrap));
+            }
+            sd.End(typeInfo);
+        }
     }
 
-    public static class DictWrap
+    public readonly struct DeserializeImpl<TKey, TKeyWrap, TValue, TValueWrap> : IDeserialize<Dictionary<TKey, TValue>>
+        where TKey : notnull
+        where TKeyWrap : IDeserialize<TKey>
+        where TValueWrap : IDeserialize<TValue>
     {
-        public readonly struct SerializeImpl<TKey, TKeyWrap, TValue, TValueWrap> : ISerialize<Dictionary<TKey, TValue>>
-            where TKey : notnull
-            where TKeyWrap : struct, ISerialize<TKey>
-            where TValueWrap : struct, ISerialize<TValue>
+        public static ISerdeInfo SerdeInfo => DictSerdeInfo<TKey, TValue>.Instance;
+        public static Dictionary<TKey, TValue> Deserialize(IDeserializer deserializer)
         {
-            public static ISerdeInfo SerdeInfo => DictSerdeInfo<TKey, TValue>.Instance;
-            public void Serialize(Dictionary<TKey, TValue> value, ISerializer serializer)
+            var typeInfo = DictSerdeInfo<TKey, TValue>.Instance;
+            var deCollection = deserializer.DeserializeCollection(typeInfo);
+            Dictionary<TKey, TValue> dict;
+            if (deCollection.SizeOpt is int size)
             {
-                var typeInfo = DictSerdeInfo<TKey, TValue>.Instance;
-                var sd = serializer.SerializeCollection(typeInfo, value.Count);
-                foreach (var (k, v) in value)
-                {
-                    sd.SerializeElement(k, default(TKeyWrap));
-                    sd.SerializeElement(v, default(TValueWrap));
-                }
-                sd.End(typeInfo);
+                dict = new(size);
             }
+            else
+            {
+                size = -1; // Set initial size to unknown
+                dict = new();
+            }
+            while (deCollection.TryReadValue<TKey, TKeyWrap>(typeInfo, out var key))
+            {
+                if (!deCollection.TryReadValue<TValue, TValueWrap>(typeInfo, out var value))
+                {
+                    throw new DeserializeException("Expected value, but reached end of collection.");
+                }
+                dict.Add(key, value);
+            }
+            if (size >= 0 && size != dict.Count)
+            {
+                throw new DeserializeException($"Expected {size} items, found {dict.Count}");
+            }
+            return dict;
         }
+    }
+}
 
-        public readonly struct DeserializeImpl<TKey, TKeyWrap, TValue, TValueWrap> : IDeserialize<Dictionary<TKey, TValue>>
-            where TKey : notnull
-            where TKeyWrap : IDeserialize<TKey>
-            where TValueWrap : IDeserialize<TValue>
+public static class ImmutableDictWrap
+{
+    public readonly struct SerializeImpl<TKey, TKeyWrap, TValue, TValueWrap> : ISerialize<ImmutableDictionary<TKey, TValue>>
+        where TKey : notnull
+        where TKeyWrap : struct, ISerialize<TKey>
+        where TValueWrap : struct, ISerialize<TValue>
+    {
+        public static ISerdeInfo SerdeInfo => DictSerdeInfo<TKey, TValue>.Instance;
+        public void Serialize(ImmutableDictionary<TKey, TValue> value, ISerializer serializer)
         {
-            public static ISerdeInfo SerdeInfo => DictSerdeInfo<TKey, TValue>.Instance;
-            public static Dictionary<TKey, TValue> Deserialize(IDeserializer deserializer)
+            var typeInfo = DictSerdeInfo<TKey, TValue>.Instance;
+            var sd = serializer.SerializeCollection(typeInfo, value.Count);
+            foreach (var (k, v) in value)
             {
-                var typeInfo = DictSerdeInfo<TKey, TValue>.Instance;
-                var deCollection = deserializer.DeserializeCollection(typeInfo);
-                Dictionary<TKey, TValue> dict;
-                if (deCollection.SizeOpt is int size)
-                {
-                    dict = new(size);
-                }
-                else
-                {
-                    size = -1; // Set initial size to unknown
-                    dict = new();
-                }
-                while (deCollection.TryReadValue<TKey, TKeyWrap>(typeInfo, out var key))
-                {
-                    if (!deCollection.TryReadValue<TValue, TValueWrap>(typeInfo, out var value))
-                    {
-                        throw new DeserializeException("Expected value, but reached end of collection.");
-                    }
-                    dict.Add(key, value);
-                }
-                if (size >= 0 && size != dict.Count)
-                {
-                    throw new DeserializeException($"Expected {size} items, found {dict.Count}");
-                }
-                return dict;
+                sd.SerializeElement(k, default(TKeyWrap));
+                sd.SerializeElement(v, default(TValueWrap));
             }
+            sd.End(typeInfo);
+        }
+    }
+
+    public readonly struct DeserializeImpl<TKey, TKeyWrap, TValue, TValueWrap> : IDeserialize<ImmutableDictionary<TKey, TValue>>
+        where TKey : notnull
+        where TKeyWrap : IDeserialize<TKey>
+        where TValueWrap : IDeserialize<TValue>
+    {
+        public static ISerdeInfo SerdeInfo => DictSerdeInfo<TKey, TValue>.Instance;
+        public static ImmutableDictionary<TKey, TValue> Deserialize(IDeserializer deserializer)
+        {
+            var typeInfo = DictSerdeInfo<TKey, TValue>.Instance;
+            var deCollection = deserializer.DeserializeCollection(typeInfo);
+            var builder = ImmutableDictionary.CreateBuilder<TKey, TValue>();
+            while (deCollection.TryReadValue<TKey, TKeyWrap>(typeInfo, out var key))
+            {
+                if (!deCollection.TryReadValue<TValue, TValueWrap>(typeInfo, out var value))
+                {
+                    throw new DeserializeException("Expected value, but reached end of collection.");
+                }
+                builder.Add(key, value);
+            }
+            if (deCollection.SizeOpt is int size && size != builder.Count)
+            {
+                throw new DeserializeException($"Expected {size} items, found {builder.Count}");
+            }
+            return builder.ToImmutable();
         }
     }
 }

--- a/src/serde/Wrappers.cs
+++ b/src/serde/Wrappers.cs
@@ -303,6 +303,30 @@ public readonly partial record struct Int64Wrap(long Value)
     }
 }
 
+public readonly record struct SingleWrap : ISerialize<float>, IDeserialize<float>
+{
+    public static ISerdeInfo SerdeInfo { get; } = Serde.SerdeInfo.MakePrimitive("float");
+    public void Serialize(float value, ISerializer serializer)
+        => serializer.SerializeFloat(value);
+    public static float Deserialize(IDeserializer deserializer)
+        => deserializer.DeserializeFloat(SerdeVisitor.Instance);
+    private sealed class SerdeVisitor : IDeserializeVisitor<float>
+    {
+        public static readonly SerdeVisitor Instance = new SerdeVisitor();
+        public string ExpectedTypeName => "float";
+        float IDeserializeVisitor<float>.VisitByte(byte b)    => b;
+        float IDeserializeVisitor<float>.VisitU16(ushort u16) => u16;
+        float IDeserializeVisitor<float>.VisitU32(uint u32)   => u32;
+        float IDeserializeVisitor<float>.VisitU64(ulong u64)  => u64;
+        float IDeserializeVisitor<float>.VisitSByte(sbyte b)  => b;
+        float IDeserializeVisitor<float>.VisitI16(short i16)  => i16;
+        float IDeserializeVisitor<float>.VisitI32(int i32)    => i32;
+        float IDeserializeVisitor<float>.VisitI64(long i64)   => i64;
+        float IDeserializeVisitor<float>.VisitFloat(float f) => f;
+        float IDeserializeVisitor<float>.VisitDouble(double d) => Convert.ToSingle(d);
+    }
+}
+
 public readonly partial record struct DoubleWrap(double Value)
     : ISerialize<double>, IDeserialize<double>
 {

--- a/src/serde/json/JsonSerializer.cs
+++ b/src/serde/json/JsonSerializer.cs
@@ -1,6 +1,9 @@
 
 using System;
+using System.Buffers.Text;
 using System.Collections.Generic;
+using System.Diagnostics;
+using System.Security.Cryptography;
 using System.Text;
 using System.Text.Json;
 
@@ -53,8 +56,66 @@ namespace Serde.Json
         public static T Deserialize<T, D>(string source)
             where D : IDeserialize<T>
         {
-            var deserializer = JsonDeserializer.FromString(source);
-            return D.Deserialize(deserializer);
+            var bytes = Encoding.UTF8.GetBytes(source);
+            return Deserialize_Unsafe<T, D>(bytes);
+        }
+
+        /// <summary>
+        /// Deserialize from an array of UTF-8 bytes.
+        /// </summary>
+        public static T Deserialize<T, D>(byte[] utf8Bytes)
+            where D : IDeserialize<T>
+        {
+            try
+            {
+                // Checks for invalid UTF-8 as a side effect.
+                _ = Encoding.UTF8.GetCharCount(utf8Bytes);
+            }
+            catch
+            {
+                throw new ArgumentException("Array is not valid UTF-8", nameof(utf8Bytes));
+            }
+            return Deserialize_Unsafe<T, D>(utf8Bytes);
+        }
+
+        /// <summary>
+        /// Assumes the input is valid UTF-8.
+        /// </summary>
+        private static T Deserialize_Unsafe<T, D>(byte[] utf8Bytes)
+            where D : IDeserialize<T>
+        {
+#if DEBUG
+            var reader = new System.Text.Json.Utf8JsonReader(utf8Bytes);
+            bool expectedSuccess = true;
+            try
+            {
+                while (reader.Read())
+                    ;
+            }
+            catch (System.Text.Json.JsonException)
+            {
+                expectedSuccess = false;
+            }
+#endif // DEBUG
+
+            T result;
+#if DEBUG
+            try
+            {
+#endif // DEBUG
+                using var deserializer = JsonDeserializer.FromUtf8_Unsafe(utf8Bytes);
+                result = D.Deserialize(deserializer);
+                deserializer.Eof();
+#if DEBUG
+            }
+            catch (Serde.Json.JsonException)
+            {
+                //Debug.Assert(!expectedSuccess, "Utf8JsonReader suceeded, but Serde.Json failed");
+                throw;
+            }
+            Debug.Assert(expectedSuccess, "Utf8JsonReader failed, but Serde.Json suceeded");
+#endif // DEBUG
+            return result;
         }
     }
 }

--- a/src/serde/json/newreader/ArrayReader.cs
+++ b/src/serde/json/newreader/ArrayReader.cs
@@ -1,0 +1,180 @@
+
+using System;
+using System.Buffers;
+using System.Buffers.Text;
+using System.Collections;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Text.Json;
+using Serde.Json;
+using static Serde.Json.ThrowHelpers;
+
+namespace Serde.IO;
+
+internal struct ArrayReader(byte[] bytes) : IByteReader
+{
+    private readonly byte[] _bytes = bytes;
+    private int _pos = 0;
+
+    public short Next()
+    {
+        var b = Peek();
+        if (b != IByteReader.EndOfStream)
+        {
+            _pos++;
+        }
+        return b;
+    }
+
+    public void Advance(int count = 1)
+    {
+        _pos += count;
+    }
+
+    public short Peek()
+    {
+        if (_pos >= _bytes.Length)
+        {
+            return IByteReader.EndOfStream;
+        }
+        return _bytes[_pos];
+    }
+
+    public bool StartsWith(Utf8Span span)
+    {
+        if (span.Length > _bytes.Length - _pos)
+        {
+            return false;
+        }
+        return span.SequenceEqual(_bytes.AsSpan(_pos, span.Length));
+    }
+
+    public Utf8Span LexUtf8Span(bool skipOnly, ScratchBuffer? scratch)
+    {
+        var span = _bytes.AsSpan();
+        int start = _pos;
+        while (true)
+        {
+            SkipToEscape();
+            if (_pos == span.Length)
+            {
+                throw new InvalidOperationException("Unexpected end of stream.");
+            }
+            var b = span[_pos];
+            switch (b)
+            {
+                case (byte)'"':
+                    {
+                        if (skipOnly)
+                        {
+                            Advance();
+                            return Utf8Span.Empty;
+                        }
+
+                        Debug.Assert(scratch is not null);
+                        var curSpan = span[start.._pos];
+                        Utf8Span strSpan;
+                        if (scratch.Count == 0)
+                        {
+                            strSpan = curSpan;
+                        }
+                        else
+                        {
+                            scratch.AddRange(curSpan);
+                            strSpan = scratch.Span;
+                        }
+                        Advance();
+                        return strSpan;
+                    }
+                case (byte)'\\':
+                    {
+                        if (!skipOnly)
+                        {
+                            scratch!.AddRange(span[start.._pos]);
+                        }
+                        Advance();
+                        LexEscape(skipOnly, scratch);
+                        start = _pos;
+                        break;
+                    }
+                default:
+                    {
+                        Advance();
+                        throw new InvalidOperationException("Invalid control character");
+                    }
+            }
+        }
+    }
+
+    private void SkipToEscape()
+    {
+        var span = _bytes.AsSpan(_pos);
+        var offset = 0;
+        while (offset < span.Length && !IsEscape(span[offset], includingControlChars: true))
+        {
+            offset++;
+        }
+        _pos += offset;
+    }
+
+    /// <summary>
+    /// Assumes we are one byte past the backslash character. Reads a JSON string escape sequence.
+    ///
+    /// If <paramref name="skipOnly"/> is true, the escape sequence is not copied to the scratch buffer.
+    /// <paramref name="scratch"/> may be null if <paramref name="skipOnly"/> is true.
+    /// </summary>
+    private void LexEscape(bool skipOnly, ScratchBuffer? scratch)
+    {
+        var s = Next();
+        ThrowIfEos(s);
+        switch ((byte)s)
+        {
+            case (byte)'"': AddOrSkip('"', skipOnly, scratch); break;
+            case (byte)'\\': AddOrSkip('\\', skipOnly, scratch); break;
+            case (byte)'/': AddOrSkip('/', skipOnly, scratch); break;
+            case (byte)'b': AddOrSkip('\b', skipOnly, scratch); break;
+            case (byte)'f': AddOrSkip('\f', skipOnly, scratch); break;
+            case (byte)'n': AddOrSkip('\n', skipOnly, scratch); break;
+            case (byte)'r': AddOrSkip('\r', skipOnly, scratch); break;
+            case (byte)'t': AddOrSkip('\t', skipOnly, scratch); break;
+            case (byte)'u':
+            {
+                if (skipOnly)
+                {
+                    Advance(4);
+                    break;
+                }
+                Debug.Assert(scratch is not null);
+                var reqLen = scratch.Count + 5;
+                scratch.EnsureCapacity(reqLen);
+                var dest = scratch.BufferSpan[scratch.Count..];
+                int written = 0;
+                JsonReaderHelper.DecodeUnicodeEscape(_bytes, dest, ref _pos, ref written);
+                scratch.Count += written;
+                break;
+            }
+            default:
+            {
+                throw new InvalidOperationException($"Invalid escape character: {s}");
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        static void AddOrSkip(char c, bool skipOnly, ScratchBuffer? scratch)
+        {
+            if (!skipOnly)
+            {
+                scratch!.Add((byte)c);
+            }
+        }
+    }
+
+    private static bool IsEscape(byte b, bool includingControlChars)
+    {
+        return b == (byte)'"' ||
+            b == (byte)'\\' ||
+            (includingControlChars && (b < 0x20));
+    }
+}

--- a/src/serde/json/newreader/IByteReader.cs
+++ b/src/serde/json/newreader/IByteReader.cs
@@ -1,0 +1,40 @@
+
+using System;
+using System.Buffers;
+using System.Runtime.CompilerServices;
+
+namespace Serde.IO;
+
+internal interface IByteReader
+{
+    public const short EndOfStream = -1;
+
+    /// <summary>
+    /// Reads a byte without advancing the stream, or returns <see cref="EndOfStream"/> if the end
+    /// of the stream has been reached.
+    /// </summary>
+    short Peek();
+
+    /// <summary>
+    /// Reads a byte and advances the stream, or returns <see cref="EndOfStream"/> if the end of the
+    /// stream has been reached.
+    /// </summary>
+    short Next();
+
+    /// <summary>
+    /// Advances the stream by <paramref name="count"/> bytes. The caller should ensure there is
+    /// enough remaining data in the stream.
+    /// </summary>
+    void Advance(int count = 1);
+
+    bool StartsWith(ReadOnlySpan<byte> span);
+
+    /// <summary>
+    /// Assumes we are one byte past the quote character. Reads a JSON string from the input.
+    /// Returns the string as a <see cref="Utf8Span"/>. If <paramref name="skipOnly"/> is true, the
+    /// string is not copied to the scratch buffer, and the returned <see cref="Utf8Span"/> is always
+    /// empty.
+    /// <paramref name="scratch"/> may be null if <paramref name="skipOnly"/> is true.
+    /// </summary>
+    Utf8Span LexUtf8Span(bool skipOnly, ScratchBuffer? scratch);
+}

--- a/src/serde/json/newreader/JsonException.cs
+++ b/src/serde/json/newreader/JsonException.cs
@@ -1,0 +1,11 @@
+
+using System;
+
+namespace Serde.Json;
+
+public sealed class JsonException : DeserializeException
+{
+    internal JsonException(string message) : base(message)
+    {
+    }
+}

--- a/src/serde/json/newreader/ScratchBuffer.cs
+++ b/src/serde/json/newreader/ScratchBuffer.cs
@@ -1,0 +1,123 @@
+
+using System;
+using System.Buffers;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+
+internal sealed class ScratchBuffer : IDisposable
+{
+    private byte[]? _rented;
+    private int _count;
+    public int Count
+    {
+        get => _count;
+        set
+        {
+            if ((uint)value >= _count && (uint)value <= _rented?.Length)
+            {
+                _count = value;
+            }
+            else
+            {
+                throw new ArgumentOutOfRangeException(nameof(value));
+            }
+        }
+    }
+
+    public int Capacity => _rented?.Length ?? 0;
+
+    public Span<byte> BufferSpan => _rented ?? default;
+
+    public Span<byte> Span => _count == 0 ? default : BufferSpan.Slice(0, _count);
+
+    public void Add(byte value)
+    {
+        var buffer = BufferSpan;
+        int count = Count;
+        if ((uint)count < (uint)buffer.Length)
+        {
+            Count = count + 1;
+            buffer[count] = value;
+        }
+        else
+        {
+            AddSlow(value);
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private void AddSlow(byte value)
+    {
+        EnsureCapacity(Count + 1);
+        BufferSpan[Count++] = value;
+    }
+
+    public void AddRange(ReadOnlySpan<byte> span)
+    {
+        if (!span.IsEmpty)
+        {
+            var buffer = BufferSpan;
+            var count = Count;
+            if (buffer.Length - count < span.Length)
+            {
+                EnsureCapacity(checked(count + span.Length));
+                buffer = BufferSpan;
+            }
+
+            span.CopyTo(buffer[count..]);
+            Count = count + span.Length;
+        }
+    }
+
+    public void EnsureCapacity(int capacity)
+    {
+        Debug.Assert(capacity >= 0);
+
+        if (BufferSpan.Length < capacity)
+        {
+            Grow(GetNewCapacity(capacity));
+        }
+    }
+
+    public void Clear()
+    {
+        _count = 0;
+    }
+
+    private const int DefaultCapacity = 64;
+
+    private int GetNewCapacity(int capacity)
+    {
+        var buffer = BufferSpan;
+        Debug.Assert(buffer.Length < capacity);
+
+        int newCapacity = buffer.Length == 0 ? DefaultCapacity : buffer.Length * 2;
+
+        if ((uint)newCapacity < (uint)capacity)
+        {
+            newCapacity = capacity;
+        }
+        return newCapacity;
+    }
+
+    private void Grow(int newSize)
+    {
+        var newArray = ArrayPool<byte>.Shared.Rent(newSize);
+        BufferSpan.CopyTo(newArray);
+        if (_rented is not null)
+        {
+            ArrayPool<byte>.Shared.Return(_rented);
+        }
+        _rented = newArray;
+    }
+
+    public void Dispose()
+    {
+        Clear();
+        if (_rented is not null)
+        {
+            ArrayPool<byte>.Shared.Return(_rented);
+            _rented = null;
+        }
+    }
+}

--- a/src/serde/json/newreader/ThrowHelpers.cs
+++ b/src/serde/json/newreader/ThrowHelpers.cs
@@ -1,0 +1,42 @@
+
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
+using Serde.IO;
+
+namespace Serde.Json;
+
+internal static class ThrowHelpers
+{
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static byte ThrowIfEos(short s)
+    {
+        if (s == IByteReader.EndOfStream)
+        {
+            ThrowUnexpectedEndOfStream();
+        }
+        return (byte)s;
+    }
+
+    [DoesNotReturn]
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static void ThrowUnexpectedEndOfStream()
+    {
+        throw new JsonException("Unexpected end of stream");
+    }
+
+    public static JsonException GetUnexpectedEndOfStreamException()
+    {
+        return new JsonException("Unexpected end of stream");
+    }
+
+    public static byte SkipWhitespaceOrThrow<T>(this ref Utf8JsonLexer<T> reader)
+        where T : IByteReader
+    {
+        var peek = reader.Peek();
+        if (peek == IByteReader.EndOfStream)
+        {
+            ThrowUnexpectedEndOfStream();
+        }
+        return (byte)peek;
+    }
+}

--- a/src/serde/json/newreader/Utf8JsonLexer.cs
+++ b/src/serde/json/newreader/Utf8JsonLexer.cs
@@ -1,0 +1,394 @@
+
+using System;
+using System.Buffers.Text;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using System.Security.Cryptography;
+using Serde.IO;
+using static Serde.Json.ThrowHelpers;
+
+namespace Serde.Json;
+
+internal struct Utf8JsonLexer<TReader>(TReader byteReader)
+    where TReader : IByteReader
+{
+    public bool StartsWith(Utf8Span value) => byteReader.StartsWith(value);
+
+    public bool GetBoolean()
+    {
+        bool result;
+        switch (ThrowIfEos(SkipWhitespace()))
+        {
+            case (byte)'t' when byteReader.StartsWith("true"u8):
+                result = true;
+                Advance(4);
+                break;
+            case (byte)'f' when byteReader.StartsWith("false"u8):
+                result = false;
+                Advance(5);
+                break;
+            default:
+                throw new InvalidOperationException("Expected boolean value");
+        }
+        return result;
+    }
+
+    public decimal GetDecimal(ScratchBuffer scratch)
+    {
+        CheckNumber();
+        var span = LexNumber(skipOnly: false, scratch);
+        if (!Utf8Parser.TryParse(span, out decimal result, out var bytesConsumed)
+            || span.Length != bytesConsumed)
+        {
+            throw new InvalidOperationException("Invalid decimal value");
+        }
+        return result;
+    }
+
+    public double GetDouble(ScratchBuffer scratch)
+    {
+        CheckNumber();
+        var span = LexNumber(skipOnly: false, scratch);
+        if (!Utf8Parser.TryParse(span, out double result, out var bytesConsumed)
+            || span.Length != bytesConsumed)
+        {
+            throw new InvalidOperationException("Invalid double value");
+        }
+        return result;
+    }
+
+    private void CheckNumber()
+    {
+        var peek = Peek();
+        if (peek is not (byte)'-' and not (>= (byte)'0' and <= (byte)'9'))
+        {
+            throw new JsonException("Expected number, found: " + (char)peek);
+        }
+    }
+
+    public long GetInt64(ScratchBuffer scratch) => (long)GetDecimal(scratch);
+
+    public ulong GetUInt64(ScratchBuffer scratch) => (ulong)GetDecimal(scratch);
+
+    public void Skip()
+    {
+        var peek = SkipWhitespace() switch {
+            IByteReader.EndOfStream => throw new InvalidOperationException("Unexpected end of stream"),
+            var s => (byte)s
+        };
+        switch (peek)
+        {
+            case (byte)'{':
+                Advance();
+                SkipObject();
+                break;
+            case (byte)'[':
+                Advance();
+                SkipArray();
+                break;
+            case (byte)'t' when byteReader.StartsWith("true"u8):
+                Advance(4);
+                break;
+            case (byte)'f' when byteReader.StartsWith("false"u8):
+                Advance(5);
+                break;
+            case (byte)'n' when byteReader.StartsWith("null"u8):
+                Advance(4);
+                break;
+            case (byte)'"':
+                Advance();
+                _ = byteReader.LexUtf8Span(skipOnly: true, null);
+                break;
+            case (byte)'-' or (>= (byte)'0' and <= (byte)'9'):
+                LexNumber(skipOnly: true, null);
+                break;
+            default:
+                throw new JsonException("Unexpected char: " + (char)peek);
+        }
+    }
+
+    /// <summary>
+    ///  Assumes we are one byte past the '{' character.
+    /// </summary>
+    private void SkipObject()
+    {
+        // Objects contain zero or more key-value pairs, separated by commas
+        // The pairs are separated by a colon
+        var first = true;
+        while (true)
+        {
+            var peek = SkipWhitespace();
+
+            // Comma, Key, or End
+            if (peek == (short)',')
+            {
+                if (first)
+                {
+                    throw new InvalidOperationException("Unexpected comma");
+                }
+                Advance();
+                peek = SkipWhitespace();
+            }
+
+            // Key
+            switch (peek)
+            {
+                case IByteReader.EndOfStream:
+                    throw new InvalidOperationException("Unexpected end of stream");
+                case (short)'}':
+                    Advance();
+                    return;
+                default:
+                    // Assume we are at the start of a key and let Skip handle it
+                    Skip();
+                    break;
+            }
+
+            // ':'
+            peek = ThrowIfEos(SkipWhitespace());
+            switch (peek)
+            {
+                case (short)':':
+                    Advance();
+                    break;
+                default:
+                    throw new JsonException($"Expected ':', found {(char)peek}");
+            }
+
+            // Value
+            Skip();
+            first = false;
+        }
+    }
+
+    /// <summary>
+    /// Assumes we are one byte past the '[' character.
+    /// </summary>
+    private void SkipArray()
+    {
+        bool first = true;
+        while (true)
+        {
+            // Arrays contain zero or more values, separated by commas
+            var peek = SkipWhitespace();
+            if (peek == (short)',')
+            {
+                if (first)
+                {
+                    throw new JsonException("Unexpected comma");
+                }
+                Advance();
+                peek = SkipWhitespace();
+            }
+
+            switch (peek)
+            {
+                case IByteReader.EndOfStream:
+                    throw new InvalidOperationException("Unexpected end of stream");
+                case (short)']':
+                    Advance();
+                    return;
+                default:
+                    // Assume we are at the start of a value and let Skip handle it
+                    Skip();
+                    break;
+            }
+            first = false;
+        }
+    }
+
+    /// <summary>
+    /// Scan a JSON number. If <paramref name="skipOnly"/> is true, this method will only skip the
+    /// number and always returns a default span.
+    ///
+    /// See <a href="https://www.json.org/json-en.html" /> for the JSON number format.
+    ///
+    /// <paramref name="scratch"/> may be null if <paramref name="skipOnly"/> is true.
+    /// </summary>
+    private Utf8Span LexNumber(bool skipOnly, ScratchBuffer? scratch)
+    {
+        var b = PeekOrThrow();
+        Debug.Assert(b is (byte)'-' or (>= (byte)'0' and <= (byte)'9'));
+
+        // Optional leading minus sign
+        switch (b)
+        {
+            case (byte)'-':
+                AddOrSkip(b, skipOnly, scratch);
+                Advance();
+                b = PeekOrThrow();
+                break;
+        }
+
+        short peek;
+
+        // JSON does not allow leading zeros. If one is present, it cannot be followed by other
+        // digits
+        if (b == (byte)'0')
+        {
+            AddOrSkip(b, skipOnly, scratch);
+            Advance();
+
+            peek = Peek();
+            if (peek is >= (short)'0' and <= (short)'9')
+            {
+                throw new JsonException("Leading zero not allowed");
+            }
+        }
+        else
+        {
+            if (b is not >= (byte)'1' and <= (byte)'9')
+            {
+                throw new InvalidOperationException("expected 1-9");
+            }
+
+            AddOrSkip(b, skipOnly, scratch);
+            Advance();
+
+            // Lex integer part
+            peek = LexDigits(skipOnly, scratch);
+            if (peek == IByteReader.EndOfStream)
+            {
+                goto ReturnSpan;
+            }
+        }
+
+        switch (peek)
+        {
+            case IByteReader.EndOfStream:
+                goto ReturnSpan;
+            case (short)'.':
+                // Fractional part
+                AddOrSkip((byte)'.', skipOnly, scratch);
+                Advance();
+
+                b = PeekOrThrow();
+                if (b is not >= (byte)'0' and <= (byte)'9')
+                {
+                    throw new InvalidOperationException("expected 0-9");
+                }
+
+                peek = LexDigits(skipOnly, scratch);
+                if (peek == IByteReader.EndOfStream)
+                {
+                    goto ReturnSpan;
+                }
+                b = (byte)peek;
+                break;
+            default:
+                b = (byte)peek;
+                break;
+        }
+
+        if (b is (byte)'e' or (byte)'E')
+        {
+            // Exponent part
+            AddOrSkip(b, skipOnly, scratch);
+            Advance();
+
+            b = PeekOrThrow();
+            if (b is (byte)'-' or (byte)'+')
+            {
+                AddOrSkip(b, skipOnly, scratch);
+                Advance();
+                b = PeekOrThrow();
+            }
+            if (b is not >= (byte)'0' and <= (byte)'9')
+            {
+                throw new InvalidOperationException("expected 0-9");
+            }
+            LexDigits(skipOnly, scratch);
+        }
+
+    ReturnSpan:
+        if (skipOnly)
+        {
+            return default;
+        }
+        return scratch!.Span;
+    }
+
+    /// <summary>
+    /// Lex a sequence of digits 0-9. Returns next character after the digits.
+    ///
+    /// <paramref name="scratch"/> may be null if <paramref name="skipOnly"/> is true.
+    /// </summary>
+    private short LexDigits(bool skipOnly, ScratchBuffer? scratch)
+    {
+        while (true)
+        {
+            var peek = Peek();
+            switch (peek)
+            {
+                case >= (short)'0' and <= (short)'9':
+                    AddOrSkip((byte)peek, skipOnly, scratch);
+                    Advance();
+                    continue;
+            }
+            return peek;
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private void AddOrSkip(byte b, bool skipOnly, ScratchBuffer? scratch)
+    {
+        if (skipOnly)
+        {
+            return;
+        }
+        scratch!.Add(b);
+    }
+
+    private byte PeekOrThrow() => Peek() switch
+    {
+        IByteReader.EndOfStream => throw new InvalidOperationException("Unexpected end of stream"),
+        var s => (byte)s
+    };
+
+
+    public Utf8Span LexUtf8Span(ScratchBuffer scratch)
+    {
+        return byteReader.LexUtf8Span(skipOnly: false, scratch);
+    }
+
+    /// <summary>
+    /// Reads a byte without advancing the stream, or returns <see cref="IByteReader.EndOfStream"/> if the end
+    /// of the stream has been reached.
+    /// </summary>
+    public short Peek() => byteReader.Peek();
+
+    public short SkipWhitespace()
+    {
+        while (true)
+        {
+            var s = byteReader.Peek();
+            switch (s)
+            {
+                case IByteReader.EndOfStream:
+                    return s;
+                case (short)' ':
+                case (short)'\t':
+                case (short)'\n':
+                case (short)'\r':
+                    byteReader.Advance();
+                    break;
+                default:
+                    return s;
+            }
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void Advance(int count = 1) => byteReader.Advance(count);
+}
+
+internal static class Utf8JsonReader_OldExtensions
+{
+    public static void ReadOrThrow(ref this Utf8JsonReader_Old reader)
+    {
+        if (!reader.Read())
+        {
+            throw new DeserializeException("Unexpected end of stream");
+        }
+    }
+}

--- a/src/serde/json/reader/JsonCommentHandling.cs
+++ b/src/serde/json/reader/JsonCommentHandling.cs
@@ -4,19 +4,19 @@
 namespace Serde.Json
 {
     /// <summary>
-    /// This enum defines the various ways the <see cref="Utf8JsonReader"/> can deal with comments.
+    /// This enum defines the various ways the <see cref="Utf8JsonReader_Old"/> can deal with comments.
     /// </summary>
     internal enum JsonCommentHandling : byte
     {
         /// <summary>
         /// By default, do no allow comments within the JSON input.
         /// Comments are treated as invalid JSON if found and a
-        /// <see cref="JsonException"/> is thrown.
+        /// <see cref="JsonException_Old"/> is thrown.
         /// </summary>
         Disallow = 0,
         /// <summary>
         /// Allow comments within the JSON input and ignore them.
-        /// The <see cref="Utf8JsonReader"/> will behave as if no comments were present.
+        /// The <see cref="Utf8JsonReader_Old"/> will behave as if no comments were present.
         /// </summary>
         Skip = 1,
         /// <summary>

--- a/src/serde/json/reader/JsonException.cs
+++ b/src/serde/json/reader/JsonException.cs
@@ -11,7 +11,7 @@ namespace Serde.Json
     /// or the JSON text is not compatible with the type of a property on an object.
     /// </summary>
     [Serializable]
-    internal class JsonException : Exception
+    internal class JsonException_Old : Exception
     {
         // Allow the message to mutate to avoid re-throwing and losing the StackTrace to an inner exception.
         internal string? _message;
@@ -27,7 +27,7 @@ namespace Serde.Json
         /// <remarks>
         /// Note that the <paramref name="bytePositionInLine"/> counts the number of bytes (i.e. UTF-8 code units) and not characters or scalars.
         /// </remarks>
-        public JsonException(string? message, string? path, long? lineNumber, long? bytePositionInLine, Exception? innerException) : base(message, innerException)
+        public JsonException_Old(string? message, string? path, long? lineNumber, long? bytePositionInLine, Exception? innerException) : base(message, innerException)
         {
             _message = message;
             LineNumber = lineNumber;
@@ -45,7 +45,7 @@ namespace Serde.Json
         /// <remarks>
         /// Note that the <paramref name="bytePositionInLine"/> counts the number of bytes (i.e. UTF-8 code units) and not characters or scalars.
         /// </remarks>
-        public JsonException(string? message, string? path, long? lineNumber, long? bytePositionInLine) : base(message)
+        public JsonException_Old(string? message, string? path, long? lineNumber, long? bytePositionInLine) : base(message)
         {
             _message = message;
             LineNumber = lineNumber;
@@ -58,7 +58,7 @@ namespace Serde.Json
         /// </summary>
         /// <param name="message">The context specific error message.</param>
         /// <param name="innerException">The exception that caused the current exception.</param>
-        public JsonException(string? message, Exception? innerException) : base(message, innerException)
+        public JsonException_Old(string? message, Exception? innerException) : base(message, innerException)
         {
             _message = message;
         }
@@ -67,7 +67,7 @@ namespace Serde.Json
         /// Creates a new exception object to relay error information to the user.
         /// </summary>
         /// <param name="message">The context specific error message.</param>
-        public JsonException(string? message) : base(message)
+        public JsonException_Old(string? message) : base(message)
         {
             _message = message;
         }
@@ -75,7 +75,7 @@ namespace Serde.Json
         /// <summary>
         /// Creates a new exception object to relay error information to the user.
         /// </summary>
-        public JsonException() : base() { }
+        public JsonException_Old() : base() { }
 
         /// <summary>
         /// Specifies that 'try' logic should append Path information to the exception message.

--- a/src/serde/json/reader/JsonHelpers.cs
+++ b/src/serde/json/reader/JsonHelpers.cs
@@ -17,7 +17,7 @@ namespace Serde.Json
         /// Returns the span for the given reader.
         /// </summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static ReadOnlySpan<byte> GetSpan(this scoped ref Utf8JsonReader reader)
+        public static ReadOnlySpan<byte> GetSpan(this scoped ref Utf8JsonReader_Old reader)
         {
             return reader.HasValueSequence ? reader.ValueSequence.ToArray() : reader.ValueSpan;
         }
@@ -82,7 +82,7 @@ namespace Serde.Json
         /// This should be called when the Read() return value is not used, such as non-Stream cases where there is only one buffer.
         /// </summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void ReadWithVerify(this ref Utf8JsonReader reader)
+        public static void ReadWithVerify(this ref Utf8JsonReader_Old reader)
         {
             bool result = reader.Read();
             Debug.Assert(result);

--- a/src/serde/json/reader/JsonReaderException.cs
+++ b/src/serde/json/reader/JsonReaderException.cs
@@ -8,7 +8,7 @@ namespace Serde.Json
 {
     // This class exists because the serializer needs to catch reader-originated exceptions in order to throw JsonException which has Path information.
     [Serializable]
-    internal sealed class JsonReaderException : JsonException
+    internal sealed class JsonReaderException : JsonException_Old
     {
         public JsonReaderException(string message, long lineNumber, long bytePositionInLine) : base(message, path: null, lineNumber, bytePositionInLine)
         {

--- a/src/serde/json/reader/JsonReaderHelper.Unescaping.cs
+++ b/src/serde/json/reader/JsonReaderHelper.Unescaping.cs
@@ -478,64 +478,10 @@ namespace Serde.Json
                     default:
                         Debug.Assert(source[idx] == 'u', "invalid escape sequences must have already been caught by Utf8JsonReader.Read()");
 
-                        // The source is known to be valid JSON, and hence if we see a \u, it is guaranteed to have 4 hex digits following it
-                        // Otherwise, the Utf8JsonReader would have already thrown an exception.
-                        Debug.Assert(source.Length >= idx + 5);
-
-                        bool result = Utf8Parser.TryParse(source.Slice(idx + 1, 4), out int scalar, out int bytesConsumed, 'x');
-                        Debug.Assert(result);
-                        Debug.Assert(bytesConsumed == 4);
-                        idx += 4;
-
-                        if (JsonHelpers.IsInRangeInclusive((uint)scalar, JsonConstants.HighSurrogateStartValue, JsonConstants.LowSurrogateEndValue))
-                        {
-                            // The first hex value cannot be a low surrogate.
-                            if (scalar >= JsonConstants.LowSurrogateStartValue)
-                            {
-                                ThrowHelper.ThrowInvalidOperationException_ReadInvalidUTF16(scalar);
-                            }
-
-                            Debug.Assert(JsonHelpers.IsInRangeInclusive((uint)scalar, JsonConstants.HighSurrogateStartValue, JsonConstants.HighSurrogateEndValue));
-
-                            // We must have a low surrogate following a high surrogate.
-                            if (source.Length < idx + 7 || source[idx + 1] != '\\' || source[idx + 2] != 'u')
-                            {
-                                ThrowHelper.ThrowInvalidOperationException_ReadIncompleteUTF16();
-                            }
-
-                            // The source is known to be valid JSON, and hence if we see a \u, it is guaranteed to have 4 hex digits following it
-                            // Otherwise, the Utf8JsonReader would have already thrown an exception.
-                            result = Utf8Parser.TryParse(source.Slice(idx + 3, 4), out int lowSurrogate, out bytesConsumed, 'x');
-                            Debug.Assert(result);
-                            Debug.Assert(bytesConsumed == 4);
-                            idx += 6;
-
-                            // If the first hex value is a high surrogate, the next one must be a low surrogate.
-                            if (!JsonHelpers.IsInRangeInclusive((uint)lowSurrogate, JsonConstants.LowSurrogateStartValue, JsonConstants.LowSurrogateEndValue))
-                            {
-                                ThrowHelper.ThrowInvalidOperationException_ReadInvalidUTF16(lowSurrogate);
-                            }
-
-                            // To find the unicode scalar:
-                            // (0x400 * (High surrogate - 0xD800)) + Low surrogate - 0xDC00 + 0x10000
-                            scalar = (JsonConstants.BitShiftBy10 * (scalar - JsonConstants.HighSurrogateStartValue))
-                                + (lowSurrogate - JsonConstants.LowSurrogateStartValue)
-                                + JsonConstants.UnicodePlane01StartValue;
-                        }
-
-#if NETCOREAPP
-                        var rune = new Rune(scalar);
-                        bool success = rune.TryEncodeToUtf8(destination.Slice(written), out int bytesWritten);
-#else
-                        bool success = TryEncodeToUtf8Bytes((uint)scalar, destination.Slice(written), out int bytesWritten);
-#endif
-                        if (!success)
+                        if (!DecodeUnicodeEscape(source, destination, ref idx, ref written))
                         {
                             goto DestinationTooShort;
                         }
-
-                        Debug.Assert(bytesWritten <= 4);
-                        written += bytesWritten;
                         break;
                 }
 
@@ -594,6 +540,73 @@ namespace Serde.Json
 
         DestinationTooShort:
             return false;
+        }
+
+        /// <summary>
+        /// Assumes idx points after the 'u' in a \u escape sequence. Writes the UTF-8 encoded scalar value to the destination buffer.
+        /// Returns false if the destination buffer is too short.
+        /// </summary>
+        internal static bool DecodeUnicodeEscape(Utf8Span source, Span<byte> destination, ref int idx, ref int written)
+        {
+            // The source is known to be valid JSON, and hence if we see a \u, it is guaranteed to have 4 hex digits following it
+            // Otherwise, the Utf8JsonReader would have already thrown an exception.
+            Debug.Assert(source.Length >= idx + 5);
+
+            bool result = Utf8Parser.TryParse(source.Slice(idx, 4), out int scalar, out int bytesConsumed, 'x');
+            Debug.Assert(result);
+            Debug.Assert(bytesConsumed == 4);
+            idx += 4;
+
+            if (JsonHelpers.IsInRangeInclusive((uint)scalar, JsonConstants.HighSurrogateStartValue, JsonConstants.LowSurrogateEndValue))
+            {
+                // The first hex value cannot be a low surrogate.
+                if (scalar >= JsonConstants.LowSurrogateStartValue)
+                {
+                    ThrowHelper.ThrowInvalidOperationException_ReadInvalidUTF16(scalar);
+                }
+
+                Debug.Assert(JsonHelpers.IsInRangeInclusive((uint)scalar, JsonConstants.HighSurrogateStartValue, JsonConstants.HighSurrogateEndValue));
+
+                // We must have a low surrogate following a high surrogate.
+                if (source.Length < idx + 7 || source[idx + 1] != '\\' || source[idx + 2] != 'u')
+                {
+                    ThrowHelper.ThrowInvalidOperationException_ReadIncompleteUTF16();
+                }
+
+                // The source is known to be valid JSON, and hence if we see a \u, it is guaranteed to have 4 hex digits following it
+                // Otherwise, the Utf8JsonReader would have already thrown an exception.
+                result = Utf8Parser.TryParse(source.Slice(idx + 3, 4), out int lowSurrogate, out bytesConsumed, 'x');
+                Debug.Assert(result);
+                Debug.Assert(bytesConsumed == 4);
+                idx += 6;
+
+                // If the first hex value is a high surrogate, the next one must be a low surrogate.
+                if (!JsonHelpers.IsInRangeInclusive((uint)lowSurrogate, JsonConstants.LowSurrogateStartValue, JsonConstants.LowSurrogateEndValue))
+                {
+                    ThrowHelper.ThrowInvalidOperationException_ReadInvalidUTF16(lowSurrogate);
+                }
+
+                // To find the unicode scalar:
+                // (0x400 * (High surrogate - 0xD800)) + Low surrogate - 0xDC00 + 0x10000
+                scalar = (JsonConstants.BitShiftBy10 * (scalar - JsonConstants.HighSurrogateStartValue))
+                    + (lowSurrogate - JsonConstants.LowSurrogateStartValue)
+                    + JsonConstants.UnicodePlane01StartValue;
+            }
+
+#if NETCOREAPP
+            var rune = new Rune(scalar);
+            bool success = rune.TryEncodeToUtf8(destination.Slice(written), out int bytesWritten);
+#else
+            bool success = TryEncodeToUtf8Bytes((uint)scalar, destination.Slice(written), out int bytesWritten);
+#endif
+            if (!success)
+            {
+                return false;
+            }
+
+            Debug.Assert(bytesWritten <= 4);
+            written += bytesWritten;
+            return true;
         }
 
 #if !NETCOREAPP

--- a/src/serde/json/reader/JsonReaderOptions.cs
+++ b/src/serde/json/reader/JsonReaderOptions.cs
@@ -17,13 +17,13 @@ namespace Serde.Json
         private JsonCommentHandling _commentHandling;
 
         /// <summary>
-        /// Defines how the <see cref="Utf8JsonReader"/> should handle comments when reading through the JSON.
+        /// Defines how the <see cref="Utf8JsonReader_Old"/> should handle comments when reading through the JSON.
         /// </summary>
         /// <exception cref="ArgumentOutOfRangeException">
         /// Thrown when the comment handling enum is set to a value that is not supported (i.e. not within the <see cref="JsonCommentHandling"/> enum range).
         /// </exception>
         /// <remarks>
-        /// By default <exception cref="JsonException"/> is thrown if a comment is encountered.
+        /// By default <exception cref="JsonException_Old"/> is thrown if a comment is encountered.
         /// </remarks>
         public JsonCommentHandling CommentHandling
         {
@@ -47,7 +47,7 @@ namespace Serde.Json
         /// Thrown when the max depth is set to a negative value.
         /// </exception>
         /// <remarks>
-        /// Reading past this depth will throw a <exception cref="JsonException"/>.
+        /// Reading past this depth will throw a <exception cref="JsonException_Old"/>.
         /// </remarks>
         public int MaxDepth
         {
@@ -68,7 +68,7 @@ namespace Serde.Json
         /// is allowed (and ignored) within the JSON payload being read.
         /// </summary>
         /// <remarks>
-        /// By default, it's set to false, and <exception cref="JsonException"/> is thrown if a trailing comma is encountered.
+        /// By default, it's set to false, and <exception cref="JsonException_Old"/> is thrown if a trailing comma is encountered.
         /// </remarks>
         public bool AllowTrailingCommas { get; set; }
     }

--- a/src/serde/json/reader/JsonReaderState.cs
+++ b/src/serde/json/reader/JsonReaderState.cs
@@ -5,11 +5,11 @@ namespace Serde.Json
 {
     /// <summary>
     /// Defines an opaque type that holds and saves all the relevant state information which must be provided
-    /// to the <see cref="Utf8JsonReader"/> to continue reading after processing incomplete data.
+    /// to the <see cref="Utf8JsonReader_Old"/> to continue reading after processing incomplete data.
     /// This type is required to support reentrancy when reading incomplete data, and to continue
-    /// reading once more data is available. Unlike the <see cref="Utf8JsonReader"/>, which is a ref struct,
+    /// reading once more data is available. Unlike the <see cref="Utf8JsonReader_Old"/>, which is a ref struct,
     /// this type can survive across async/await boundaries and hence this type is required to provide
-    /// support for reading in more data asynchronously before continuing with a new instance of the <see cref="Utf8JsonReader"/>.
+    /// support for reading in more data asynchronously before continuing with a new instance of the <see cref="Utf8JsonReader_Old"/>.
     /// </summary>
     internal struct JsonReaderState
     {
@@ -27,14 +27,14 @@ namespace Serde.Json
         /// <summary>
         /// Constructs a new <see cref="JsonReaderState"/> instance.
         /// </summary>
-        /// <param name="options">Defines the customized behavior of the <see cref="Utf8JsonReader"/>
+        /// <param name="options">Defines the customized behavior of the <see cref="Utf8JsonReader_Old"/>
         /// that is different from the JSON RFC (for example how to handle comments or maximum depth allowed when reading).
-        /// By default, the <see cref="Utf8JsonReader"/> follows the JSON RFC strictly (i.e. comments within the JSON are invalid) and reads up to a maximum depth of 64.</param>
+        /// By default, the <see cref="Utf8JsonReader_Old"/> follows the JSON RFC strictly (i.e. comments within the JSON are invalid) and reads up to a maximum depth of 64.</param>
         /// <remarks>
-        /// An instance of this state must be passed to the <see cref="Utf8JsonReader"/> ctor with the JSON data.
-        /// Unlike the <see cref="Utf8JsonReader"/>, which is a ref struct, the state can survive
+        /// An instance of this state must be passed to the <see cref="Utf8JsonReader_Old"/> ctor with the JSON data.
+        /// Unlike the <see cref="Utf8JsonReader_Old"/>, which is a ref struct, the state can survive
         /// across async/await boundaries and hence this type is required to provide support for reading
-        /// in more data asynchronously before continuing with a new instance of the <see cref="Utf8JsonReader"/>.
+        /// in more data asynchronously before continuing with a new instance of the <see cref="Utf8JsonReader_Old"/>.
         /// </remarks>
         public JsonReaderState(JsonReaderOptions options = default)
         {
@@ -55,7 +55,7 @@ namespace Serde.Json
 
         /// <summary>
         /// Gets the custom behavior when reading JSON using
-        /// the <see cref="Utf8JsonReader"/> that may deviate from strict adherence
+        /// the <see cref="Utf8JsonReader_Old"/> that may deviate from strict adherence
         /// to the JSON specification, which is the default behavior.
         /// </summary>
         public JsonReaderOptions Options => _readerOptions;

--- a/src/serde/json/reader/JsonTokenType.cs
+++ b/src/serde/json/reader/JsonTokenType.cs
@@ -5,9 +5,9 @@ namespace Serde.Json
 {
     /// <summary>
     /// This enum defines the various JSON tokens that make up a JSON text and is used by
-    /// the <see cref="Utf8JsonReader"/> when moving from one token to the next.
-    /// The <see cref="Utf8JsonReader"/> starts at 'None' by default. The 'Comment' enum value
-    /// is only ever reached in a specific <see cref="Utf8JsonReader"/> mode and is not
+    /// the <see cref="Utf8JsonReader_Old"/> when moving from one token to the next.
+    /// The <see cref="Utf8JsonReader_Old"/> starts at 'None' by default. The 'Comment' enum value
+    /// is only ever reached in a specific <see cref="Utf8JsonReader_Old"/> mode and is not
     /// reachable by default.
     /// </summary>
     internal enum JsonTokenType : byte
@@ -19,7 +19,7 @@ namespace Serde.Json
         ///   Indicates that there is no value (as distinct from <see cref="Null"/>).
         /// </summary>
         /// <remarks>
-        ///   This is the default token type if no data has been read by the <see cref="Utf8JsonReader"/>.
+        ///   This is the default token type if no data has been read by the <see cref="Utf8JsonReader_Old"/>.
         /// </remarks>
         None,
 

--- a/src/serde/json/reader/ThrowHelper.cs
+++ b/src/serde/json/reader/ThrowHelper.cs
@@ -301,13 +301,13 @@ namespace Serde.Json
         }
 
         [DoesNotReturn]
-        public static void ThrowJsonReaderException(ref Utf8JsonReader json, ExceptionResource resource, byte nextByte = default, ReadOnlySpan<byte> bytes = default)
+        public static void ThrowJsonReaderException(ref Utf8JsonReader_Old json, ExceptionResource resource, byte nextByte = default, ReadOnlySpan<byte> bytes = default)
         {
             throw GetJsonReaderException(ref json, resource, nextByte, bytes);
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]
-        public static JsonException GetJsonReaderException(ref Utf8JsonReader json, ExceptionResource resource, byte nextByte, ReadOnlySpan<byte> bytes)
+        public static JsonException_Old GetJsonReaderException(ref Utf8JsonReader_Old json, ExceptionResource resource, byte nextByte, ReadOnlySpan<byte> bytes)
         {
             string message = GetResourceString(ref json, resource, nextByte, JsonHelpers.Utf8GetString(bytes));
 
@@ -328,7 +328,7 @@ namespace Serde.Json
 
         // This function will convert an ExceptionResource enum value to the resource string.
         [MethodImpl(MethodImplOptions.NoInlining)]
-        private static string GetResourceString(ref Utf8JsonReader json, ExceptionResource resource, byte nextByte, string characters)
+        private static string GetResourceString(ref Utf8JsonReader_Old json, ExceptionResource resource, byte nextByte, string characters)
         {
             string character = GetPrintableString(nextByte);
 

--- a/src/serde/json/reader/Utf8JsonReader.TryGet.cs
+++ b/src/serde/json/reader/Utf8JsonReader.TryGet.cs
@@ -10,7 +10,7 @@ using System.Runtime.CompilerServices;
 
 namespace Serde.Json
 {
-    partial struct Utf8JsonReader
+    partial struct Utf8JsonReader_Old
     {
         /// <summary>
         /// Parses the current JSON token value from the source, unescaped, and transcoded as a <see cref="string"/>.

--- a/src/serde/json/reader/Utf8JsonReader.cs
+++ b/src/serde/json/reader/Utf8JsonReader.cs
@@ -13,14 +13,14 @@ namespace Serde.Json
     /// Provides a high-performance API for forward-only, read-only access to the UTF-8 encoded JSON text.
     /// It processes the text sequentially with no caching and adheres strictly to the JSON RFC
     /// by default (https://tools.ietf.org/html/rfc8259). When it encounters invalid JSON, it throws
-    /// a JsonException with basic error information like line number and byte position on the line.
+    /// a JsonException_Old with basic error information like line number and byte position on the line.
     /// Since this type is a ref struct, it does not directly support async. However, it does provide
     /// support for reentrancy to read incomplete data, and continue reading once more data is presented.
     /// To be able to set max depth while reading OR allow skipping comments, create an instance of
     /// <see cref="JsonReaderState"/> and pass that in to the reader.
     /// </summary>
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
-    internal partial struct Utf8JsonReader
+    internal partial struct Utf8JsonReader_Old
     {
         private ReadOnlyMemory<byte> _buffer;
         private ReadOnlySpan<byte> GetBufferSpan => _buffer.Span;
@@ -64,8 +64,8 @@ namespace Serde.Json
         public readonly ReadOnlySpan<byte> ValueSpan => _valueMemory.Span;
 
         /// <summary>
-        /// Returns the total amount of bytes consumed by the <see cref="Utf8JsonReader"/> so far
-        /// for the current instance of the <see cref="Utf8JsonReader"/> with the given UTF-8 encoded input text.
+        /// Returns the total amount of bytes consumed by the <see cref="Utf8JsonReader_Old"/> so far
+        /// for the current instance of the <see cref="Utf8JsonReader_Old"/> with the given UTF-8 encoded input text.
         /// </summary>
         public readonly long BytesConsumed
         {
@@ -143,11 +143,11 @@ namespace Serde.Json
         public ReadOnlySequence<byte> ValueSequence { get; private set; }
 
         /// <summary>
-        /// Returns the current snapshot of the <see cref="Utf8JsonReader"/> state which must
-        /// be captured by the caller and passed back in to the <see cref="Utf8JsonReader"/> ctor with more data.
-        /// Unlike the <see cref="Utf8JsonReader"/>, which is a ref struct, the state can survive
+        /// Returns the current snapshot of the <see cref="Utf8JsonReader_Old"/> state which must
+        /// be captured by the caller and passed back in to the <see cref="Utf8JsonReader_Old"/> ctor with more data.
+        /// Unlike the <see cref="Utf8JsonReader_Old"/>, which is a ref struct, the state can survive
         /// across async/await boundaries and hence this type is required to provide support for reading
-        /// in more data asynchronously before continuing with a new instance of the <see cref="Utf8JsonReader"/>.
+        /// in more data asynchronously before continuing with a new instance of the <see cref="Utf8JsonReader_Old"/>.
         /// </summary>
         public readonly JsonReaderState CurrentState => new JsonReaderState
         {
@@ -164,16 +164,16 @@ namespace Serde.Json
         };
 
         /// <summary>
-        /// Constructs a new <see cref="Utf8JsonReader"/> instance.
+        /// Constructs a new <see cref="Utf8JsonReader_Old"/> instance.
         /// </summary>
         /// <param name="jsonData">The ReadOnlySpan&lt;byte&gt; containing the UTF-8 encoded JSON text to process.</param>
         /// <param name="state">If this is the first call to the ctor, pass in a default state. Otherwise,
-        /// capture the state from the previous instance of the <see cref="Utf8JsonReader"/> and pass that back.</param>
+        /// capture the state from the previous instance of the <see cref="Utf8JsonReader_Old"/> and pass that back.</param>
         /// <remarks>
         /// Since this type is a ref struct, it is a stack-only type and all the limitations of ref structs apply to it.
         /// This is the reason why the ctor accepts a <see cref="JsonReaderState"/>.
         /// </remarks>
-        public Utf8JsonReader(ReadOnlyMemory<byte> jsonData, JsonReaderState state)
+        public Utf8JsonReader_Old(ReadOnlyMemory<byte> jsonData, JsonReaderState state)
         {
             _buffer = jsonData;
 
@@ -207,7 +207,7 @@ namespace Serde.Json
         /// Read the next JSON token from input source.
         /// </summary>
         /// <returns>True if the token was read successfully, else false.</returns>
-        /// <exception cref="JsonException">
+        /// <exception cref="JsonException_Old">
         /// Thrown when an invalid JSON token is encountered according to the JSON RFC
         /// or if the current depth exceeds the recursive limit set by the max depth.
         /// </exception>
@@ -228,7 +228,7 @@ namespace Serde.Json
         /// <summary>
         /// Skips the children of the current JSON token.
         /// </summary>
-        /// <exception cref="JsonException">
+        /// <exception cref="JsonException_Old">
         /// Thrown when an invalid JSON token is encountered while skipping, according to the JSON RFC,
         /// or if the current depth exceeds the recursive limit set by the max depth.
         /// </exception>
@@ -275,7 +275,7 @@ namespace Serde.Json
         /// Tries to skip the children of the current JSON token.
         /// </summary>
         /// <returns>True if there was enough data for the children to be skipped successfully, else false.</returns>
-        /// <exception cref="JsonException">
+        /// <exception cref="JsonException_Old">
         /// Thrown when an invalid JSON token is encountered while skipping, according to the JSON RFC,
         /// or if the current depth exceeds the recursive limit set by the max depth.
         /// </exception>

--- a/test/Serde.Generation.Test/test_output/AllInOneTest.GeneratorTest/Serde.Test.AllInOne.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/AllInOneTest.GeneratorTest/Serde.Test.AllInOne.IDeserialize.verified.cs
@@ -21,12 +21,13 @@ namespace Serde.Test
             int _l_intfield = default !;
             long _l_longfield = default !;
             string _l_stringfield = default !;
+            string _l_escapedstringfield = default !;
             string? _l_nullstringfield = default !;
             uint[] _l_uintarr = default !;
             int[][] _l_nestedarr = default !;
             System.Collections.Immutable.ImmutableArray<int> _l_intimm = default !;
             Serde.Test.AllInOne.ColorEnum _l_color = default !;
-            ushort _r_assignedValid = 0;
+            uint _r_assignedValid = 0;
             var _l_serdeInfo = global::Serde.SerdeInfoProvider.GetInfo<AllInOne>();
             var typeDeserialize = deserializer.DeserializeType(_l_serdeInfo);
             int _l_index_;
@@ -36,76 +37,81 @@ namespace Serde.Test
                 {
                     case 0:
                         _l_boolfield = typeDeserialize.ReadValue<bool, global::Serde.BoolWrap>(_l_index_);
-                        _r_assignedValid |= ((ushort)1) << 0;
+                        _r_assignedValid |= ((uint)1) << 0;
                         break;
                     case 1:
                         _l_charfield = typeDeserialize.ReadValue<char, global::Serde.CharWrap>(_l_index_);
-                        _r_assignedValid |= ((ushort)1) << 1;
+                        _r_assignedValid |= ((uint)1) << 1;
                         break;
                     case 2:
                         _l_bytefield = typeDeserialize.ReadValue<byte, global::Serde.ByteWrap>(_l_index_);
-                        _r_assignedValid |= ((ushort)1) << 2;
+                        _r_assignedValid |= ((uint)1) << 2;
                         break;
                     case 3:
                         _l_ushortfield = typeDeserialize.ReadValue<ushort, global::Serde.UInt16Wrap>(_l_index_);
-                        _r_assignedValid |= ((ushort)1) << 3;
+                        _r_assignedValid |= ((uint)1) << 3;
                         break;
                     case 4:
                         _l_uintfield = typeDeserialize.ReadValue<uint, global::Serde.UInt32Wrap>(_l_index_);
-                        _r_assignedValid |= ((ushort)1) << 4;
+                        _r_assignedValid |= ((uint)1) << 4;
                         break;
                     case 5:
                         _l_ulongfield = typeDeserialize.ReadValue<ulong, global::Serde.UInt64Wrap>(_l_index_);
-                        _r_assignedValid |= ((ushort)1) << 5;
+                        _r_assignedValid |= ((uint)1) << 5;
                         break;
                     case 6:
                         _l_sbytefield = typeDeserialize.ReadValue<sbyte, global::Serde.SByteWrap>(_l_index_);
-                        _r_assignedValid |= ((ushort)1) << 6;
+                        _r_assignedValid |= ((uint)1) << 6;
                         break;
                     case 7:
                         _l_shortfield = typeDeserialize.ReadValue<short, global::Serde.Int16Wrap>(_l_index_);
-                        _r_assignedValid |= ((ushort)1) << 7;
+                        _r_assignedValid |= ((uint)1) << 7;
                         break;
                     case 8:
                         _l_intfield = typeDeserialize.ReadValue<int, global::Serde.Int32Wrap>(_l_index_);
-                        _r_assignedValid |= ((ushort)1) << 8;
+                        _r_assignedValid |= ((uint)1) << 8;
                         break;
                     case 9:
                         _l_longfield = typeDeserialize.ReadValue<long, global::Serde.Int64Wrap>(_l_index_);
-                        _r_assignedValid |= ((ushort)1) << 9;
+                        _r_assignedValid |= ((uint)1) << 9;
                         break;
                     case 10:
                         _l_stringfield = typeDeserialize.ReadValue<string, global::Serde.StringWrap>(_l_index_);
-                        _r_assignedValid |= ((ushort)1) << 10;
+                        _r_assignedValid |= ((uint)1) << 10;
                         break;
                     case 11:
-                        _l_nullstringfield = typeDeserialize.ReadValue<string?, Serde.NullableRefWrap.DeserializeImpl<string, global::Serde.StringWrap>>(_l_index_);
-                        _r_assignedValid |= ((ushort)1) << 11;
+                        _l_escapedstringfield = typeDeserialize.ReadValue<string, global::Serde.StringWrap>(_l_index_);
+                        _r_assignedValid |= ((uint)1) << 11;
                         break;
                     case 12:
-                        _l_uintarr = typeDeserialize.ReadValue<uint[], Serde.ArrayWrap.DeserializeImpl<uint, global::Serde.UInt32Wrap>>(_l_index_);
-                        _r_assignedValid |= ((ushort)1) << 12;
+                        _l_nullstringfield = typeDeserialize.ReadValue<string?, Serde.NullableRefWrap.DeserializeImpl<string, global::Serde.StringWrap>>(_l_index_);
+                        _r_assignedValid |= ((uint)1) << 12;
                         break;
                     case 13:
-                        _l_nestedarr = typeDeserialize.ReadValue<int[][], Serde.ArrayWrap.DeserializeImpl<int[], Serde.ArrayWrap.DeserializeImpl<int, global::Serde.Int32Wrap>>>(_l_index_);
-                        _r_assignedValid |= ((ushort)1) << 13;
+                        _l_uintarr = typeDeserialize.ReadValue<uint[], Serde.ArrayWrap.DeserializeImpl<uint, global::Serde.UInt32Wrap>>(_l_index_);
+                        _r_assignedValid |= ((uint)1) << 13;
                         break;
                     case 14:
-                        _l_intimm = typeDeserialize.ReadValue<System.Collections.Immutable.ImmutableArray<int>, Serde.ImmutableArrayWrap.DeserializeImpl<int, global::Serde.Int32Wrap>>(_l_index_);
-                        _r_assignedValid |= ((ushort)1) << 14;
+                        _l_nestedarr = typeDeserialize.ReadValue<int[][], Serde.ArrayWrap.DeserializeImpl<int[], Serde.ArrayWrap.DeserializeImpl<int, global::Serde.Int32Wrap>>>(_l_index_);
+                        _r_assignedValid |= ((uint)1) << 14;
                         break;
                     case 15:
+                        _l_intimm = typeDeserialize.ReadValue<System.Collections.Immutable.ImmutableArray<int>, Serde.ImmutableArrayWrap.DeserializeImpl<int, global::Serde.Int32Wrap>>(_l_index_);
+                        _r_assignedValid |= ((uint)1) << 15;
+                        break;
+                    case 16:
                         _l_color = typeDeserialize.ReadValue<Serde.Test.AllInOne.ColorEnum, Serde.Test.AllInOne.ColorEnumWrap>(_l_index_);
-                        _r_assignedValid |= ((ushort)1) << 15;
+                        _r_assignedValid |= ((uint)1) << 16;
                         break;
                     case Serde.IDeserializeType.IndexNotFound:
+                        typeDeserialize.SkipValue();
                         break;
                     default:
                         throw new InvalidOperationException("Unexpected index: " + _l_index_);
                 }
             }
 
-            if ((_r_assignedValid & 0b1111011111111111) != 0b1111011111111111)
+            if ((_r_assignedValid & 0b11110111111111111) != 0b11110111111111111)
             {
                 throw Serde.DeserializeException.UnassignedMember();
             }
@@ -123,6 +129,7 @@ namespace Serde.Test
                 IntField = _l_intfield,
                 LongField = _l_longfield,
                 StringField = _l_stringfield,
+                EscapedStringField = _l_escapedstringfield,
                 NullStringField = _l_nullstringfield,
                 UIntArr = _l_uintarr,
                 NestedArr = _l_nestedarr,

--- a/test/Serde.Generation.Test/test_output/AllInOneTest.GeneratorTest/Serde.Test.AllInOne.ISerdeInfoProvider.verified.cs
+++ b/test/Serde.Generation.Test/test_output/AllInOneTest.GeneratorTest/Serde.Test.AllInOne.ISerdeInfoProvider.verified.cs
@@ -19,6 +19,7 @@ partial record AllInOne : Serde.ISerdeInfoProvider
 ("intField", global::Serde.SerdeInfoProvider.GetInfo<global::Serde.Int32Wrap>(), typeof(Serde.Test.AllInOne).GetField("IntField")!),
 ("longField", global::Serde.SerdeInfoProvider.GetInfo<global::Serde.Int64Wrap>(), typeof(Serde.Test.AllInOne).GetField("LongField")!),
 ("stringField", global::Serde.SerdeInfoProvider.GetInfo<global::Serde.StringWrap>(), typeof(Serde.Test.AllInOne).GetField("StringField")!),
+("escapedStringField", global::Serde.SerdeInfoProvider.GetInfo<global::Serde.StringWrap>(), typeof(Serde.Test.AllInOne).GetField("EscapedStringField")!),
 ("nullStringField", global::Serde.SerdeInfoProvider.GetInfo<Serde.NullableRefWrap.SerializeImpl<string,global::Serde.StringWrap>>(), typeof(Serde.Test.AllInOne).GetField("NullStringField")!),
 ("uIntArr", global::Serde.SerdeInfoProvider.GetInfo<Serde.ArrayWrap.SerializeImpl<uint,global::Serde.UInt32Wrap>>(), typeof(Serde.Test.AllInOne).GetField("UIntArr")!),
 ("nestedArr", global::Serde.SerdeInfoProvider.GetInfo<Serde.ArrayWrap.SerializeImpl<int[],Serde.ArrayWrap.SerializeImpl<int,global::Serde.Int32Wrap>>>(), typeof(Serde.Test.AllInOne).GetField("NestedArr")!),

--- a/test/Serde.Generation.Test/test_output/AllInOneTest.GeneratorTest/Serde.Test.AllInOne.ISerialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/AllInOneTest.GeneratorTest/Serde.Test.AllInOne.ISerialize.verified.cs
@@ -23,11 +23,12 @@ namespace Serde.Test
             type.SerializeField<int, global::Serde.Int32Wrap>(_l_serdeInfo, 8, value.IntField);
             type.SerializeField<long, global::Serde.Int64Wrap>(_l_serdeInfo, 9, value.LongField);
             type.SerializeField<string, global::Serde.StringWrap>(_l_serdeInfo, 10, value.StringField);
-            type.SerializeFieldIfNotNull<string?, Serde.NullableRefWrap.SerializeImpl<string, global::Serde.StringWrap>>(_l_serdeInfo, 11, value.NullStringField);
-            type.SerializeField<uint[], Serde.ArrayWrap.SerializeImpl<uint, global::Serde.UInt32Wrap>>(_l_serdeInfo, 12, value.UIntArr);
-            type.SerializeField<int[][], Serde.ArrayWrap.SerializeImpl<int[], Serde.ArrayWrap.SerializeImpl<int, global::Serde.Int32Wrap>>>(_l_serdeInfo, 13, value.NestedArr);
-            type.SerializeField<System.Collections.Immutable.ImmutableArray<int>, Serde.ImmutableArrayWrap.SerializeImpl<int, global::Serde.Int32Wrap>>(_l_serdeInfo, 14, value.IntImm);
-            type.SerializeField<Serde.Test.AllInOne.ColorEnum, Serde.Test.AllInOne.ColorEnumWrap>(_l_serdeInfo, 15, value.Color);
+            type.SerializeField<string, global::Serde.StringWrap>(_l_serdeInfo, 11, value.EscapedStringField);
+            type.SerializeFieldIfNotNull<string?, Serde.NullableRefWrap.SerializeImpl<string, global::Serde.StringWrap>>(_l_serdeInfo, 12, value.NullStringField);
+            type.SerializeField<uint[], Serde.ArrayWrap.SerializeImpl<uint, global::Serde.UInt32Wrap>>(_l_serdeInfo, 13, value.UIntArr);
+            type.SerializeField<int[][], Serde.ArrayWrap.SerializeImpl<int[], Serde.ArrayWrap.SerializeImpl<int, global::Serde.Int32Wrap>>>(_l_serdeInfo, 14, value.NestedArr);
+            type.SerializeField<System.Collections.Immutable.ImmutableArray<int>, Serde.ImmutableArrayWrap.SerializeImpl<int, global::Serde.Int32Wrap>>(_l_serdeInfo, 15, value.IntImm);
+            type.SerializeField<Serde.Test.AllInOne.ColorEnum, Serde.Test.AllInOne.ColorEnumWrap>(_l_serdeInfo, 16, value.Color);
             type.End();
         }
     }

--- a/test/Serde.Generation.Test/test_output/DeserializeTests.EnumMember/C.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/DeserializeTests.EnumMember/C.IDeserialize.verified.cs
@@ -37,6 +37,7 @@ partial class C : Serde.IDeserialize<C>
                     _r_assignedValid |= ((byte)1) << 3;
                     break;
                 case Serde.IDeserializeType.IndexNotFound:
+                    typeDeserialize.SkipValue();
                     break;
                 default:
                     throw new InvalidOperationException("Unexpected index: " + _l_index_);

--- a/test/Serde.Generation.Test/test_output/DeserializeTests.NestedExplicitDeserializeWrapper/OptsWrap.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/DeserializeTests.NestedExplicitDeserializeWrapper/OptsWrap.IDeserialize.verified.cs
@@ -37,6 +37,7 @@ partial record struct OptsWrap : Serde.IDeserialize<System.Runtime.InteropServic
                     _r_assignedValid |= ((byte)1) << 3;
                     break;
                 case Serde.IDeserializeType.IndexNotFound:
+                    typeDeserialize.SkipValue();
                     break;
                 default:
                     throw new InvalidOperationException("Unexpected index: " + _l_index_);

--- a/test/Serde.Generation.Test/test_output/DeserializeTests.NestedExplicitDeserializeWrapper/S.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/DeserializeTests.NestedExplicitDeserializeWrapper/S.IDeserialize.verified.cs
@@ -22,6 +22,7 @@ partial struct S : Serde.IDeserialize<S>
                     _r_assignedValid |= ((byte)1) << 0;
                     break;
                 case Serde.IDeserializeType.IndexNotFound:
+                    typeDeserialize.SkipValue();
                     break;
                 default:
                     throw new InvalidOperationException("Unexpected index: " + _l_index_);

--- a/test/Serde.Generation.Test/test_output/DeserializeTests/Array#ArrayField.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/DeserializeTests/Array#ArrayField.IDeserialize.verified.cs
@@ -22,6 +22,7 @@ partial class ArrayField : Serde.IDeserialize<ArrayField>
                     _r_assignedValid |= ((byte)1) << 0;
                     break;
                 case Serde.IDeserializeType.IndexNotFound:
+                    typeDeserialize.SkipValue();
                     break;
                 default:
                     throw new InvalidOperationException("Unexpected index: " + _l_index_);

--- a/test/Serde.Generation.Test/test_output/DeserializeTests/DeserializeMissing#SetToNull.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/DeserializeTests/DeserializeMissing#SetToNull.IDeserialize.verified.cs
@@ -32,6 +32,7 @@ partial record struct SetToNull : Serde.IDeserialize<SetToNull>
                     _r_assignedValid |= ((byte)1) << 2;
                     break;
                 case Serde.IDeserializeType.IndexNotFound:
+                    typeDeserialize.SkipValue();
                     break;
                 default:
                     throw new InvalidOperationException("Unexpected index: " + _l_index_);

--- a/test/Serde.Generation.Test/test_output/DeserializeTests/DeserializeOnlyWrap#Wrap.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/DeserializeTests/DeserializeOnlyWrap#Wrap.IDeserialize.verified.cs
@@ -37,6 +37,7 @@ partial record struct Wrap : Serde.IDeserialize<System.Runtime.InteropServices.C
                     _r_assignedValid |= ((byte)1) << 3;
                     break;
                 case Serde.IDeserializeType.IndexNotFound:
+                    typeDeserialize.SkipValue();
                     break;
                 default:
                     throw new InvalidOperationException("Unexpected index: " + _l_index_);

--- a/test/Serde.Generation.Test/test_output/DeserializeTests/MemberSkip#Rgb.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/DeserializeTests/MemberSkip#Rgb.IDeserialize.verified.cs
@@ -27,6 +27,7 @@ partial struct Rgb : Serde.IDeserialize<Rgb>
                     _r_assignedValid |= ((byte)1) << 1;
                     break;
                 case Serde.IDeserializeType.IndexNotFound:
+                    typeDeserialize.SkipValue();
                     break;
                 default:
                     throw new InvalidOperationException("Unexpected index: " + _l_index_);

--- a/test/Serde.Generation.Test/test_output/DeserializeTests/MemberSkipDeserialize#Rgb.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/DeserializeTests/MemberSkipDeserialize#Rgb.IDeserialize.verified.cs
@@ -28,6 +28,7 @@ partial struct Rgb : Serde.IDeserialize<Rgb>
                     break;
                 case 1:
                 case Serde.IDeserializeType.IndexNotFound:
+                    typeDeserialize.SkipValue();
                     break;
                 default:
                     throw new InvalidOperationException("Unexpected index: " + _l_index_);

--- a/test/Serde.Generation.Test/test_output/DeserializeTests/MemberSkipSerialize#Rgb.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/DeserializeTests/MemberSkipSerialize#Rgb.IDeserialize.verified.cs
@@ -32,6 +32,7 @@ partial struct Rgb : Serde.IDeserialize<Rgb>
                     _r_assignedValid |= ((byte)1) << 2;
                     break;
                 case Serde.IDeserializeType.IndexNotFound:
+                    typeDeserialize.SkipValue();
                     break;
                 default:
                     throw new InvalidOperationException("Unexpected index: " + _l_index_);

--- a/test/Serde.Generation.Test/test_output/DeserializeTests/NestedPartialClasses#A.B.C.D.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/DeserializeTests/NestedPartialClasses#A.B.C.D.IDeserialize.verified.cs
@@ -28,6 +28,7 @@ partial class A
                                 _r_assignedValid |= ((byte)1) << 0;
                                 break;
                             case Serde.IDeserializeType.IndexNotFound:
+                                typeDeserialize.SkipValue();
                                 break;
                             default:
                                 throw new InvalidOperationException("Unexpected index: " + _l_index_);

--- a/test/Serde.Generation.Test/test_output/DeserializeTests/NullableRefField#S.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/DeserializeTests/NullableRefField#S.IDeserialize.verified.cs
@@ -22,6 +22,7 @@ partial struct S : Serde.IDeserialize<S>
                     _r_assignedValid |= ((byte)1) << 0;
                     break;
                 case Serde.IDeserializeType.IndexNotFound:
+                    typeDeserialize.SkipValue();
                     break;
                 default:
                     throw new InvalidOperationException("Unexpected index: " + _l_index_);

--- a/test/Serde.Generation.Test/test_output/DeserializeTests/Rgb#Rgb.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/DeserializeTests/Rgb#Rgb.IDeserialize.verified.cs
@@ -32,6 +32,7 @@ partial struct Rgb : Serde.IDeserialize<Rgb>
                     _r_assignedValid |= ((byte)1) << 2;
                     break;
                 case Serde.IDeserializeType.IndexNotFound:
+                    typeDeserialize.SkipValue();
                     break;
                 default:
                     throw new InvalidOperationException("Unexpected index: " + _l_index_);

--- a/test/Serde.Generation.Test/test_output/MemberFormatTests.EnumValues/S.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/MemberFormatTests.EnumValues/S.IDeserialize.verified.cs
@@ -22,6 +22,7 @@ partial struct S : Serde.IDeserialize<S>
                     _r_assignedValid |= ((byte)1) << 0;
                     break;
                 case Serde.IDeserializeType.IndexNotFound:
+                    typeDeserialize.SkipValue();
                     break;
                 default:
                     throw new InvalidOperationException("Unexpected index: " + _l_index_);

--- a/test/Serde.Generation.Test/test_output/MemberFormatTests.EnumValues/S2.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/MemberFormatTests.EnumValues/S2.IDeserialize.verified.cs
@@ -22,6 +22,7 @@ partial struct S2 : Serde.IDeserialize<S2>
                     _r_assignedValid |= ((byte)1) << 0;
                     break;
                 case Serde.IDeserializeType.IndexNotFound:
+                    typeDeserialize.SkipValue();
                     break;
                 default:
                     throw new InvalidOperationException("Unexpected index: " + _l_index_);

--- a/test/Serde.Generation.Test/test_output/MemberFormatTests.KebabCase/S.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/MemberFormatTests.KebabCase/S.IDeserialize.verified.cs
@@ -27,6 +27,7 @@ partial struct S : Serde.IDeserialize<S>
                     _r_assignedValid |= ((byte)1) << 1;
                     break;
                 case Serde.IDeserializeType.IndexNotFound:
+                    typeDeserialize.SkipValue();
                     break;
                 default:
                     throw new InvalidOperationException("Unexpected index: " + _l_index_);

--- a/test/Serde.Generation.Test/test_output/SerializeTests.NestedExplicitSerializeWrapper/OPTSWrap.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/SerializeTests.NestedExplicitSerializeWrapper/OPTSWrap.IDeserialize.verified.cs
@@ -37,6 +37,7 @@ partial record struct OPTSWrap : Serde.IDeserialize<System.Runtime.InteropServic
                     _r_assignedValid |= ((byte)1) << 3;
                     break;
                 case Serde.IDeserializeType.IndexNotFound:
+                    typeDeserialize.SkipValue();
                     break;
                 default:
                     throw new InvalidOperationException("Unexpected index: " + _l_index_);

--- a/test/Serde.Generation.Test/test_output/SerializeTests.NestedExplicitSerializeWrapper/S.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/SerializeTests.NestedExplicitSerializeWrapper/S.IDeserialize.verified.cs
@@ -22,6 +22,7 @@ partial struct S : Serde.IDeserialize<S>
                     _r_assignedValid |= ((byte)1) << 0;
                     break;
                 case Serde.IDeserializeType.IndexNotFound:
+                    typeDeserialize.SkipValue();
                     break;
                 default:
                     throw new InvalidOperationException("Unexpected index: " + _l_index_);

--- a/test/Serde.Generation.Test/test_output/WrapperTests.ExplicitInvalidGenericWrapper/Container.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/WrapperTests.ExplicitInvalidGenericWrapper/Container.IDeserialize.verified.cs
@@ -22,6 +22,7 @@ partial record Container : Serde.IDeserialize<Container>
                     _r_assignedValid |= ((byte)1) << 0;
                     break;
                 case Serde.IDeserializeType.IndexNotFound:
+                    typeDeserialize.SkipValue();
                     break;
                 default:
                     throw new InvalidOperationException("Unexpected index: " + _l_index_);

--- a/test/Serde.Generation.Test/test_output/WrapperTests.ExplicitInvalidGenericWrapper/Original.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/WrapperTests.ExplicitInvalidGenericWrapper/Original.IDeserialize.verified.cs
@@ -22,6 +22,7 @@ partial record struct Original : Serde.IDeserialize<Original>
                     _r_assignedValid |= ((byte)1) << 0;
                     break;
                 case Serde.IDeserializeType.IndexNotFound:
+                    typeDeserialize.SkipValue();
                     break;
                 default:
                     throw new InvalidOperationException("Unexpected index: " + _l_index_);

--- a/test/Serde.Generation.Test/test_output/WrapperTests.ExplicitNullableProxy/Container.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/WrapperTests.ExplicitNullableProxy/Container.IDeserialize.verified.cs
@@ -22,6 +22,7 @@ partial record Container : Serde.IDeserialize<Container>
                     _r_assignedValid |= ((byte)1) << 0;
                     break;
                 case Serde.IDeserializeType.IndexNotFound:
+                    typeDeserialize.SkipValue();
                     break;
                 default:
                     throw new InvalidOperationException("Unexpected index: " + _l_index_);

--- a/test/Serde.Generation.Test/test_output/WrapperTests.ExplicitNullableProxy/Original.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/WrapperTests.ExplicitNullableProxy/Original.IDeserialize.verified.cs
@@ -22,6 +22,7 @@ partial record struct Original : Serde.IDeserialize<Original>
                     _r_assignedValid |= ((byte)1) << 0;
                     break;
                 case Serde.IDeserializeType.IndexNotFound:
+                    typeDeserialize.SkipValue();
                     break;
                 default:
                     throw new InvalidOperationException("Unexpected index: " + _l_index_);

--- a/test/Serde.Generation.Test/test_output/WrapperTests.GenerateSerdeWrap/OPTSWrap.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/WrapperTests.GenerateSerdeWrap/OPTSWrap.IDeserialize.verified.cs
@@ -37,6 +37,7 @@ partial record struct OPTSWrap : Serde.IDeserialize<System.Runtime.InteropServic
                     _r_assignedValid |= ((byte)1) << 3;
                     break;
                 case Serde.IDeserializeType.IndexNotFound:
+                    typeDeserialize.SkipValue();
                     break;
                 default:
                     throw new InvalidOperationException("Unexpected index: " + _l_index_);

--- a/test/Serde.Generation.Test/test_output/WrapperTests.ImmutableArrayEnumDeserialize/Test.ChannelList.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/WrapperTests.ImmutableArrayEnumDeserialize/Test.ChannelList.IDeserialize.verified.cs
@@ -24,6 +24,7 @@ namespace Test
                         _r_assignedValid |= ((byte)1) << 0;
                         break;
                     case Serde.IDeserializeType.IndexNotFound:
+                        typeDeserialize.SkipValue();
                         break;
                     default:
                         throw new InvalidOperationException("Unexpected index: " + _l_index_);

--- a/test/Serde.Generation.Test/test_output/WrapperTests.NestedDeserializeWrap/C.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/WrapperTests.NestedDeserializeWrap/C.IDeserialize.verified.cs
@@ -22,6 +22,7 @@ partial class C : Serde.IDeserialize<C>
                     _r_assignedValid |= ((byte)1) << 0;
                     break;
                 case Serde.IDeserializeType.IndexNotFound:
+                    typeDeserialize.SkipValue();
                     break;
                 default:
                     throw new InvalidOperationException("Unexpected index: " + _l_index_);

--- a/test/Serde.Generation.Test/test_output/WrapperTests.NestedDeserializeWrap/OPTSWrap.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/WrapperTests.NestedDeserializeWrap/OPTSWrap.IDeserialize.verified.cs
@@ -37,6 +37,7 @@ partial record struct OPTSWrap : Serde.IDeserialize<System.Runtime.InteropServic
                     _r_assignedValid |= ((byte)1) << 3;
                     break;
                 case Serde.IDeserializeType.IndexNotFound:
+                    typeDeserialize.SkipValue();
                     break;
                 default:
                     throw new InvalidOperationException("Unexpected index: " + _l_index_);

--- a/test/Serde.Generation.Test/test_output/WrapperTests.PointWrap/PointWrap.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/WrapperTests.PointWrap/PointWrap.IDeserialize.verified.cs
@@ -27,6 +27,7 @@ partial struct PointWrap : Serde.IDeserialize<Point>
                     _r_assignedValid |= ((byte)1) << 1;
                     break;
                 case Serde.IDeserializeType.IndexNotFound:
+                    typeDeserialize.SkipValue();
                     break;
                 default:
                     throw new InvalidOperationException("Unexpected index: " + _l_index_);

--- a/test/Serde.Generation.Test/test_output/WrapperTests.PositionalRecordDeserialize/R.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/WrapperTests.PositionalRecordDeserialize/R.IDeserialize.verified.cs
@@ -27,6 +27,7 @@ partial record R : Serde.IDeserialize<R>
                     _r_assignedValid |= ((byte)1) << 1;
                     break;
                 case Serde.IDeserializeType.IndexNotFound:
+                    typeDeserialize.SkipValue();
                     break;
                 default:
                     throw new InvalidOperationException("Unexpected index: " + _l_index_);

--- a/test/Serde.Generation.Test/test_output/WrapperTests.RecursiveType/Test.Parent.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/WrapperTests.RecursiveType/Test.Parent.IDeserialize.verified.cs
@@ -24,6 +24,7 @@ namespace Test
                         _r_assignedValid |= ((byte)1) << 0;
                         break;
                     case Serde.IDeserializeType.IndexNotFound:
+                        typeDeserialize.SkipValue();
                         break;
                     default:
                         throw new InvalidOperationException("Unexpected index: " + _l_index_);

--- a/test/Serde.Generation.Test/test_output/WrapperTests.RecursiveType/Test.RecursiveWrap.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/WrapperTests.RecursiveType/Test.RecursiveWrap.IDeserialize.verified.cs
@@ -24,6 +24,7 @@ namespace Test
                         _r_assignedValid |= ((byte)1) << 0;
                         break;
                     case Serde.IDeserializeType.IndexNotFound:
+                        typeDeserialize.SkipValue();
                         break;
                     default:
                         throw new InvalidOperationException("Unexpected index: " + _l_index_);

--- a/test/Serde.Test/AllInOneSrc.cs
+++ b/test/Serde.Test/AllInOneSrc.cs
@@ -30,6 +30,8 @@ namespace Serde.Test
 
         public string StringField = "StringValue";
 
+        public required string EscapedStringField;
+
         public string? NullStringField = null;
 
         public uint[] UIntArr = null!;
@@ -62,6 +64,7 @@ namespace Serde.Test
                 IntField == other.IntField &&
                 LongField == other.LongField &&
                 StringField == other.StringField &&
+                EscapedStringField == other.EscapedStringField &&
                 NullStringField == other.NullStringField &&
                 UIntArr.AsSpan().SequenceEqual(other.UIntArr.AsSpan()) &&
                 NestedArr.AsSpan().SequenceEqual(other.NestedArr.AsSpan(),
@@ -102,6 +105,7 @@ namespace Serde.Test
             LongField = long.MaxValue,
 
             StringField = "StringValue",
+            EscapedStringField = "+0 11 222 333 44",
 
             UIntArr = new uint[] { 1, 2, 3 },
             NestedArr = new[] { new[] { 1 }, new[] { 2 } },
@@ -124,6 +128,7 @@ namespace Serde.Test
   "intField": 2147483647,
   "longField": 9223372036854775807,
   "stringField": "StringValue",
+  "escapedStringField": "\u002B0 11 222 333 44",
   "uIntArr": [
     1,
     2,

--- a/test/Serde.Test/InvalidJsonTests.cs
+++ b/test/Serde.Test/InvalidJsonTests.cs
@@ -1,0 +1,479 @@
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.ExceptionServices;
+using System.Text.Json;
+using Xunit;
+
+namespace Serde.Json.Test;
+
+public sealed partial class InvalidJsonTests
+{
+    [Fact]
+    public void Empty()
+    {
+        AssertInvalid("");
+    }
+
+    [Fact]
+    public void LeadingZero()
+    {
+        AssertInvalid("01");
+    }
+
+    [Fact]
+    public void DoubleComma()
+    {
+        AssertInvalid("[ 1 ,, 2]");
+        AssertInvalid("""
+        { "a": 1,,  "b": 2 }
+        """);
+    }
+
+    [Fact]
+    public void SkipDoubleComma()
+    {
+        AssertInvalid<SkipClass>("""
+        { "d": [ 1,,2 ] }, "c": 3 }
+        """);
+        AssertInvalid<SkipClass>("""
+        { "d": { "a": 1,,  "b": 2 }, "c": 3 }
+        """);
+    }
+
+    [GenerateDeserialize]
+    private partial class SkipClass
+    {
+        public int C { get; set; }
+    }
+
+    [Fact]
+    public void CommaBeforeFirstElement()
+    {
+        AssertInvalid("[,1]");
+        AssertInvalid("{, \"a\": 1}");
+    }
+
+    private static void AssertInvalid(string json)
+    {
+        var stj = Assert.Throws<System.Text.Json.JsonException>(() => System.Text.Json.JsonSerializer.Deserialize<JsonElement>(json));
+        var serde = Assert.Throws<Serde.Json.JsonException>(() => Serde.Json.JsonSerializer.Deserialize<JsonValue>(json));
+    }
+
+    private static void AssertInvalid<T>(string json) where T : IDeserialize<T>
+    {
+        var stj = Assert.Throws<System.Text.Json.JsonException>(() => System.Text.Json.JsonSerializer.Deserialize<T>(json));
+        var serde = Assert.Throws<Serde.Json.JsonException>(() => Serde.Json.JsonSerializer.Deserialize<T>(json));
+    }
+
+    [Theory]
+    [InlineData(typeof(ImmutableDictionary<string, string>),
+        typeof(ImmutableDictWrap.DeserializeImpl<string, StringWrap, string, StringWrap>), "\"headers\"")]
+    [InlineData(typeof(Dictionary<string, string>), typeof(DictWrap.DeserializeImpl<string, StringWrap, string, StringWrap>), "\"headers\"")]
+    [InlineData(typeof(PocoDictionary), typeof(PocoDictionary), "\"headers\"")]
+    public static void InvalidJsonForValueShouldFail(Type type, Type deserializeImpl, string json)
+    {
+        AssertInvalid(type, deserializeImpl, json);
+    }
+
+    public static IEnumerable<string> InvalidJsonForIntValue()
+    {
+        yield return @"""1""";
+        yield return "[";
+        yield return "}";
+        yield return @"[""1""]";
+        yield return "[true]";
+    }
+
+    public static IEnumerable<string> InvalidJsonForPoco()
+    {
+        foreach (string value in InvalidJsonForIntValue())
+        {
+            yield return value;
+            yield return "[" + value + "]";
+            if (value != "}")
+            {
+                // Skip "{}}" becaues this is an invalid deserialization before the JSON error
+                yield return "{" + value + "}";
+            }
+            yield return @"{""id"":" + value + "}";
+        }
+    }
+
+    [GenerateDeserialize]
+    public partial class PocoWithParameterizedCtor
+    {
+        public required int Obj { get; set; }
+    }
+
+    [GenerateDeserialize]
+    public partial class ClassWithInt
+    {
+        public required int Obj { get; set; }
+    }
+
+    [GenerateDeserialize]
+    public partial class ClassWithIntList
+    {
+        public required List<int> Obj { get; set; }
+    }
+
+    [GenerateDeserialize]
+    public partial class ClassWithIntArray
+    {
+        public required int[] Obj { get; set; }
+    }
+
+    [GenerateDeserialize]
+    public partial class ClassWithPoco
+    {
+        public required Poco Obj { get; set; }
+    }
+
+    //[GenerateDeserialize]
+    //public partial class ClassWithParameterizedCtor_WithPoco
+    //{
+    //    public required PocoWithParameterizedCtor Obj { get; set; }
+
+    //    public ClassWithParameterizedCtor_WithPoco(PocoWithParameterizedCtor obj) => Obj = obj;
+    //}
+
+    [GenerateDeserialize]
+    public partial class ClassWithPocoArray
+    {
+        public required Poco[] Obj { get; set; }
+    }
+
+    //public class ClassWithParameterizedCtor_WithPocoArray
+    //{
+    //    public PocoWithParameterizedCtor[] Obj { get; set; }
+
+    //    public ClassWithParameterizedCtor_WithPocoArray(PocoWithParameterizedCtor[] obj) => Obj = obj;
+    //}
+
+    [GenerateDeserialize]
+    public partial class ClassWithDictionaryOfIntArray
+    {
+        public required Dictionary<string, int[]> Obj { get; set; }
+    }
+
+    [GenerateDeserialize]
+    public partial class ClassWithDictionaryOfPoco
+    {
+        public required Dictionary<string, Poco> Obj { get; set; }
+    }
+
+    [GenerateDeserialize]
+    public partial class ClassWithDictionaryOfPocoList
+    {
+        public required Dictionary<string, List<Poco>> Obj { get; set; }
+    }
+
+    //public class ClassWithParameterizedCtor_WithDictionaryOfPocoList
+    //{
+    //    public Dictionary<string, List<PocoWithParameterizedCtor>> Obj { get; set; }
+
+    //    public ClassWithParameterizedCtor_WithDictionaryOfPocoList(Dictionary<string, List<PocoWithParameterizedCtor>> obj) => Obj = obj;
+    //}
+
+    public static IEnumerable<(Type, Type)> TypesForInvalidJsonForCollectionTests()
+    {
+        var elementTypes = new Dictionary<Type, Type>
+        {
+            [typeof(int)] = typeof(Int32Wrap),
+            [typeof(Poco)] = typeof(Poco),
+            [typeof(ClassWithInt)] = typeof(ClassWithInt),
+            [typeof(ClassWithIntList)] = typeof(ClassWithIntList),
+            [typeof(ClassWithPoco)] = typeof(ClassWithPoco),
+            [typeof(ClassWithPocoArray)] = typeof(ClassWithPocoArray),
+            [typeof(ClassWithDictionaryOfIntArray)] = typeof(ClassWithDictionaryOfIntArray),
+            [typeof(ClassWithDictionaryOfPoco)] = typeof(ClassWithDictionaryOfPoco),
+            [typeof(ClassWithDictionaryOfPocoList)] = typeof(ClassWithDictionaryOfPocoList),
+            [typeof(PocoWithParameterizedCtor)] = typeof(PocoWithParameterizedCtor),
+            //[typeof(ClassWithParameterizedCtor_WithPoco)] = typeof(ClassWithParameterizedCtor_WithPoco),
+            //[typeof(ClassWithParameterizedCtor_WithPocoArray)] = typeof(ClassWithParameterizedCtor_WithPocoArray),
+            //[typeof(ClassWithParameterizedCtor_WithDictionaryOfPocoList)] = typeof(ClassWithParameterizedCtor_WithDictionaryOfPocoList),
+        };
+
+        Type GetImplType(Type input)
+        {
+            // Recursively walk the type and find the impls
+            if (input == typeof(string))
+            {
+                return typeof(StringWrap);
+            }
+            if (!input.IsGenericType)
+            {
+                return elementTypes[input];
+            }
+            var def = input.GetGenericTypeDefinition();
+            if (def == typeof(List<>))
+            {
+                var arg = input.GetGenericArguments()[0];
+                return typeof(ListWrap.DeserializeImpl<,>).MakeGenericType(
+                    arg,
+                    GetImplType(arg));
+            }
+            else if (def == typeof(Dictionary<,>))
+            {
+                var keyArg = input.GetGenericArguments()[0];
+                var valueArg = input.GetGenericArguments()[1];
+                return typeof(DictWrap.DeserializeImpl<,,,>).MakeGenericType(
+                    keyArg,
+                    GetImplType(keyArg),
+                    valueArg,
+                    GetImplType(valueArg));
+            }
+            throw new ArgumentException("Unexpected type: " + input);
+        }
+
+        (Type, Type) MakeClosedCollectionType(Type openCollectionType, Type elementType)
+        {
+            if (openCollectionType == typeof(Dictionary<,>))
+            {
+                return (typeof(Dictionary<,>).MakeGenericType(typeof(string), elementType),
+                        typeof(DictWrap.DeserializeImpl<,,,>).MakeGenericType(
+                            typeof(string),
+                            typeof(StringWrap),
+                            elementType,
+                            GetImplType(elementType)));
+            }
+            else if (openCollectionType == typeof(List<>))
+            {
+                return (typeof(List<>).MakeGenericType(elementType),
+                        typeof(ListWrap.DeserializeImpl<,>).MakeGenericType(
+                            elementType,
+                            GetImplType(elementType)));
+            }
+            throw new InvalidOperationException("Unexpected collection type");
+        }
+
+        Type[] collectionTypes = new Type[]
+        {
+            typeof(List<>),
+            typeof(Dictionary<,>),
+        };
+
+        foreach (var elem in elementTypes)
+        {
+            yield return (elem.Key, elem.Value);
+        }
+
+        List<Type> innerTypes = new List<Type>(elementTypes.Keys);
+
+        // Create permutations of collections with 1 and 2 levels of nesting.
+        for (int i = 0; i < 2; i++)
+        {
+            foreach (Type collectionType in collectionTypes)
+            {
+                List<Type> newInnerTypes = new List<Type>();
+
+                foreach (Type elementType in innerTypes)
+                {
+                    var collectionTypeAndDeserializeImpl = MakeClosedCollectionType(collectionType, elementType);
+                    newInnerTypes.Add(collectionTypeAndDeserializeImpl.Item1);
+                    yield return collectionTypeAndDeserializeImpl;
+                }
+
+                innerTypes = newInnerTypes;
+            }
+        }
+    }
+
+    static IEnumerable<string> GetInvalidJsonStringsForType(Type type)
+    {
+        if (type == typeof(int))
+        {
+            foreach (string json in InvalidJsonForIntValue())
+            {
+                yield return json;
+            }
+            yield break;
+        }
+
+        if (type == typeof(Poco))
+        {
+            foreach (string json in InvalidJsonForPoco())
+            {
+                yield return json;
+            }
+            yield break;
+        }
+
+        Type elementType;
+
+        if (!typeof(IEnumerable).IsAssignableFrom(type))
+        {
+            // Get type of "Obj" property.
+            elementType = type.GetProperties(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)[0].PropertyType;
+        }
+        else if (type.IsArray)
+        {
+            elementType = type.GetElementType()!;
+        }
+        else if (!type.IsGenericType)
+        {
+            Assert.Fail("Expected generic type");
+            yield break;
+        }
+        else
+        {
+            Type genericTypeDef = type.GetGenericTypeDefinition();
+
+            if (genericTypeDef == typeof(List<>))
+            {
+                elementType = type.GetGenericArguments()[0];
+            }
+            else if (genericTypeDef == typeof(Dictionary<,>))
+            {
+                elementType = type.GetGenericArguments()[1];
+            }
+            else
+            {
+                Assert.Fail("Expected List or Dictionary type");
+                yield break;
+            }
+        }
+
+        foreach (string invalidJson in GetInvalidJsonStringsForType(elementType))
+        {
+            yield return "[" + invalidJson + "]";
+            if (invalidJson != "}")
+            {
+                // Skip "}}" becaues this is an invalid deserialization before the JSON error
+                yield return "{" + invalidJson + "}";
+            }
+            yield return @"{""obj"":" + invalidJson + "}";
+        }
+    }
+
+    public static IEnumerable<object[]> DataForInvalidJsonForTypeTests()
+    {
+        foreach (var (type, deserializeImpl) in TypesForInvalidJsonForCollectionTests())
+        {
+            foreach (string invalidJson in GetInvalidJsonStringsForType(type))
+            {
+                yield return new object[] { type, deserializeImpl, invalidJson };
+            }
+        }
+
+        yield return new object[] { typeof(int[]), typeof(ArrayWrap.DeserializeImpl<int, Int32Wrap>), @"""test""" };
+        yield return new object[] { typeof(int[]), typeof(ArrayWrap.DeserializeImpl<int, Int32Wrap>), @"1" };
+        yield return new object[] { typeof(int[]), typeof(ArrayWrap.DeserializeImpl<int, Int32Wrap>), @"false" };
+        yield return new object[] { typeof(int[]), typeof(ArrayWrap.DeserializeImpl<int, Int32Wrap>), @"{}" };
+        yield return new object[] { typeof(int[]), typeof(ArrayWrap.DeserializeImpl<int, Int32Wrap>), @"{""test"": 1}" };
+        yield return new object[] { typeof(int[]), typeof(ArrayWrap.DeserializeImpl<int, Int32Wrap>), @"[""test""" };
+        yield return new object[] { typeof(int[]), typeof(ArrayWrap.DeserializeImpl<int, Int32Wrap>), @"[""test""]" };
+        yield return new object[] { typeof(int[]), typeof(ArrayWrap.DeserializeImpl<int, Int32Wrap>), @"[true]" };
+        yield return new object[] { typeof(int[]), typeof(ArrayWrap.DeserializeImpl<int, Int32Wrap>), @"[{}]" };
+        yield return new object[] { typeof(int[]), typeof(ArrayWrap.DeserializeImpl<int, Int32Wrap>), @"[[]]" };
+        yield return new object[] { typeof(int[]), typeof(ArrayWrap.DeserializeImpl<int, Int32Wrap>), @"[{""test"": 1}]" };
+        yield return new object[] { typeof(int[]), typeof(ArrayWrap.DeserializeImpl<int, Int32Wrap>), @"[[true]]" };
+        yield return new object[] { typeof(Dictionary<string, int[]>), typeof(DictWrap.DeserializeImpl<string, StringWrap, int[], ArrayWrap.DeserializeImpl<int, Int32Wrap>>), @"{""test"": {}}" };
+        yield return new object[] { typeof(Dictionary<string, int[]>), typeof(DictWrap.DeserializeImpl<string, StringWrap, int[], ArrayWrap.DeserializeImpl<int, Int32Wrap>>), @"{""test"": {""test"": 1}}" };
+        yield return new object[] { typeof(Dictionary<string, int[]>), typeof(DictWrap.DeserializeImpl<string, StringWrap, int[], ArrayWrap.DeserializeImpl<int, Int32Wrap>>), @"{""test"": ""test""}" };
+        yield return new object[] { typeof(Dictionary<string, int[]>), typeof(DictWrap.DeserializeImpl<string, StringWrap, int[], ArrayWrap.DeserializeImpl<int, Int32Wrap>>), @"{""test"": 1}" };
+        yield return new object[] { typeof(Dictionary<string, int[]>), typeof(DictWrap.DeserializeImpl<string, StringWrap, int[], ArrayWrap.DeserializeImpl<int, Int32Wrap>>), @"{""test"": true}" };
+        yield return new object[] { typeof(Dictionary<string, int[]>), typeof(DictWrap.DeserializeImpl<string, StringWrap, int[], ArrayWrap.DeserializeImpl<int, Int32Wrap>>), @"{""test"": [""test""}" };
+        yield return new object[] { typeof(Dictionary<string, int[]>), typeof(DictWrap.DeserializeImpl<string, StringWrap, int[], ArrayWrap.DeserializeImpl<int, Int32Wrap>>), @"{""test"": [""test""]}" };
+        yield return new object[] { typeof(Dictionary<string, int[]>), typeof(DictWrap.DeserializeImpl<string, StringWrap, int[], ArrayWrap.DeserializeImpl<int, Int32Wrap>>), @"{""test"": [[]]}" };
+        yield return new object[] { typeof(Dictionary<string, int[]>), typeof(DictWrap.DeserializeImpl<string, StringWrap, int[], ArrayWrap.DeserializeImpl<int, Int32Wrap>>), @"{""test"": [true]}" };
+        yield return new object[] { typeof(Dictionary<string, int[]>), typeof(DictWrap.DeserializeImpl<string, StringWrap, int[], ArrayWrap.DeserializeImpl<int, Int32Wrap>>), @"{""test"": [{}]}" };
+        yield return new object[] { typeof(ClassWithIntArray), typeof(ClassWithIntArray), @"{""obj"": ""test""}" };
+        yield return new object[] { typeof(ClassWithIntArray), typeof(ClassWithIntArray), @"{""obj"": 1}" };
+        yield return new object[] { typeof(ClassWithIntArray), typeof(ClassWithIntArray), @"{""obj"": false}" };
+        yield return new object[] { typeof(ClassWithIntArray), typeof(ClassWithIntArray), @"{""obj"": {}}" };
+        yield return new object[] { typeof(ClassWithIntArray), typeof(ClassWithIntArray), @"{""obj"": {""test"": 1}}" };
+        yield return new object[] { typeof(ClassWithIntArray), typeof(ClassWithIntArray), @"{""obj"": [""test""}" };
+        yield return new object[] { typeof(ClassWithIntArray), typeof(ClassWithIntArray), @"{""obj"": [""test""]}" };
+        yield return new object[] { typeof(ClassWithIntArray), typeof(ClassWithIntArray), @"{""obj"": [true]}" };
+        yield return new object[] { typeof(ClassWithIntArray), typeof(ClassWithIntArray), @"{""obj"": [{}]}" };
+        yield return new object[] { typeof(ClassWithIntArray), typeof(ClassWithIntArray), @"{""obj"": [[]]}" };
+        yield return new object[] { typeof(ClassWithIntArray), typeof(ClassWithIntArray), @"{""obj"": [{""test"": 1}]}" };
+        yield return new object[] { typeof(ClassWithIntArray), typeof(ClassWithIntArray), @"{""obj"": [[true]]}" };
+        yield return new object[] { typeof(Dictionary<string, string>), typeof(DictWrap.DeserializeImpl<string, StringWrap, string, StringWrap>), @"""test""" };
+        yield return new object[] { typeof(Dictionary<string, string>), typeof(DictWrap.DeserializeImpl<string, StringWrap, string, StringWrap>), @"1" };
+        yield return new object[] { typeof(Dictionary<string, string>), typeof(DictWrap.DeserializeImpl<string, StringWrap, string, StringWrap>), @"false" };
+        yield return new object[] { typeof(Dictionary<string, string>), typeof(DictWrap.DeserializeImpl<string, StringWrap, string, StringWrap>), @"{"""": 1}" };
+        yield return new object[] { typeof(Dictionary<string, string>), typeof(DictWrap.DeserializeImpl<string, StringWrap, string, StringWrap>), @"{"""": {}}" };
+        yield return new object[] { typeof(Dictionary<string, string>), typeof(DictWrap.DeserializeImpl<string, StringWrap, string, StringWrap>), @"{"""": {"""":""""}}" };
+        yield return new object[] { typeof(Dictionary<string, string>), typeof(DictWrap.DeserializeImpl<string, StringWrap, string, StringWrap>), @"[""test""" };
+        yield return new object[] { typeof(Dictionary<string, string>), typeof(DictWrap.DeserializeImpl<string, StringWrap, string, StringWrap>), @"[""test""]" };
+        yield return new object[] { typeof(Dictionary<string, string>), typeof(DictWrap.DeserializeImpl<string, StringWrap, string, StringWrap>), @"[true]" };
+        yield return new object[] { typeof(Dictionary<string, string>), typeof(DictWrap.DeserializeImpl<string, StringWrap, string, StringWrap>), @"[{}]" };
+        yield return new object[] { typeof(Dictionary<string, string>), typeof(DictWrap.DeserializeImpl<string, StringWrap, string, StringWrap>), @"[[]]" };
+        yield return new object[] { typeof(Dictionary<string, string>), typeof(DictWrap.DeserializeImpl<string, StringWrap, string, StringWrap>), @"[{""test"": 1}]" };
+        yield return new object[] { typeof(Dictionary<string, string>), typeof(DictWrap.DeserializeImpl<string, StringWrap, string, StringWrap>), @"[[true]]" };
+        yield return new object[] { typeof(ClassWithDictionaryOfIntArray), typeof(ClassWithDictionaryOfIntArray), @"{""obj"":""test""}" };
+        yield return new object[] { typeof(ClassWithDictionaryOfIntArray), typeof(ClassWithDictionaryOfIntArray), @"{""obj"":1}" };
+        yield return new object[] { typeof(ClassWithDictionaryOfIntArray), typeof(ClassWithDictionaryOfIntArray), @"{""obj"":false}" };
+        yield return new object[] { typeof(ClassWithDictionaryOfIntArray), typeof(ClassWithDictionaryOfIntArray), @"{""obj"":{"""": 1}}" };
+        yield return new object[] { typeof(ClassWithDictionaryOfIntArray), typeof(ClassWithDictionaryOfIntArray), @"{""obj"":{"""": {}}}" };
+        yield return new object[] { typeof(ClassWithDictionaryOfIntArray), typeof(ClassWithDictionaryOfIntArray), @"{""obj"":{"""": {"""":""""}}}" };
+        yield return new object[] { typeof(ClassWithDictionaryOfIntArray), typeof(ClassWithDictionaryOfIntArray), @"{""obj"":[""test""}" };
+        yield return new object[] { typeof(ClassWithDictionaryOfIntArray), typeof(ClassWithDictionaryOfIntArray), @"{""obj"":[""test""]}" };
+        yield return new object[] { typeof(ClassWithDictionaryOfIntArray), typeof(ClassWithDictionaryOfIntArray), @"{""obj"":[true]}" };
+        yield return new object[] { typeof(ClassWithDictionaryOfIntArray), typeof(ClassWithDictionaryOfIntArray), @"{""obj"":[{}]}" };
+        yield return new object[] { typeof(ClassWithDictionaryOfIntArray), typeof(ClassWithDictionaryOfIntArray), @"{""obj"":[[]]}" };
+        yield return new object[] { typeof(ClassWithDictionaryOfIntArray), typeof(ClassWithDictionaryOfIntArray), @"{""obj"":[{""test"": 1}]}" };
+        yield return new object[] { typeof(ClassWithDictionaryOfIntArray), typeof(ClassWithDictionaryOfIntArray), @"{""obj"":[[true]]}" };
+        yield return new object[] { typeof(Dictionary<string, Poco>), typeof(DictWrap.DeserializeImpl<string, StringWrap, Poco, Poco>), @"{""key"":[{""id"":3}]}" };
+        yield return new object[] { typeof(Dictionary<string, Poco>), typeof(DictWrap.DeserializeImpl<string, StringWrap, Poco, Poco>), @"{""key"":[""test""]}" };
+        yield return new object[] { typeof(Dictionary<string, Poco>), typeof(DictWrap.DeserializeImpl<string, StringWrap, Poco, Poco>), @"{""key"":[1]}" };
+        yield return new object[] { typeof(Dictionary<string, Poco>), typeof(DictWrap.DeserializeImpl<string, StringWrap, Poco, Poco>), @"{""key"":[false]}" };
+        yield return new object[] { typeof(Dictionary<string, Poco>), typeof(DictWrap.DeserializeImpl<string, StringWrap, Poco, Poco>), @"{""key"":[]}" };
+        yield return new object[] { typeof(Dictionary<string, Poco>), typeof(DictWrap.DeserializeImpl<string, StringWrap, Poco, Poco>), @"{""key"":1}" };
+        yield return new object[] { typeof(Dictionary<string, List<Poco>>), typeof(DictWrap.DeserializeImpl<string, StringWrap, List<Poco>, ListWrap.DeserializeImpl<Poco, Poco>>), @"{""key"":{}}" };
+        yield return new object[] { typeof(Dictionary<string, List<Poco>>), typeof(DictWrap.DeserializeImpl<string, StringWrap, List<Poco>, ListWrap.DeserializeImpl<Poco, Poco>>), @"{""key"":[[]]}" };
+        yield return new object[] { typeof(Dictionary<string, Dictionary<string, Poco>>), typeof(DictWrap.DeserializeImpl<string, StringWrap, Dictionary<string, Poco>, DictWrap.DeserializeImpl<string, StringWrap, Poco, Poco>>), @"{""key"":[]}" };
+        yield return new object[] { typeof(Dictionary<string, Dictionary<string, Poco>>), typeof(DictWrap.DeserializeImpl<string, StringWrap, Dictionary<string, Poco>, DictWrap.DeserializeImpl<string, StringWrap, Poco, Poco>>), @"{""key"":1}" };
+    }
+
+    [Fact]
+    public static void InvalidJsonForTypeShouldFail()
+    {
+        foreach (object[] args in DataForInvalidJsonForTypeTests()) // ~140K tests, too many for theory to handle well with our infrastructure
+        {
+            var type = (Type)args[0];
+            var deserializeImpl = (Type)args[1];
+            var invalidJson = (string)args[2];
+            AssertInvalid(type, deserializeImpl, invalidJson);
+        }
+    }
+
+    private static void AssertInvalid(Type type, Type deserializeImpl, string invalidJson)
+    {
+        try
+        {
+            GetDeserialize().MakeGenericMethod(
+                type,
+                deserializeImpl)!.Invoke(null, [invalidJson]);
+        }
+        catch (Exception e)
+        {
+            if (e.InnerException is { } inner and not JsonException)
+            {
+                ExceptionDispatchInfo.Capture(inner).Throw();
+            }
+        }
+    }
+
+    private static readonly MethodInfo s_deserialize = typeof(JsonSerializer)
+            .GetMethods()
+            .First(mi =>
+                mi.Name == "Deserialize"
+                && mi.GetGenericArguments().Length == 2
+                && mi.GetParameters().SingleOrDefault()?.ParameterType == typeof(string));
+
+    private static MethodInfo GetDeserialize() => s_deserialize;
+
+    [Fact]
+    public static void InvalidEmptyDictionaryInput()
+    {
+        Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<string, StringWrap>("{}"));
+    }
+}

--- a/test/Serde.Test/JsonDeserializeTests.cs
+++ b/test/Serde.Test/JsonDeserializeTests.cs
@@ -58,6 +58,13 @@ namespace Serde.Test
         }
 
         [Fact]
+        public void BadValueAtEnd()
+        {
+            var src = "123 456";
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<JsonValue>(src));
+        }
+
+        [Fact]
         public void DeserializeBool()
         {
             var src = "true";
@@ -357,6 +364,54 @@ namespace Serde.Test
             Red,
             Green,
             Blue
+        }
+
+        [Fact]
+        public void StringsWithEscapes()
+        {
+            var loc = JsonSerializer.Deserialize<Location>(Location.SampleString);
+            Assert.Equal(Location.Sample, loc);
+        }
+
+        [GenerateDeserialize]
+        public partial record Location
+        {
+            public int Id { get; set; }
+            public required string Address1 { get; set; }
+            public required string Address2 { get; set; }
+            public required string City { get; set; }
+            public required string State { get; set; }
+            public required string PostalCode { get; set; }
+            public required string Name { get; set; }
+            public required string PhoneNumber { get; set; }
+            public required string Country { get; set; }
+
+            public const string SampleString = """
+{
+    "id": 1234,
+    "address1": "The Street Name",
+    "address2": "20/11",
+    "city": "The City",
+    "state": "The State",
+    "postalCode": "abc-12",
+    "name": "Nonexisting",
+    "phoneNumber": "+0 11 222 333 44",
+    "country": "The Greatest"
+}
+""";
+
+            public static Location Sample => new Location
+            {
+                Id = 1234,
+                Address1 = "The Street Name",
+                Address2 = "20/11",
+                City = "The City",
+                State = "The State",
+                PostalCode = "abc-12",
+                Name = "Nonexisting",
+                PhoneNumber = "+0 11 222 333 44",
+                Country = "The Greatest"
+            };
         }
     }
 }

--- a/test/Serde.Test/TestClasses.cs
+++ b/test/Serde.Test/TestClasses.cs
@@ -1,0 +1,26 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Text;
+using Xunit;
+
+namespace Serde.Json.Test;
+
+[GenerateDeserialize]
+public partial class PocoDictionary
+{
+    public Dictionary<string, string> key { get; set; }
+}
+
+[GenerateDeserialize]
+public partial class Poco
+{
+    public int Id { get; set; }
+}

--- a/test/Serde.Test/TestClasses.cs
+++ b/test/Serde.Test/TestClasses.cs
@@ -16,7 +16,7 @@ namespace Serde.Json.Test;
 [GenerateDeserialize]
 public partial class PocoDictionary
 {
-    public Dictionary<string, string> key { get; set; }
+    public required Dictionary<string, string> key { get; set; }
 }
 
 [GenerateDeserialize]

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Json.Test.InvalidJsonTests.ClassWithDictionaryOfIntArray.IDeserialize.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Json.Test.InvalidJsonTests.ClassWithDictionaryOfIntArray.IDeserialize.cs
@@ -1,0 +1,48 @@
+﻿
+#nullable enable
+using System;
+using Serde;
+
+namespace Serde.Json.Test
+{
+    partial class InvalidJsonTests
+    {
+        partial class ClassWithDictionaryOfIntArray : Serde.IDeserialize<Serde.Json.Test.InvalidJsonTests.ClassWithDictionaryOfIntArray>
+        {
+            static Serde.Json.Test.InvalidJsonTests.ClassWithDictionaryOfIntArray Serde.IDeserialize<Serde.Json.Test.InvalidJsonTests.ClassWithDictionaryOfIntArray>.Deserialize(IDeserializer deserializer)
+            {
+                System.Collections.Generic.Dictionary<string, int[]> _l_obj = default !;
+                byte _r_assignedValid = 0;
+                var _l_serdeInfo = global::Serde.SerdeInfoProvider.GetInfo<ClassWithDictionaryOfIntArray>();
+                var typeDeserialize = deserializer.DeserializeType(_l_serdeInfo);
+                int _l_index_;
+                while ((_l_index_ = typeDeserialize.TryReadIndex(_l_serdeInfo, out var _l_errorName)) != IDeserializeType.EndOfType)
+                {
+                    switch (_l_index_)
+                    {
+                        case 0:
+                            _l_obj = typeDeserialize.ReadValue<System.Collections.Generic.Dictionary<string, int[]>, Serde.DictWrap.DeserializeImpl<string, global::Serde.StringWrap, int[], Serde.ArrayWrap.DeserializeImpl<int, global::Serde.Int32Wrap>>>(_l_index_);
+                            _r_assignedValid |= ((byte)1) << 0;
+                            break;
+                        case Serde.IDeserializeType.IndexNotFound:
+                            typeDeserialize.SkipValue();
+                            break;
+                        default:
+                            throw new InvalidOperationException("Unexpected index: " + _l_index_);
+                    }
+                }
+
+                if ((_r_assignedValid & 0b1) != 0b1)
+                {
+                    throw Serde.DeserializeException.UnassignedMember();
+                }
+
+                var newType = new Serde.Json.Test.InvalidJsonTests.ClassWithDictionaryOfIntArray()
+                {
+                    Obj = _l_obj,
+                };
+                return newType;
+            }
+        }
+    }
+}

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Json.Test.InvalidJsonTests.ClassWithDictionaryOfIntArray.ISerdeInfoProvider.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Json.Test.InvalidJsonTests.ClassWithDictionaryOfIntArray.ISerdeInfoProvider.cs
@@ -1,0 +1,15 @@
+﻿
+#nullable enable
+namespace Serde.Json.Test;
+partial class InvalidJsonTests
+{
+    partial class ClassWithDictionaryOfIntArray : Serde.ISerdeInfoProvider
+{
+    static global::Serde.ISerdeInfo global::Serde.ISerdeInfoProvider.SerdeInfo { get; } = Serde.SerdeInfo.MakeCustom(
+        "ClassWithDictionaryOfIntArray",
+        typeof(Serde.Json.Test.InvalidJsonTests.ClassWithDictionaryOfIntArray).GetCustomAttributesData(),
+        new (string, global::Serde.ISerdeInfo, System.Reflection.MemberInfo)[] {
+("obj", global::Serde.SerdeInfoProvider.GetInfo<Serde.DictWrap.DeserializeImpl<string,global::Serde.StringWrap,int[],Serde.ArrayWrap.DeserializeImpl<int,global::Serde.Int32Wrap>>>(), typeof(Serde.Json.Test.InvalidJsonTests.ClassWithDictionaryOfIntArray).GetProperty("Obj")!)
+    });
+}
+}

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Json.Test.InvalidJsonTests.ClassWithDictionaryOfPoco.IDeserialize.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Json.Test.InvalidJsonTests.ClassWithDictionaryOfPoco.IDeserialize.cs
@@ -1,0 +1,48 @@
+﻿
+#nullable enable
+using System;
+using Serde;
+
+namespace Serde.Json.Test
+{
+    partial class InvalidJsonTests
+    {
+        partial class ClassWithDictionaryOfPoco : Serde.IDeserialize<Serde.Json.Test.InvalidJsonTests.ClassWithDictionaryOfPoco>
+        {
+            static Serde.Json.Test.InvalidJsonTests.ClassWithDictionaryOfPoco Serde.IDeserialize<Serde.Json.Test.InvalidJsonTests.ClassWithDictionaryOfPoco>.Deserialize(IDeserializer deserializer)
+            {
+                System.Collections.Generic.Dictionary<string, Serde.Json.Test.Poco> _l_obj = default !;
+                byte _r_assignedValid = 0;
+                var _l_serdeInfo = global::Serde.SerdeInfoProvider.GetInfo<ClassWithDictionaryOfPoco>();
+                var typeDeserialize = deserializer.DeserializeType(_l_serdeInfo);
+                int _l_index_;
+                while ((_l_index_ = typeDeserialize.TryReadIndex(_l_serdeInfo, out var _l_errorName)) != IDeserializeType.EndOfType)
+                {
+                    switch (_l_index_)
+                    {
+                        case 0:
+                            _l_obj = typeDeserialize.ReadValue<System.Collections.Generic.Dictionary<string, Serde.Json.Test.Poco>, Serde.DictWrap.DeserializeImpl<string, global::Serde.StringWrap, Serde.Json.Test.Poco, Serde.Json.Test.Poco>>(_l_index_);
+                            _r_assignedValid |= ((byte)1) << 0;
+                            break;
+                        case Serde.IDeserializeType.IndexNotFound:
+                            typeDeserialize.SkipValue();
+                            break;
+                        default:
+                            throw new InvalidOperationException("Unexpected index: " + _l_index_);
+                    }
+                }
+
+                if ((_r_assignedValid & 0b1) != 0b1)
+                {
+                    throw Serde.DeserializeException.UnassignedMember();
+                }
+
+                var newType = new Serde.Json.Test.InvalidJsonTests.ClassWithDictionaryOfPoco()
+                {
+                    Obj = _l_obj,
+                };
+                return newType;
+            }
+        }
+    }
+}

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Json.Test.InvalidJsonTests.ClassWithDictionaryOfPoco.ISerdeInfoProvider.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Json.Test.InvalidJsonTests.ClassWithDictionaryOfPoco.ISerdeInfoProvider.cs
@@ -1,0 +1,15 @@
+﻿
+#nullable enable
+namespace Serde.Json.Test;
+partial class InvalidJsonTests
+{
+    partial class ClassWithDictionaryOfPoco : Serde.ISerdeInfoProvider
+{
+    static global::Serde.ISerdeInfo global::Serde.ISerdeInfoProvider.SerdeInfo { get; } = Serde.SerdeInfo.MakeCustom(
+        "ClassWithDictionaryOfPoco",
+        typeof(Serde.Json.Test.InvalidJsonTests.ClassWithDictionaryOfPoco).GetCustomAttributesData(),
+        new (string, global::Serde.ISerdeInfo, System.Reflection.MemberInfo)[] {
+("obj", global::Serde.SerdeInfoProvider.GetInfo<Serde.DictWrap.DeserializeImpl<string,global::Serde.StringWrap,Serde.Json.Test.Poco,Serde.Json.Test.Poco>>(), typeof(Serde.Json.Test.InvalidJsonTests.ClassWithDictionaryOfPoco).GetProperty("Obj")!)
+    });
+}
+}

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Json.Test.InvalidJsonTests.ClassWithDictionaryOfPocoList.IDeserialize.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Json.Test.InvalidJsonTests.ClassWithDictionaryOfPocoList.IDeserialize.cs
@@ -1,0 +1,48 @@
+﻿
+#nullable enable
+using System;
+using Serde;
+
+namespace Serde.Json.Test
+{
+    partial class InvalidJsonTests
+    {
+        partial class ClassWithDictionaryOfPocoList : Serde.IDeserialize<Serde.Json.Test.InvalidJsonTests.ClassWithDictionaryOfPocoList>
+        {
+            static Serde.Json.Test.InvalidJsonTests.ClassWithDictionaryOfPocoList Serde.IDeserialize<Serde.Json.Test.InvalidJsonTests.ClassWithDictionaryOfPocoList>.Deserialize(IDeserializer deserializer)
+            {
+                System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<Serde.Json.Test.Poco>> _l_obj = default !;
+                byte _r_assignedValid = 0;
+                var _l_serdeInfo = global::Serde.SerdeInfoProvider.GetInfo<ClassWithDictionaryOfPocoList>();
+                var typeDeserialize = deserializer.DeserializeType(_l_serdeInfo);
+                int _l_index_;
+                while ((_l_index_ = typeDeserialize.TryReadIndex(_l_serdeInfo, out var _l_errorName)) != IDeserializeType.EndOfType)
+                {
+                    switch (_l_index_)
+                    {
+                        case 0:
+                            _l_obj = typeDeserialize.ReadValue<System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<Serde.Json.Test.Poco>>, Serde.DictWrap.DeserializeImpl<string, global::Serde.StringWrap, System.Collections.Generic.List<Serde.Json.Test.Poco>, Serde.ListWrap.DeserializeImpl<Serde.Json.Test.Poco, Serde.Json.Test.Poco>>>(_l_index_);
+                            _r_assignedValid |= ((byte)1) << 0;
+                            break;
+                        case Serde.IDeserializeType.IndexNotFound:
+                            typeDeserialize.SkipValue();
+                            break;
+                        default:
+                            throw new InvalidOperationException("Unexpected index: " + _l_index_);
+                    }
+                }
+
+                if ((_r_assignedValid & 0b1) != 0b1)
+                {
+                    throw Serde.DeserializeException.UnassignedMember();
+                }
+
+                var newType = new Serde.Json.Test.InvalidJsonTests.ClassWithDictionaryOfPocoList()
+                {
+                    Obj = _l_obj,
+                };
+                return newType;
+            }
+        }
+    }
+}

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Json.Test.InvalidJsonTests.ClassWithDictionaryOfPocoList.ISerdeInfoProvider.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Json.Test.InvalidJsonTests.ClassWithDictionaryOfPocoList.ISerdeInfoProvider.cs
@@ -1,0 +1,15 @@
+﻿
+#nullable enable
+namespace Serde.Json.Test;
+partial class InvalidJsonTests
+{
+    partial class ClassWithDictionaryOfPocoList : Serde.ISerdeInfoProvider
+{
+    static global::Serde.ISerdeInfo global::Serde.ISerdeInfoProvider.SerdeInfo { get; } = Serde.SerdeInfo.MakeCustom(
+        "ClassWithDictionaryOfPocoList",
+        typeof(Serde.Json.Test.InvalidJsonTests.ClassWithDictionaryOfPocoList).GetCustomAttributesData(),
+        new (string, global::Serde.ISerdeInfo, System.Reflection.MemberInfo)[] {
+("obj", global::Serde.SerdeInfoProvider.GetInfo<Serde.DictWrap.DeserializeImpl<string,global::Serde.StringWrap,System.Collections.Generic.List<Serde.Json.Test.Poco>,Serde.ListWrap.DeserializeImpl<Serde.Json.Test.Poco,Serde.Json.Test.Poco>>>(), typeof(Serde.Json.Test.InvalidJsonTests.ClassWithDictionaryOfPocoList).GetProperty("Obj")!)
+    });
+}
+}

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Json.Test.InvalidJsonTests.ClassWithInt.IDeserialize.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Json.Test.InvalidJsonTests.ClassWithInt.IDeserialize.cs
@@ -1,0 +1,48 @@
+﻿
+#nullable enable
+using System;
+using Serde;
+
+namespace Serde.Json.Test
+{
+    partial class InvalidJsonTests
+    {
+        partial class ClassWithInt : Serde.IDeserialize<Serde.Json.Test.InvalidJsonTests.ClassWithInt>
+        {
+            static Serde.Json.Test.InvalidJsonTests.ClassWithInt Serde.IDeserialize<Serde.Json.Test.InvalidJsonTests.ClassWithInt>.Deserialize(IDeserializer deserializer)
+            {
+                int _l_obj = default !;
+                byte _r_assignedValid = 0;
+                var _l_serdeInfo = global::Serde.SerdeInfoProvider.GetInfo<ClassWithInt>();
+                var typeDeserialize = deserializer.DeserializeType(_l_serdeInfo);
+                int _l_index_;
+                while ((_l_index_ = typeDeserialize.TryReadIndex(_l_serdeInfo, out var _l_errorName)) != IDeserializeType.EndOfType)
+                {
+                    switch (_l_index_)
+                    {
+                        case 0:
+                            _l_obj = typeDeserialize.ReadValue<int, global::Serde.Int32Wrap>(_l_index_);
+                            _r_assignedValid |= ((byte)1) << 0;
+                            break;
+                        case Serde.IDeserializeType.IndexNotFound:
+                            typeDeserialize.SkipValue();
+                            break;
+                        default:
+                            throw new InvalidOperationException("Unexpected index: " + _l_index_);
+                    }
+                }
+
+                if ((_r_assignedValid & 0b1) != 0b1)
+                {
+                    throw Serde.DeserializeException.UnassignedMember();
+                }
+
+                var newType = new Serde.Json.Test.InvalidJsonTests.ClassWithInt()
+                {
+                    Obj = _l_obj,
+                };
+                return newType;
+            }
+        }
+    }
+}

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Json.Test.InvalidJsonTests.ClassWithInt.ISerdeInfoProvider.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Json.Test.InvalidJsonTests.ClassWithInt.ISerdeInfoProvider.cs
@@ -1,0 +1,15 @@
+﻿
+#nullable enable
+namespace Serde.Json.Test;
+partial class InvalidJsonTests
+{
+    partial class ClassWithInt : Serde.ISerdeInfoProvider
+{
+    static global::Serde.ISerdeInfo global::Serde.ISerdeInfoProvider.SerdeInfo { get; } = Serde.SerdeInfo.MakeCustom(
+        "ClassWithInt",
+        typeof(Serde.Json.Test.InvalidJsonTests.ClassWithInt).GetCustomAttributesData(),
+        new (string, global::Serde.ISerdeInfo, System.Reflection.MemberInfo)[] {
+("obj", global::Serde.SerdeInfoProvider.GetInfo<global::Serde.Int32Wrap>(), typeof(Serde.Json.Test.InvalidJsonTests.ClassWithInt).GetProperty("Obj")!)
+    });
+}
+}

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Json.Test.InvalidJsonTests.ClassWithIntArray.IDeserialize.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Json.Test.InvalidJsonTests.ClassWithIntArray.IDeserialize.cs
@@ -1,0 +1,48 @@
+﻿
+#nullable enable
+using System;
+using Serde;
+
+namespace Serde.Json.Test
+{
+    partial class InvalidJsonTests
+    {
+        partial class ClassWithIntArray : Serde.IDeserialize<Serde.Json.Test.InvalidJsonTests.ClassWithIntArray>
+        {
+            static Serde.Json.Test.InvalidJsonTests.ClassWithIntArray Serde.IDeserialize<Serde.Json.Test.InvalidJsonTests.ClassWithIntArray>.Deserialize(IDeserializer deserializer)
+            {
+                int[] _l_obj = default !;
+                byte _r_assignedValid = 0;
+                var _l_serdeInfo = global::Serde.SerdeInfoProvider.GetInfo<ClassWithIntArray>();
+                var typeDeserialize = deserializer.DeserializeType(_l_serdeInfo);
+                int _l_index_;
+                while ((_l_index_ = typeDeserialize.TryReadIndex(_l_serdeInfo, out var _l_errorName)) != IDeserializeType.EndOfType)
+                {
+                    switch (_l_index_)
+                    {
+                        case 0:
+                            _l_obj = typeDeserialize.ReadValue<int[], Serde.ArrayWrap.DeserializeImpl<int, global::Serde.Int32Wrap>>(_l_index_);
+                            _r_assignedValid |= ((byte)1) << 0;
+                            break;
+                        case Serde.IDeserializeType.IndexNotFound:
+                            typeDeserialize.SkipValue();
+                            break;
+                        default:
+                            throw new InvalidOperationException("Unexpected index: " + _l_index_);
+                    }
+                }
+
+                if ((_r_assignedValid & 0b1) != 0b1)
+                {
+                    throw Serde.DeserializeException.UnassignedMember();
+                }
+
+                var newType = new Serde.Json.Test.InvalidJsonTests.ClassWithIntArray()
+                {
+                    Obj = _l_obj,
+                };
+                return newType;
+            }
+        }
+    }
+}

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Json.Test.InvalidJsonTests.ClassWithIntArray.ISerdeInfoProvider.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Json.Test.InvalidJsonTests.ClassWithIntArray.ISerdeInfoProvider.cs
@@ -1,0 +1,15 @@
+﻿
+#nullable enable
+namespace Serde.Json.Test;
+partial class InvalidJsonTests
+{
+    partial class ClassWithIntArray : Serde.ISerdeInfoProvider
+{
+    static global::Serde.ISerdeInfo global::Serde.ISerdeInfoProvider.SerdeInfo { get; } = Serde.SerdeInfo.MakeCustom(
+        "ClassWithIntArray",
+        typeof(Serde.Json.Test.InvalidJsonTests.ClassWithIntArray).GetCustomAttributesData(),
+        new (string, global::Serde.ISerdeInfo, System.Reflection.MemberInfo)[] {
+("obj", global::Serde.SerdeInfoProvider.GetInfo<Serde.ArrayWrap.DeserializeImpl<int,global::Serde.Int32Wrap>>(), typeof(Serde.Json.Test.InvalidJsonTests.ClassWithIntArray).GetProperty("Obj")!)
+    });
+}
+}

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Json.Test.InvalidJsonTests.ClassWithIntList.IDeserialize.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Json.Test.InvalidJsonTests.ClassWithIntList.IDeserialize.cs
@@ -1,0 +1,48 @@
+﻿
+#nullable enable
+using System;
+using Serde;
+
+namespace Serde.Json.Test
+{
+    partial class InvalidJsonTests
+    {
+        partial class ClassWithIntList : Serde.IDeserialize<Serde.Json.Test.InvalidJsonTests.ClassWithIntList>
+        {
+            static Serde.Json.Test.InvalidJsonTests.ClassWithIntList Serde.IDeserialize<Serde.Json.Test.InvalidJsonTests.ClassWithIntList>.Deserialize(IDeserializer deserializer)
+            {
+                System.Collections.Generic.List<int> _l_obj = default !;
+                byte _r_assignedValid = 0;
+                var _l_serdeInfo = global::Serde.SerdeInfoProvider.GetInfo<ClassWithIntList>();
+                var typeDeserialize = deserializer.DeserializeType(_l_serdeInfo);
+                int _l_index_;
+                while ((_l_index_ = typeDeserialize.TryReadIndex(_l_serdeInfo, out var _l_errorName)) != IDeserializeType.EndOfType)
+                {
+                    switch (_l_index_)
+                    {
+                        case 0:
+                            _l_obj = typeDeserialize.ReadValue<System.Collections.Generic.List<int>, Serde.ListWrap.DeserializeImpl<int, global::Serde.Int32Wrap>>(_l_index_);
+                            _r_assignedValid |= ((byte)1) << 0;
+                            break;
+                        case Serde.IDeserializeType.IndexNotFound:
+                            typeDeserialize.SkipValue();
+                            break;
+                        default:
+                            throw new InvalidOperationException("Unexpected index: " + _l_index_);
+                    }
+                }
+
+                if ((_r_assignedValid & 0b1) != 0b1)
+                {
+                    throw Serde.DeserializeException.UnassignedMember();
+                }
+
+                var newType = new Serde.Json.Test.InvalidJsonTests.ClassWithIntList()
+                {
+                    Obj = _l_obj,
+                };
+                return newType;
+            }
+        }
+    }
+}

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Json.Test.InvalidJsonTests.ClassWithIntList.ISerdeInfoProvider.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Json.Test.InvalidJsonTests.ClassWithIntList.ISerdeInfoProvider.cs
@@ -1,0 +1,15 @@
+﻿
+#nullable enable
+namespace Serde.Json.Test;
+partial class InvalidJsonTests
+{
+    partial class ClassWithIntList : Serde.ISerdeInfoProvider
+{
+    static global::Serde.ISerdeInfo global::Serde.ISerdeInfoProvider.SerdeInfo { get; } = Serde.SerdeInfo.MakeCustom(
+        "ClassWithIntList",
+        typeof(Serde.Json.Test.InvalidJsonTests.ClassWithIntList).GetCustomAttributesData(),
+        new (string, global::Serde.ISerdeInfo, System.Reflection.MemberInfo)[] {
+("obj", global::Serde.SerdeInfoProvider.GetInfo<Serde.ListWrap.DeserializeImpl<int,global::Serde.Int32Wrap>>(), typeof(Serde.Json.Test.InvalidJsonTests.ClassWithIntList).GetProperty("Obj")!)
+    });
+}
+}

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Json.Test.InvalidJsonTests.ClassWithParameterizedCtor_WithPoco.IDeserialize.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Json.Test.InvalidJsonTests.ClassWithParameterizedCtor_WithPoco.IDeserialize.cs
@@ -1,0 +1,48 @@
+﻿
+#nullable enable
+using System;
+using Serde;
+
+namespace Serde.Json.Test
+{
+    partial class InvalidJsonTests
+    {
+        partial class ClassWithParameterizedCtor_WithPoco : Serde.IDeserialize<Serde.Json.Test.InvalidJsonTests.ClassWithParameterizedCtor_WithPoco>
+        {
+            static Serde.Json.Test.InvalidJsonTests.ClassWithParameterizedCtor_WithPoco Serde.IDeserialize<Serde.Json.Test.InvalidJsonTests.ClassWithParameterizedCtor_WithPoco>.Deserialize(IDeserializer deserializer)
+            {
+                Serde.Json.Test.InvalidJsonTests.PocoWithParameterizedCtor _l_obj = default !;
+                byte _r_assignedValid = 0;
+                var _l_serdeInfo = global::Serde.SerdeInfoProvider.GetInfo<ClassWithParameterizedCtor_WithPoco>();
+                var typeDeserialize = deserializer.DeserializeType(_l_serdeInfo);
+                int _l_index_;
+                while ((_l_index_ = typeDeserialize.TryReadIndex(_l_serdeInfo, out var _l_errorName)) != IDeserializeType.EndOfType)
+                {
+                    switch (_l_index_)
+                    {
+                        case 0:
+                            _l_obj = typeDeserialize.ReadValue<Serde.Json.Test.InvalidJsonTests.PocoWithParameterizedCtor, Serde.Json.Test.InvalidJsonTests.PocoWithParameterizedCtor>(_l_index_);
+                            _r_assignedValid |= ((byte)1) << 0;
+                            break;
+                        case Serde.IDeserializeType.IndexNotFound:
+                            typeDeserialize.SkipValue();
+                            break;
+                        default:
+                            throw new InvalidOperationException("Unexpected index: " + _l_index_);
+                    }
+                }
+
+                if ((_r_assignedValid & 0b1) != 0b1)
+                {
+                    throw Serde.DeserializeException.UnassignedMember();
+                }
+
+                var newType = new Serde.Json.Test.InvalidJsonTests.ClassWithParameterizedCtor_WithPoco()
+                {
+                    Obj = _l_obj,
+                };
+                return newType;
+            }
+        }
+    }
+}

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Json.Test.InvalidJsonTests.ClassWithParameterizedCtor_WithPoco.ISerdeInfoProvider.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Json.Test.InvalidJsonTests.ClassWithParameterizedCtor_WithPoco.ISerdeInfoProvider.cs
@@ -1,0 +1,15 @@
+﻿
+#nullable enable
+namespace Serde.Json.Test;
+partial class InvalidJsonTests
+{
+    partial class ClassWithParameterizedCtor_WithPoco : Serde.ISerdeInfoProvider
+{
+    static global::Serde.ISerdeInfo global::Serde.ISerdeInfoProvider.SerdeInfo { get; } = Serde.SerdeInfo.MakeCustom(
+        "ClassWithParameterizedCtor_WithPoco",
+        typeof(Serde.Json.Test.InvalidJsonTests.ClassWithParameterizedCtor_WithPoco).GetCustomAttributesData(),
+        new (string, global::Serde.ISerdeInfo, System.Reflection.MemberInfo)[] {
+("obj", global::Serde.SerdeInfoProvider.GetInfo<Serde.Json.Test.InvalidJsonTests.PocoWithParameterizedCtor>(), typeof(Serde.Json.Test.InvalidJsonTests.ClassWithParameterizedCtor_WithPoco).GetProperty("Obj")!)
+    });
+}
+}

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Json.Test.InvalidJsonTests.ClassWithPoco.IDeserialize.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Json.Test.InvalidJsonTests.ClassWithPoco.IDeserialize.cs
@@ -1,0 +1,48 @@
+﻿
+#nullable enable
+using System;
+using Serde;
+
+namespace Serde.Json.Test
+{
+    partial class InvalidJsonTests
+    {
+        partial class ClassWithPoco : Serde.IDeserialize<Serde.Json.Test.InvalidJsonTests.ClassWithPoco>
+        {
+            static Serde.Json.Test.InvalidJsonTests.ClassWithPoco Serde.IDeserialize<Serde.Json.Test.InvalidJsonTests.ClassWithPoco>.Deserialize(IDeserializer deserializer)
+            {
+                Serde.Json.Test.Poco _l_obj = default !;
+                byte _r_assignedValid = 0;
+                var _l_serdeInfo = global::Serde.SerdeInfoProvider.GetInfo<ClassWithPoco>();
+                var typeDeserialize = deserializer.DeserializeType(_l_serdeInfo);
+                int _l_index_;
+                while ((_l_index_ = typeDeserialize.TryReadIndex(_l_serdeInfo, out var _l_errorName)) != IDeserializeType.EndOfType)
+                {
+                    switch (_l_index_)
+                    {
+                        case 0:
+                            _l_obj = typeDeserialize.ReadValue<Serde.Json.Test.Poco, Serde.Json.Test.Poco>(_l_index_);
+                            _r_assignedValid |= ((byte)1) << 0;
+                            break;
+                        case Serde.IDeserializeType.IndexNotFound:
+                            typeDeserialize.SkipValue();
+                            break;
+                        default:
+                            throw new InvalidOperationException("Unexpected index: " + _l_index_);
+                    }
+                }
+
+                if ((_r_assignedValid & 0b1) != 0b1)
+                {
+                    throw Serde.DeserializeException.UnassignedMember();
+                }
+
+                var newType = new Serde.Json.Test.InvalidJsonTests.ClassWithPoco()
+                {
+                    Obj = _l_obj,
+                };
+                return newType;
+            }
+        }
+    }
+}

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Json.Test.InvalidJsonTests.ClassWithPoco.ISerdeInfoProvider.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Json.Test.InvalidJsonTests.ClassWithPoco.ISerdeInfoProvider.cs
@@ -1,0 +1,15 @@
+﻿
+#nullable enable
+namespace Serde.Json.Test;
+partial class InvalidJsonTests
+{
+    partial class ClassWithPoco : Serde.ISerdeInfoProvider
+{
+    static global::Serde.ISerdeInfo global::Serde.ISerdeInfoProvider.SerdeInfo { get; } = Serde.SerdeInfo.MakeCustom(
+        "ClassWithPoco",
+        typeof(Serde.Json.Test.InvalidJsonTests.ClassWithPoco).GetCustomAttributesData(),
+        new (string, global::Serde.ISerdeInfo, System.Reflection.MemberInfo)[] {
+("obj", global::Serde.SerdeInfoProvider.GetInfo<Serde.Json.Test.Poco>(), typeof(Serde.Json.Test.InvalidJsonTests.ClassWithPoco).GetProperty("Obj")!)
+    });
+}
+}

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Json.Test.InvalidJsonTests.ClassWithPocoArray.IDeserialize.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Json.Test.InvalidJsonTests.ClassWithPocoArray.IDeserialize.cs
@@ -1,0 +1,48 @@
+﻿
+#nullable enable
+using System;
+using Serde;
+
+namespace Serde.Json.Test
+{
+    partial class InvalidJsonTests
+    {
+        partial class ClassWithPocoArray : Serde.IDeserialize<Serde.Json.Test.InvalidJsonTests.ClassWithPocoArray>
+        {
+            static Serde.Json.Test.InvalidJsonTests.ClassWithPocoArray Serde.IDeserialize<Serde.Json.Test.InvalidJsonTests.ClassWithPocoArray>.Deserialize(IDeserializer deserializer)
+            {
+                Serde.Json.Test.Poco[] _l_obj = default !;
+                byte _r_assignedValid = 0;
+                var _l_serdeInfo = global::Serde.SerdeInfoProvider.GetInfo<ClassWithPocoArray>();
+                var typeDeserialize = deserializer.DeserializeType(_l_serdeInfo);
+                int _l_index_;
+                while ((_l_index_ = typeDeserialize.TryReadIndex(_l_serdeInfo, out var _l_errorName)) != IDeserializeType.EndOfType)
+                {
+                    switch (_l_index_)
+                    {
+                        case 0:
+                            _l_obj = typeDeserialize.ReadValue<Serde.Json.Test.Poco[], Serde.ArrayWrap.DeserializeImpl<Serde.Json.Test.Poco, Serde.Json.Test.Poco>>(_l_index_);
+                            _r_assignedValid |= ((byte)1) << 0;
+                            break;
+                        case Serde.IDeserializeType.IndexNotFound:
+                            typeDeserialize.SkipValue();
+                            break;
+                        default:
+                            throw new InvalidOperationException("Unexpected index: " + _l_index_);
+                    }
+                }
+
+                if ((_r_assignedValid & 0b1) != 0b1)
+                {
+                    throw Serde.DeserializeException.UnassignedMember();
+                }
+
+                var newType = new Serde.Json.Test.InvalidJsonTests.ClassWithPocoArray()
+                {
+                    Obj = _l_obj,
+                };
+                return newType;
+            }
+        }
+    }
+}

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Json.Test.InvalidJsonTests.ClassWithPocoArray.ISerdeInfoProvider.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Json.Test.InvalidJsonTests.ClassWithPocoArray.ISerdeInfoProvider.cs
@@ -1,0 +1,15 @@
+﻿
+#nullable enable
+namespace Serde.Json.Test;
+partial class InvalidJsonTests
+{
+    partial class ClassWithPocoArray : Serde.ISerdeInfoProvider
+{
+    static global::Serde.ISerdeInfo global::Serde.ISerdeInfoProvider.SerdeInfo { get; } = Serde.SerdeInfo.MakeCustom(
+        "ClassWithPocoArray",
+        typeof(Serde.Json.Test.InvalidJsonTests.ClassWithPocoArray).GetCustomAttributesData(),
+        new (string, global::Serde.ISerdeInfo, System.Reflection.MemberInfo)[] {
+("obj", global::Serde.SerdeInfoProvider.GetInfo<Serde.ArrayWrap.DeserializeImpl<Serde.Json.Test.Poco,Serde.Json.Test.Poco>>(), typeof(Serde.Json.Test.InvalidJsonTests.ClassWithPocoArray).GetProperty("Obj")!)
+    });
+}
+}

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Json.Test.InvalidJsonTests.PocoWithParameterizedCtor.IDeserialize.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Json.Test.InvalidJsonTests.PocoWithParameterizedCtor.IDeserialize.cs
@@ -1,0 +1,48 @@
+﻿
+#nullable enable
+using System;
+using Serde;
+
+namespace Serde.Json.Test
+{
+    partial class InvalidJsonTests
+    {
+        partial class PocoWithParameterizedCtor : Serde.IDeserialize<Serde.Json.Test.InvalidJsonTests.PocoWithParameterizedCtor>
+        {
+            static Serde.Json.Test.InvalidJsonTests.PocoWithParameterizedCtor Serde.IDeserialize<Serde.Json.Test.InvalidJsonTests.PocoWithParameterizedCtor>.Deserialize(IDeserializer deserializer)
+            {
+                int _l_obj = default !;
+                byte _r_assignedValid = 0;
+                var _l_serdeInfo = global::Serde.SerdeInfoProvider.GetInfo<PocoWithParameterizedCtor>();
+                var typeDeserialize = deserializer.DeserializeType(_l_serdeInfo);
+                int _l_index_;
+                while ((_l_index_ = typeDeserialize.TryReadIndex(_l_serdeInfo, out var _l_errorName)) != IDeserializeType.EndOfType)
+                {
+                    switch (_l_index_)
+                    {
+                        case 0:
+                            _l_obj = typeDeserialize.ReadValue<int, global::Serde.Int32Wrap>(_l_index_);
+                            _r_assignedValid |= ((byte)1) << 0;
+                            break;
+                        case Serde.IDeserializeType.IndexNotFound:
+                            typeDeserialize.SkipValue();
+                            break;
+                        default:
+                            throw new InvalidOperationException("Unexpected index: " + _l_index_);
+                    }
+                }
+
+                if ((_r_assignedValid & 0b1) != 0b1)
+                {
+                    throw Serde.DeserializeException.UnassignedMember();
+                }
+
+                var newType = new Serde.Json.Test.InvalidJsonTests.PocoWithParameterizedCtor()
+                {
+                    Obj = _l_obj,
+                };
+                return newType;
+            }
+        }
+    }
+}

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Json.Test.InvalidJsonTests.PocoWithParameterizedCtor.ISerdeInfoProvider.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Json.Test.InvalidJsonTests.PocoWithParameterizedCtor.ISerdeInfoProvider.cs
@@ -1,0 +1,15 @@
+﻿
+#nullable enable
+namespace Serde.Json.Test;
+partial class InvalidJsonTests
+{
+    partial class PocoWithParameterizedCtor : Serde.ISerdeInfoProvider
+{
+    static global::Serde.ISerdeInfo global::Serde.ISerdeInfoProvider.SerdeInfo { get; } = Serde.SerdeInfo.MakeCustom(
+        "PocoWithParameterizedCtor",
+        typeof(Serde.Json.Test.InvalidJsonTests.PocoWithParameterizedCtor).GetCustomAttributesData(),
+        new (string, global::Serde.ISerdeInfo, System.Reflection.MemberInfo)[] {
+("obj", global::Serde.SerdeInfoProvider.GetInfo<global::Serde.Int32Wrap>(), typeof(Serde.Json.Test.InvalidJsonTests.PocoWithParameterizedCtor).GetProperty("Obj")!)
+    });
+}
+}

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Json.Test.InvalidJsonTests.SkipClass.IDeserialize.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Json.Test.InvalidJsonTests.SkipClass.IDeserialize.cs
@@ -1,0 +1,48 @@
+﻿
+#nullable enable
+using System;
+using Serde;
+
+namespace Serde.Json.Test
+{
+    partial class InvalidJsonTests
+    {
+        partial class SkipClass : Serde.IDeserialize<Serde.Json.Test.InvalidJsonTests.SkipClass>
+        {
+            static Serde.Json.Test.InvalidJsonTests.SkipClass Serde.IDeserialize<Serde.Json.Test.InvalidJsonTests.SkipClass>.Deserialize(IDeserializer deserializer)
+            {
+                int _l_c = default !;
+                byte _r_assignedValid = 0;
+                var _l_serdeInfo = global::Serde.SerdeInfoProvider.GetInfo<SkipClass>();
+                var typeDeserialize = deserializer.DeserializeType(_l_serdeInfo);
+                int _l_index_;
+                while ((_l_index_ = typeDeserialize.TryReadIndex(_l_serdeInfo, out var _l_errorName)) != IDeserializeType.EndOfType)
+                {
+                    switch (_l_index_)
+                    {
+                        case 0:
+                            _l_c = typeDeserialize.ReadValue<int, global::Serde.Int32Wrap>(_l_index_);
+                            _r_assignedValid |= ((byte)1) << 0;
+                            break;
+                        case Serde.IDeserializeType.IndexNotFound:
+                            typeDeserialize.SkipValue();
+                            break;
+                        default:
+                            throw new InvalidOperationException("Unexpected index: " + _l_index_);
+                    }
+                }
+
+                if ((_r_assignedValid & 0b1) != 0b1)
+                {
+                    throw Serde.DeserializeException.UnassignedMember();
+                }
+
+                var newType = new Serde.Json.Test.InvalidJsonTests.SkipClass()
+                {
+                    C = _l_c,
+                };
+                return newType;
+            }
+        }
+    }
+}

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Json.Test.InvalidJsonTests.SkipClass.ISerdeInfoProvider.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Json.Test.InvalidJsonTests.SkipClass.ISerdeInfoProvider.cs
@@ -1,0 +1,15 @@
+﻿
+#nullable enable
+namespace Serde.Json.Test;
+partial class InvalidJsonTests
+{
+    partial class SkipClass : Serde.ISerdeInfoProvider
+{
+    static global::Serde.ISerdeInfo global::Serde.ISerdeInfoProvider.SerdeInfo { get; } = Serde.SerdeInfo.MakeCustom(
+        "SkipClass",
+        typeof(Serde.Json.Test.InvalidJsonTests.SkipClass).GetCustomAttributesData(),
+        new (string, global::Serde.ISerdeInfo, System.Reflection.MemberInfo)[] {
+("c", global::Serde.SerdeInfoProvider.GetInfo<global::Serde.Int32Wrap>(), typeof(Serde.Json.Test.InvalidJsonTests.SkipClass).GetProperty("C")!)
+    });
+}
+}

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Json.Test.InvalidJsonTests.SkipDoubleCommaClass.IDeserialize.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Json.Test.InvalidJsonTests.SkipDoubleCommaClass.IDeserialize.cs
@@ -1,0 +1,47 @@
+﻿
+#nullable enable
+using System;
+using Serde;
+
+namespace Serde.Json.Test
+{
+    partial class InvalidJsonTests
+    {
+        partial class SkipDoubleCommaClass : Serde.IDeserialize<Serde.Json.Test.InvalidJsonTests.SkipDoubleCommaClass>
+        {
+            static Serde.Json.Test.InvalidJsonTests.SkipDoubleCommaClass Serde.IDeserialize<Serde.Json.Test.InvalidJsonTests.SkipDoubleCommaClass>.Deserialize(IDeserializer deserializer)
+            {
+                int _l_c = default !;
+                byte _r_assignedValid = 0;
+                var _l_serdeInfo = global::Serde.SerdeInfoProvider.GetInfo<SkipDoubleCommaClass>();
+                var typeDeserialize = deserializer.DeserializeType(_l_serdeInfo);
+                int _l_index_;
+                while ((_l_index_ = typeDeserialize.TryReadIndex(_l_serdeInfo, out var _l_errorName)) != IDeserializeType.EndOfType)
+                {
+                    switch (_l_index_)
+                    {
+                        case 0:
+                            _l_c = typeDeserialize.ReadValue<int, global::Serde.Int32Wrap>(_l_index_);
+                            _r_assignedValid |= ((byte)1) << 0;
+                            break;
+                        case Serde.IDeserializeType.IndexNotFound:
+                            break;
+                        default:
+                            throw new InvalidOperationException("Unexpected index: " + _l_index_);
+                    }
+                }
+
+                if ((_r_assignedValid & 0b1) != 0b1)
+                {
+                    throw Serde.DeserializeException.UnassignedMember();
+                }
+
+                var newType = new Serde.Json.Test.InvalidJsonTests.SkipDoubleCommaClass()
+                {
+                    C = _l_c,
+                };
+                return newType;
+            }
+        }
+    }
+}

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Json.Test.InvalidJsonTests.SkipDoubleCommaClass.ISerdeInfoProvider.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Json.Test.InvalidJsonTests.SkipDoubleCommaClass.ISerdeInfoProvider.cs
@@ -1,0 +1,15 @@
+﻿
+#nullable enable
+namespace Serde.Json.Test;
+partial class InvalidJsonTests
+{
+    partial class SkipDoubleCommaClass : Serde.ISerdeInfoProvider
+{
+    static global::Serde.ISerdeInfo global::Serde.ISerdeInfoProvider.SerdeInfo { get; } = Serde.SerdeInfo.MakeCustom(
+        "SkipDoubleCommaClass",
+        typeof(Serde.Json.Test.InvalidJsonTests.SkipDoubleCommaClass).GetCustomAttributesData(),
+        new (string, global::Serde.ISerdeInfo, System.Reflection.MemberInfo)[] {
+("c", global::Serde.SerdeInfoProvider.GetInfo<global::Serde.Int32Wrap>(), typeof(Serde.Json.Test.InvalidJsonTests.SkipDoubleCommaClass).GetProperty("C")!)
+    });
+}
+}

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Json.Test.Poco.IDeserialize.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Json.Test.Poco.IDeserialize.cs
@@ -1,0 +1,45 @@
+﻿
+#nullable enable
+using System;
+using Serde;
+
+namespace Serde.Json.Test
+{
+    partial class Poco : Serde.IDeserialize<Serde.Json.Test.Poco>
+    {
+        static Serde.Json.Test.Poco Serde.IDeserialize<Serde.Json.Test.Poco>.Deserialize(IDeserializer deserializer)
+        {
+            int _l_id = default !;
+            byte _r_assignedValid = 0;
+            var _l_serdeInfo = global::Serde.SerdeInfoProvider.GetInfo<Poco>();
+            var typeDeserialize = deserializer.DeserializeType(_l_serdeInfo);
+            int _l_index_;
+            while ((_l_index_ = typeDeserialize.TryReadIndex(_l_serdeInfo, out var _l_errorName)) != IDeserializeType.EndOfType)
+            {
+                switch (_l_index_)
+                {
+                    case 0:
+                        _l_id = typeDeserialize.ReadValue<int, global::Serde.Int32Wrap>(_l_index_);
+                        _r_assignedValid |= ((byte)1) << 0;
+                        break;
+                    case Serde.IDeserializeType.IndexNotFound:
+                        typeDeserialize.SkipValue();
+                        break;
+                    default:
+                        throw new InvalidOperationException("Unexpected index: " + _l_index_);
+                }
+            }
+
+            if ((_r_assignedValid & 0b1) != 0b1)
+            {
+                throw Serde.DeserializeException.UnassignedMember();
+            }
+
+            var newType = new Serde.Json.Test.Poco()
+            {
+                Id = _l_id,
+            };
+            return newType;
+        }
+    }
+}

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Json.Test.Poco.ISerdeInfoProvider.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Json.Test.Poco.ISerdeInfoProvider.cs
@@ -1,0 +1,12 @@
+﻿
+#nullable enable
+namespace Serde.Json.Test;
+partial class Poco : Serde.ISerdeInfoProvider
+{
+    static global::Serde.ISerdeInfo global::Serde.ISerdeInfoProvider.SerdeInfo { get; } = Serde.SerdeInfo.MakeCustom(
+        "Poco",
+        typeof(Serde.Json.Test.Poco).GetCustomAttributesData(),
+        new (string, global::Serde.ISerdeInfo, System.Reflection.MemberInfo)[] {
+("id", global::Serde.SerdeInfoProvider.GetInfo<global::Serde.Int32Wrap>(), typeof(Serde.Json.Test.Poco).GetProperty("Id")!)
+    });
+}

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Json.Test.PocoDictionary.IDeserialize.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Json.Test.PocoDictionary.IDeserialize.cs
@@ -1,0 +1,45 @@
+﻿
+#nullable enable
+using System;
+using Serde;
+
+namespace Serde.Json.Test
+{
+    partial class PocoDictionary : Serde.IDeserialize<Serde.Json.Test.PocoDictionary>
+    {
+        static Serde.Json.Test.PocoDictionary Serde.IDeserialize<Serde.Json.Test.PocoDictionary>.Deserialize(IDeserializer deserializer)
+        {
+            System.Collections.Generic.Dictionary<string, string> _l_key = default !;
+            byte _r_assignedValid = 0;
+            var _l_serdeInfo = global::Serde.SerdeInfoProvider.GetInfo<PocoDictionary>();
+            var typeDeserialize = deserializer.DeserializeType(_l_serdeInfo);
+            int _l_index_;
+            while ((_l_index_ = typeDeserialize.TryReadIndex(_l_serdeInfo, out var _l_errorName)) != IDeserializeType.EndOfType)
+            {
+                switch (_l_index_)
+                {
+                    case 0:
+                        _l_key = typeDeserialize.ReadValue<System.Collections.Generic.Dictionary<string, string>, Serde.DictWrap.DeserializeImpl<string, global::Serde.StringWrap, string, global::Serde.StringWrap>>(_l_index_);
+                        _r_assignedValid |= ((byte)1) << 0;
+                        break;
+                    case Serde.IDeserializeType.IndexNotFound:
+                        typeDeserialize.SkipValue();
+                        break;
+                    default:
+                        throw new InvalidOperationException("Unexpected index: " + _l_index_);
+                }
+            }
+
+            if ((_r_assignedValid & 0b1) != 0b1)
+            {
+                throw Serde.DeserializeException.UnassignedMember();
+            }
+
+            var newType = new Serde.Json.Test.PocoDictionary()
+            {
+                key = _l_key,
+            };
+            return newType;
+        }
+    }
+}

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Json.Test.PocoDictionary.ISerdeInfoProvider.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Json.Test.PocoDictionary.ISerdeInfoProvider.cs
@@ -1,0 +1,12 @@
+﻿
+#nullable enable
+namespace Serde.Json.Test;
+partial class PocoDictionary : Serde.ISerdeInfoProvider
+{
+    static global::Serde.ISerdeInfo global::Serde.ISerdeInfoProvider.SerdeInfo { get; } = Serde.SerdeInfo.MakeCustom(
+        "PocoDictionary",
+        typeof(Serde.Json.Test.PocoDictionary).GetCustomAttributesData(),
+        new (string, global::Serde.ISerdeInfo, System.Reflection.MemberInfo)[] {
+("key", global::Serde.SerdeInfoProvider.GetInfo<Serde.DictWrap.DeserializeImpl<string,global::Serde.StringWrap,string,global::Serde.StringWrap>>(), typeof(Serde.Json.Test.PocoDictionary).GetProperty("key")!)
+    });
+}

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.AllInOne.IDeserialize.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.AllInOne.IDeserialize.cs
@@ -20,12 +20,13 @@ namespace Serde.Test
             int _l_intfield = default !;
             long _l_longfield = default !;
             string _l_stringfield = default !;
+            string _l_escapedstringfield = default !;
             string? _l_nullstringfield = default !;
             uint[] _l_uintarr = default !;
             int[][] _l_nestedarr = default !;
             System.Collections.Immutable.ImmutableArray<int> _l_intimm = default !;
             Serde.Test.AllInOne.ColorEnum _l_color = default !;
-            ushort _r_assignedValid = 0;
+            uint _r_assignedValid = 0;
             var _l_serdeInfo = global::Serde.SerdeInfoProvider.GetInfo<AllInOne>();
             var typeDeserialize = deserializer.DeserializeType(_l_serdeInfo);
             int _l_index_;
@@ -35,76 +36,81 @@ namespace Serde.Test
                 {
                     case 0:
                         _l_boolfield = typeDeserialize.ReadValue<bool, global::Serde.BoolWrap>(_l_index_);
-                        _r_assignedValid |= ((ushort)1) << 0;
+                        _r_assignedValid |= ((uint)1) << 0;
                         break;
                     case 1:
                         _l_charfield = typeDeserialize.ReadValue<char, global::Serde.CharWrap>(_l_index_);
-                        _r_assignedValid |= ((ushort)1) << 1;
+                        _r_assignedValid |= ((uint)1) << 1;
                         break;
                     case 2:
                         _l_bytefield = typeDeserialize.ReadValue<byte, global::Serde.ByteWrap>(_l_index_);
-                        _r_assignedValid |= ((ushort)1) << 2;
+                        _r_assignedValid |= ((uint)1) << 2;
                         break;
                     case 3:
                         _l_ushortfield = typeDeserialize.ReadValue<ushort, global::Serde.UInt16Wrap>(_l_index_);
-                        _r_assignedValid |= ((ushort)1) << 3;
+                        _r_assignedValid |= ((uint)1) << 3;
                         break;
                     case 4:
                         _l_uintfield = typeDeserialize.ReadValue<uint, global::Serde.UInt32Wrap>(_l_index_);
-                        _r_assignedValid |= ((ushort)1) << 4;
+                        _r_assignedValid |= ((uint)1) << 4;
                         break;
                     case 5:
                         _l_ulongfield = typeDeserialize.ReadValue<ulong, global::Serde.UInt64Wrap>(_l_index_);
-                        _r_assignedValid |= ((ushort)1) << 5;
+                        _r_assignedValid |= ((uint)1) << 5;
                         break;
                     case 6:
                         _l_sbytefield = typeDeserialize.ReadValue<sbyte, global::Serde.SByteWrap>(_l_index_);
-                        _r_assignedValid |= ((ushort)1) << 6;
+                        _r_assignedValid |= ((uint)1) << 6;
                         break;
                     case 7:
                         _l_shortfield = typeDeserialize.ReadValue<short, global::Serde.Int16Wrap>(_l_index_);
-                        _r_assignedValid |= ((ushort)1) << 7;
+                        _r_assignedValid |= ((uint)1) << 7;
                         break;
                     case 8:
                         _l_intfield = typeDeserialize.ReadValue<int, global::Serde.Int32Wrap>(_l_index_);
-                        _r_assignedValid |= ((ushort)1) << 8;
+                        _r_assignedValid |= ((uint)1) << 8;
                         break;
                     case 9:
                         _l_longfield = typeDeserialize.ReadValue<long, global::Serde.Int64Wrap>(_l_index_);
-                        _r_assignedValid |= ((ushort)1) << 9;
+                        _r_assignedValid |= ((uint)1) << 9;
                         break;
                     case 10:
                         _l_stringfield = typeDeserialize.ReadValue<string, global::Serde.StringWrap>(_l_index_);
-                        _r_assignedValid |= ((ushort)1) << 10;
+                        _r_assignedValid |= ((uint)1) << 10;
                         break;
                     case 11:
-                        _l_nullstringfield = typeDeserialize.ReadValue<string?, Serde.NullableRefWrap.DeserializeImpl<string, global::Serde.StringWrap>>(_l_index_);
-                        _r_assignedValid |= ((ushort)1) << 11;
+                        _l_escapedstringfield = typeDeserialize.ReadValue<string, global::Serde.StringWrap>(_l_index_);
+                        _r_assignedValid |= ((uint)1) << 11;
                         break;
                     case 12:
-                        _l_uintarr = typeDeserialize.ReadValue<uint[], Serde.ArrayWrap.DeserializeImpl<uint, global::Serde.UInt32Wrap>>(_l_index_);
-                        _r_assignedValid |= ((ushort)1) << 12;
+                        _l_nullstringfield = typeDeserialize.ReadValue<string?, Serde.NullableRefWrap.DeserializeImpl<string, global::Serde.StringWrap>>(_l_index_);
+                        _r_assignedValid |= ((uint)1) << 12;
                         break;
                     case 13:
-                        _l_nestedarr = typeDeserialize.ReadValue<int[][], Serde.ArrayWrap.DeserializeImpl<int[], Serde.ArrayWrap.DeserializeImpl<int, global::Serde.Int32Wrap>>>(_l_index_);
-                        _r_assignedValid |= ((ushort)1) << 13;
+                        _l_uintarr = typeDeserialize.ReadValue<uint[], Serde.ArrayWrap.DeserializeImpl<uint, global::Serde.UInt32Wrap>>(_l_index_);
+                        _r_assignedValid |= ((uint)1) << 13;
                         break;
                     case 14:
-                        _l_intimm = typeDeserialize.ReadValue<System.Collections.Immutable.ImmutableArray<int>, Serde.ImmutableArrayWrap.DeserializeImpl<int, global::Serde.Int32Wrap>>(_l_index_);
-                        _r_assignedValid |= ((ushort)1) << 14;
+                        _l_nestedarr = typeDeserialize.ReadValue<int[][], Serde.ArrayWrap.DeserializeImpl<int[], Serde.ArrayWrap.DeserializeImpl<int, global::Serde.Int32Wrap>>>(_l_index_);
+                        _r_assignedValid |= ((uint)1) << 14;
                         break;
                     case 15:
+                        _l_intimm = typeDeserialize.ReadValue<System.Collections.Immutable.ImmutableArray<int>, Serde.ImmutableArrayWrap.DeserializeImpl<int, global::Serde.Int32Wrap>>(_l_index_);
+                        _r_assignedValid |= ((uint)1) << 15;
+                        break;
+                    case 16:
                         _l_color = typeDeserialize.ReadValue<Serde.Test.AllInOne.ColorEnum, Serde.Test.AllInOne.ColorEnumWrap>(_l_index_);
-                        _r_assignedValid |= ((ushort)1) << 15;
+                        _r_assignedValid |= ((uint)1) << 16;
                         break;
                     case Serde.IDeserializeType.IndexNotFound:
+                        typeDeserialize.SkipValue();
                         break;
                     default:
                         throw new InvalidOperationException("Unexpected index: " + _l_index_);
                 }
             }
 
-            if ((_r_assignedValid & 0b1111011111111111) != 0b1111011111111111)
+            if ((_r_assignedValid & 0b11110111111111111) != 0b11110111111111111)
             {
                 throw Serde.DeserializeException.UnassignedMember();
             }
@@ -122,6 +128,7 @@ namespace Serde.Test
                 IntField = _l_intfield,
                 LongField = _l_longfield,
                 StringField = _l_stringfield,
+                EscapedStringField = _l_escapedstringfield,
                 NullStringField = _l_nullstringfield,
                 UIntArr = _l_uintarr,
                 NestedArr = _l_nestedarr,

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.AllInOne.ISerdeInfoProvider.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.AllInOne.ISerdeInfoProvider.cs
@@ -18,6 +18,7 @@ partial record AllInOne : Serde.ISerdeInfoProvider
 ("intField", global::Serde.SerdeInfoProvider.GetInfo<global::Serde.Int32Wrap>(), typeof(Serde.Test.AllInOne).GetField("IntField")!),
 ("longField", global::Serde.SerdeInfoProvider.GetInfo<global::Serde.Int64Wrap>(), typeof(Serde.Test.AllInOne).GetField("LongField")!),
 ("stringField", global::Serde.SerdeInfoProvider.GetInfo<global::Serde.StringWrap>(), typeof(Serde.Test.AllInOne).GetField("StringField")!),
+("escapedStringField", global::Serde.SerdeInfoProvider.GetInfo<global::Serde.StringWrap>(), typeof(Serde.Test.AllInOne).GetField("EscapedStringField")!),
 ("nullStringField", global::Serde.SerdeInfoProvider.GetInfo<Serde.NullableRefWrap.SerializeImpl<string,global::Serde.StringWrap>>(), typeof(Serde.Test.AllInOne).GetField("NullStringField")!),
 ("uIntArr", global::Serde.SerdeInfoProvider.GetInfo<Serde.ArrayWrap.SerializeImpl<uint,global::Serde.UInt32Wrap>>(), typeof(Serde.Test.AllInOne).GetField("UIntArr")!),
 ("nestedArr", global::Serde.SerdeInfoProvider.GetInfo<Serde.ArrayWrap.SerializeImpl<int[],Serde.ArrayWrap.SerializeImpl<int,global::Serde.Int32Wrap>>>(), typeof(Serde.Test.AllInOne).GetField("NestedArr")!),

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.AllInOne.ISerialize.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.AllInOne.ISerialize.cs
@@ -22,11 +22,12 @@ namespace Serde.Test
             type.SerializeField<int, global::Serde.Int32Wrap>(_l_serdeInfo, 8, value.IntField);
             type.SerializeField<long, global::Serde.Int64Wrap>(_l_serdeInfo, 9, value.LongField);
             type.SerializeField<string, global::Serde.StringWrap>(_l_serdeInfo, 10, value.StringField);
-            type.SerializeFieldIfNotNull<string?, Serde.NullableRefWrap.SerializeImpl<string, global::Serde.StringWrap>>(_l_serdeInfo, 11, value.NullStringField);
-            type.SerializeField<uint[], Serde.ArrayWrap.SerializeImpl<uint, global::Serde.UInt32Wrap>>(_l_serdeInfo, 12, value.UIntArr);
-            type.SerializeField<int[][], Serde.ArrayWrap.SerializeImpl<int[], Serde.ArrayWrap.SerializeImpl<int, global::Serde.Int32Wrap>>>(_l_serdeInfo, 13, value.NestedArr);
-            type.SerializeField<System.Collections.Immutable.ImmutableArray<int>, Serde.ImmutableArrayWrap.SerializeImpl<int, global::Serde.Int32Wrap>>(_l_serdeInfo, 14, value.IntImm);
-            type.SerializeField<Serde.Test.AllInOne.ColorEnum, Serde.Test.AllInOne.ColorEnumWrap>(_l_serdeInfo, 15, value.Color);
+            type.SerializeField<string, global::Serde.StringWrap>(_l_serdeInfo, 11, value.EscapedStringField);
+            type.SerializeFieldIfNotNull<string?, Serde.NullableRefWrap.SerializeImpl<string, global::Serde.StringWrap>>(_l_serdeInfo, 12, value.NullStringField);
+            type.SerializeField<uint[], Serde.ArrayWrap.SerializeImpl<uint, global::Serde.UInt32Wrap>>(_l_serdeInfo, 13, value.UIntArr);
+            type.SerializeField<int[][], Serde.ArrayWrap.SerializeImpl<int[], Serde.ArrayWrap.SerializeImpl<int, global::Serde.Int32Wrap>>>(_l_serdeInfo, 14, value.NestedArr);
+            type.SerializeField<System.Collections.Immutable.ImmutableArray<int>, Serde.ImmutableArrayWrap.SerializeImpl<int, global::Serde.Int32Wrap>>(_l_serdeInfo, 15, value.IntImm);
+            type.SerializeField<Serde.Test.AllInOne.ColorEnum, Serde.Test.AllInOne.ColorEnumWrap>(_l_serdeInfo, 16, value.Color);
             type.End();
         }
     }

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.GenericWrapperTests.CustomArrayWrapExplicitOnType.IDeserialize.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.GenericWrapperTests.CustomArrayWrapExplicitOnType.IDeserialize.cs
@@ -25,6 +25,7 @@ namespace Serde.Test
                             _r_assignedValid |= ((byte)1) << 0;
                             break;
                         case Serde.IDeserializeType.IndexNotFound:
+                            typeDeserialize.SkipValue();
                             break;
                         default:
                             throw new InvalidOperationException("Unexpected index: " + _l_index_);

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.GenericWrapperTests.CustomImArrayExplicitWrapOnMember.IDeserialize.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.GenericWrapperTests.CustomImArrayExplicitWrapOnMember.IDeserialize.cs
@@ -25,6 +25,7 @@ namespace Serde.Test
                             _r_assignedValid |= ((byte)1) << 0;
                             break;
                         case Serde.IDeserializeType.IndexNotFound:
+                            typeDeserialize.SkipValue();
                             break;
                         default:
                             throw new InvalidOperationException("Unexpected index: " + _l_index_);

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonDeserializeTests.ExtraMembers.IDeserialize.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonDeserializeTests.ExtraMembers.IDeserialize.cs
@@ -25,6 +25,7 @@ namespace Serde.Test
                             _r_assignedValid |= ((byte)1) << 0;
                             break;
                         case Serde.IDeserializeType.IndexNotFound:
+                            typeDeserialize.SkipValue();
                             break;
                         default:
                             throw new InvalidOperationException("Unexpected index: " + _l_index_);

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonDeserializeTests.IdStruct.IDeserialize.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonDeserializeTests.IdStruct.IDeserialize.cs
@@ -25,6 +25,7 @@ namespace Serde.Test
                             _r_assignedValid |= ((byte)1) << 0;
                             break;
                         case Serde.IDeserializeType.IndexNotFound:
+                            typeDeserialize.SkipValue();
                             break;
                         default:
                             throw new InvalidOperationException("Unexpected index: " + _l_index_);

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonDeserializeTests.IdStructList.IDeserialize.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonDeserializeTests.IdStructList.IDeserialize.cs
@@ -30,6 +30,7 @@ namespace Serde.Test
                             _r_assignedValid |= ((byte)1) << 1;
                             break;
                         case Serde.IDeserializeType.IndexNotFound:
+                            typeDeserialize.SkipValue();
                             break;
                         default:
                             throw new InvalidOperationException("Unexpected index: " + _l_index_);

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonDeserializeTests.Location.IDeserialize.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonDeserializeTests.Location.IDeserialize.cs
@@ -1,0 +1,96 @@
+﻿
+#nullable enable
+using System;
+using Serde;
+
+namespace Serde.Test
+{
+    partial class JsonDeserializeTests
+    {
+        partial record Location : Serde.IDeserialize<Serde.Test.JsonDeserializeTests.Location>
+        {
+            static Serde.Test.JsonDeserializeTests.Location Serde.IDeserialize<Serde.Test.JsonDeserializeTests.Location>.Deserialize(IDeserializer deserializer)
+            {
+                int _l_id = default !;
+                string _l_address1 = default !;
+                string _l_address2 = default !;
+                string _l_city = default !;
+                string _l_state = default !;
+                string _l_postalcode = default !;
+                string _l_name = default !;
+                string _l_phonenumber = default !;
+                string _l_country = default !;
+                ushort _r_assignedValid = 0;
+                var _l_serdeInfo = global::Serde.SerdeInfoProvider.GetInfo<Location>();
+                var typeDeserialize = deserializer.DeserializeType(_l_serdeInfo);
+                int _l_index_;
+                while ((_l_index_ = typeDeserialize.TryReadIndex(_l_serdeInfo, out var _l_errorName)) != IDeserializeType.EndOfType)
+                {
+                    switch (_l_index_)
+                    {
+                        case 0:
+                            _l_id = typeDeserialize.ReadValue<int, global::Serde.Int32Wrap>(_l_index_);
+                            _r_assignedValid |= ((ushort)1) << 0;
+                            break;
+                        case 1:
+                            _l_address1 = typeDeserialize.ReadValue<string, global::Serde.StringWrap>(_l_index_);
+                            _r_assignedValid |= ((ushort)1) << 1;
+                            break;
+                        case 2:
+                            _l_address2 = typeDeserialize.ReadValue<string, global::Serde.StringWrap>(_l_index_);
+                            _r_assignedValid |= ((ushort)1) << 2;
+                            break;
+                        case 3:
+                            _l_city = typeDeserialize.ReadValue<string, global::Serde.StringWrap>(_l_index_);
+                            _r_assignedValid |= ((ushort)1) << 3;
+                            break;
+                        case 4:
+                            _l_state = typeDeserialize.ReadValue<string, global::Serde.StringWrap>(_l_index_);
+                            _r_assignedValid |= ((ushort)1) << 4;
+                            break;
+                        case 5:
+                            _l_postalcode = typeDeserialize.ReadValue<string, global::Serde.StringWrap>(_l_index_);
+                            _r_assignedValid |= ((ushort)1) << 5;
+                            break;
+                        case 6:
+                            _l_name = typeDeserialize.ReadValue<string, global::Serde.StringWrap>(_l_index_);
+                            _r_assignedValid |= ((ushort)1) << 6;
+                            break;
+                        case 7:
+                            _l_phonenumber = typeDeserialize.ReadValue<string, global::Serde.StringWrap>(_l_index_);
+                            _r_assignedValid |= ((ushort)1) << 7;
+                            break;
+                        case 8:
+                            _l_country = typeDeserialize.ReadValue<string, global::Serde.StringWrap>(_l_index_);
+                            _r_assignedValid |= ((ushort)1) << 8;
+                            break;
+                        case Serde.IDeserializeType.IndexNotFound:
+                            typeDeserialize.SkipValue();
+                            break;
+                        default:
+                            throw new InvalidOperationException("Unexpected index: " + _l_index_);
+                    }
+                }
+
+                if ((_r_assignedValid & 0b111111111) != 0b111111111)
+                {
+                    throw Serde.DeserializeException.UnassignedMember();
+                }
+
+                var newType = new Serde.Test.JsonDeserializeTests.Location()
+                {
+                    Id = _l_id,
+                    Address1 = _l_address1,
+                    Address2 = _l_address2,
+                    City = _l_city,
+                    State = _l_state,
+                    PostalCode = _l_postalcode,
+                    Name = _l_name,
+                    PhoneNumber = _l_phonenumber,
+                    Country = _l_country,
+                };
+                return newType;
+            }
+        }
+    }
+}

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonDeserializeTests.Location.ISerdeInfoProvider.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonDeserializeTests.Location.ISerdeInfoProvider.cs
@@ -1,0 +1,23 @@
+﻿
+#nullable enable
+namespace Serde.Test;
+partial class JsonDeserializeTests
+{
+    partial record Location : Serde.ISerdeInfoProvider
+{
+    static global::Serde.ISerdeInfo global::Serde.ISerdeInfoProvider.SerdeInfo { get; } = Serde.SerdeInfo.MakeCustom(
+        "Location",
+        typeof(Serde.Test.JsonDeserializeTests.Location).GetCustomAttributesData(),
+        new (string, global::Serde.ISerdeInfo, System.Reflection.MemberInfo)[] {
+("id", global::Serde.SerdeInfoProvider.GetInfo<global::Serde.Int32Wrap>(), typeof(Serde.Test.JsonDeserializeTests.Location).GetProperty("Id")!),
+("address1", global::Serde.SerdeInfoProvider.GetInfo<global::Serde.StringWrap>(), typeof(Serde.Test.JsonDeserializeTests.Location).GetProperty("Address1")!),
+("address2", global::Serde.SerdeInfoProvider.GetInfo<global::Serde.StringWrap>(), typeof(Serde.Test.JsonDeserializeTests.Location).GetProperty("Address2")!),
+("city", global::Serde.SerdeInfoProvider.GetInfo<global::Serde.StringWrap>(), typeof(Serde.Test.JsonDeserializeTests.Location).GetProperty("City")!),
+("state", global::Serde.SerdeInfoProvider.GetInfo<global::Serde.StringWrap>(), typeof(Serde.Test.JsonDeserializeTests.Location).GetProperty("State")!),
+("postalCode", global::Serde.SerdeInfoProvider.GetInfo<global::Serde.StringWrap>(), typeof(Serde.Test.JsonDeserializeTests.Location).GetProperty("PostalCode")!),
+("name", global::Serde.SerdeInfoProvider.GetInfo<global::Serde.StringWrap>(), typeof(Serde.Test.JsonDeserializeTests.Location).GetProperty("Name")!),
+("phoneNumber", global::Serde.SerdeInfoProvider.GetInfo<global::Serde.StringWrap>(), typeof(Serde.Test.JsonDeserializeTests.Location).GetProperty("PhoneNumber")!),
+("country", global::Serde.SerdeInfoProvider.GetInfo<global::Serde.StringWrap>(), typeof(Serde.Test.JsonDeserializeTests.Location).GetProperty("Country")!)
+    });
+}
+}

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonDeserializeTests.Location.ISerialize.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonDeserializeTests.Location.ISerialize.cs
@@ -1,0 +1,29 @@
+﻿
+#nullable enable
+using System;
+using Serde;
+
+namespace Serde.Test
+{
+    partial class JsonDeserializeTests
+    {
+        partial record Location : Serde.ISerialize<Serde.Test.JsonDeserializeTests.Location>
+        {
+            void ISerialize<Serde.Test.JsonDeserializeTests.Location>.Serialize(Serde.Test.JsonDeserializeTests.Location value, ISerializer serializer)
+            {
+                var _l_serdeInfo = global::Serde.SerdeInfoProvider.GetInfo<Location>();
+                var type = serializer.SerializeType(_l_serdeInfo);
+                type.SerializeField<int, global::Serde.Int32Wrap>(_l_serdeInfo, 0, value.Id);
+                type.SerializeField<string, global::Serde.StringWrap>(_l_serdeInfo, 1, value.Address1);
+                type.SerializeField<string, global::Serde.StringWrap>(_l_serdeInfo, 2, value.Address2);
+                type.SerializeField<string, global::Serde.StringWrap>(_l_serdeInfo, 3, value.City);
+                type.SerializeField<string, global::Serde.StringWrap>(_l_serdeInfo, 4, value.State);
+                type.SerializeField<string, global::Serde.StringWrap>(_l_serdeInfo, 5, value.PostalCode);
+                type.SerializeField<string, global::Serde.StringWrap>(_l_serdeInfo, 6, value.Name);
+                type.SerializeField<string, global::Serde.StringWrap>(_l_serdeInfo, 7, value.PhoneNumber);
+                type.SerializeField<string, global::Serde.StringWrap>(_l_serdeInfo, 8, value.Country);
+                type.End();
+            }
+        }
+    }
+}

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonDeserializeTests.NullableFields.IDeserialize.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonDeserializeTests.NullableFields.IDeserialize.cs
@@ -30,6 +30,7 @@ namespace Serde.Test
                             _r_assignedValid |= ((byte)1) << 1;
                             break;
                         case Serde.IDeserializeType.IndexNotFound:
+                            typeDeserialize.SkipValue();
                             break;
                         default:
                             throw new InvalidOperationException("Unexpected index: " + _l_index_);

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonDeserializeTests.SetToNull.IDeserialize.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonDeserializeTests.SetToNull.IDeserialize.cs
@@ -30,6 +30,7 @@ namespace Serde.Test
                             _r_assignedValid |= ((byte)1) << 1;
                             break;
                         case Serde.IDeserializeType.IndexNotFound:
+                            typeDeserialize.SkipValue();
                             break;
                         default:
                             throw new InvalidOperationException("Unexpected index: " + _l_index_);

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonDeserializeTests.SkipDeserialize.IDeserialize.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonDeserializeTests.SkipDeserialize.IDeserialize.cs
@@ -26,6 +26,7 @@ namespace Serde.Test
                             break;
                         case 1:
                         case Serde.IDeserializeType.IndexNotFound:
+                            typeDeserialize.SkipValue();
                             break;
                         default:
                             throw new InvalidOperationException("Unexpected index: " + _l_index_);

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonDeserializeTests.ThrowMissing.IDeserialize.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonDeserializeTests.ThrowMissing.IDeserialize.cs
@@ -30,6 +30,7 @@ namespace Serde.Test
                             _r_assignedValid |= ((byte)1) << 1;
                             break;
                         case Serde.IDeserializeType.IndexNotFound:
+                            typeDeserialize.SkipValue();
                             break;
                         default:
                             throw new InvalidOperationException("Unexpected index: " + _l_index_);

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonDeserializeTests.ThrowMissingFalse.IDeserialize.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonDeserializeTests.ThrowMissingFalse.IDeserialize.cs
@@ -30,6 +30,7 @@ namespace Serde.Test
                             _r_assignedValid |= ((byte)1) << 1;
                             break;
                         case Serde.IDeserializeType.IndexNotFound:
+                            typeDeserialize.SkipValue();
                             break;
                         default:
                             throw new InvalidOperationException("Unexpected index: " + _l_index_);

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.MaxSizeType.IDeserialize.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.MaxSizeType.IDeserialize.cs
@@ -338,6 +338,7 @@ namespace Serde.Test
                         _r_assignedValid |= ((ulong)1) << 63;
                         break;
                     case Serde.IDeserializeType.IndexNotFound:
+                        typeDeserialize.SkipValue();
                         break;
                     default:
                         throw new InvalidOperationException("Unexpected index: " + _l_index_);

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.SerdeInfoTests.EmptyRecord.IDeserialize.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.SerdeInfoTests.EmptyRecord.IDeserialize.cs
@@ -20,6 +20,7 @@ namespace Serde.Test
                     switch (_l_index_)
                     {
                         case Serde.IDeserializeType.IndexNotFound:
+                            typeDeserialize.SkipValue();
                             break;
                         default:
                             throw new InvalidOperationException("Unexpected index: " + _l_index_);

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.SerdeInfoTests.RgbProxy.IDeserialize.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.SerdeInfoTests.RgbProxy.IDeserialize.cs
@@ -35,6 +35,7 @@ namespace Serde.Test
                             _r_assignedValid |= ((byte)1) << 2;
                             break;
                         case Serde.IDeserializeType.IndexNotFound:
+                            typeDeserialize.SkipValue();
                             break;
                         default:
                             throw new InvalidOperationException("Unexpected index: " + _l_index_);

--- a/test/Serde.Xml.Test/XmlTests.cs
+++ b/test/Serde.Xml.Test/XmlTests.cs
@@ -22,6 +22,7 @@ namespace Serde.Test
   <intField>2147483647</intField>
   <longField>9223372036854775807</longField>
   <stringField>StringValue</stringField>
+  <escapedStringField>+0 11 222 333 44</escapedStringField>
   <uIntArr>
     <int>1</int>
     <int>2</int>

--- a/test/Serde.Xml.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.AllInOne.IDeserialize.cs
+++ b/test/Serde.Xml.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.AllInOne.IDeserialize.cs
@@ -20,12 +20,13 @@ namespace Serde.Test
             int _l_intfield = default !;
             long _l_longfield = default !;
             string _l_stringfield = default !;
+            string _l_escapedstringfield = default !;
             string? _l_nullstringfield = default !;
             uint[] _l_uintarr = default !;
             int[][] _l_nestedarr = default !;
             System.Collections.Immutable.ImmutableArray<int> _l_intimm = default !;
             Serde.Test.AllInOne.ColorEnum _l_color = default !;
-            ushort _r_assignedValid = 0;
+            uint _r_assignedValid = 0;
             var _l_serdeInfo = global::Serde.SerdeInfoProvider.GetInfo<AllInOne>();
             var typeDeserialize = deserializer.DeserializeType(_l_serdeInfo);
             int _l_index_;
@@ -35,76 +36,81 @@ namespace Serde.Test
                 {
                     case 0:
                         _l_boolfield = typeDeserialize.ReadValue<bool, global::Serde.BoolWrap>(_l_index_);
-                        _r_assignedValid |= ((ushort)1) << 0;
+                        _r_assignedValid |= ((uint)1) << 0;
                         break;
                     case 1:
                         _l_charfield = typeDeserialize.ReadValue<char, global::Serde.CharWrap>(_l_index_);
-                        _r_assignedValid |= ((ushort)1) << 1;
+                        _r_assignedValid |= ((uint)1) << 1;
                         break;
                     case 2:
                         _l_bytefield = typeDeserialize.ReadValue<byte, global::Serde.ByteWrap>(_l_index_);
-                        _r_assignedValid |= ((ushort)1) << 2;
+                        _r_assignedValid |= ((uint)1) << 2;
                         break;
                     case 3:
                         _l_ushortfield = typeDeserialize.ReadValue<ushort, global::Serde.UInt16Wrap>(_l_index_);
-                        _r_assignedValid |= ((ushort)1) << 3;
+                        _r_assignedValid |= ((uint)1) << 3;
                         break;
                     case 4:
                         _l_uintfield = typeDeserialize.ReadValue<uint, global::Serde.UInt32Wrap>(_l_index_);
-                        _r_assignedValid |= ((ushort)1) << 4;
+                        _r_assignedValid |= ((uint)1) << 4;
                         break;
                     case 5:
                         _l_ulongfield = typeDeserialize.ReadValue<ulong, global::Serde.UInt64Wrap>(_l_index_);
-                        _r_assignedValid |= ((ushort)1) << 5;
+                        _r_assignedValid |= ((uint)1) << 5;
                         break;
                     case 6:
                         _l_sbytefield = typeDeserialize.ReadValue<sbyte, global::Serde.SByteWrap>(_l_index_);
-                        _r_assignedValid |= ((ushort)1) << 6;
+                        _r_assignedValid |= ((uint)1) << 6;
                         break;
                     case 7:
                         _l_shortfield = typeDeserialize.ReadValue<short, global::Serde.Int16Wrap>(_l_index_);
-                        _r_assignedValid |= ((ushort)1) << 7;
+                        _r_assignedValid |= ((uint)1) << 7;
                         break;
                     case 8:
                         _l_intfield = typeDeserialize.ReadValue<int, global::Serde.Int32Wrap>(_l_index_);
-                        _r_assignedValid |= ((ushort)1) << 8;
+                        _r_assignedValid |= ((uint)1) << 8;
                         break;
                     case 9:
                         _l_longfield = typeDeserialize.ReadValue<long, global::Serde.Int64Wrap>(_l_index_);
-                        _r_assignedValid |= ((ushort)1) << 9;
+                        _r_assignedValid |= ((uint)1) << 9;
                         break;
                     case 10:
                         _l_stringfield = typeDeserialize.ReadValue<string, global::Serde.StringWrap>(_l_index_);
-                        _r_assignedValid |= ((ushort)1) << 10;
+                        _r_assignedValid |= ((uint)1) << 10;
                         break;
                     case 11:
-                        _l_nullstringfield = typeDeserialize.ReadValue<string?, Serde.NullableRefWrap.DeserializeImpl<string, global::Serde.StringWrap>>(_l_index_);
-                        _r_assignedValid |= ((ushort)1) << 11;
+                        _l_escapedstringfield = typeDeserialize.ReadValue<string, global::Serde.StringWrap>(_l_index_);
+                        _r_assignedValid |= ((uint)1) << 11;
                         break;
                     case 12:
-                        _l_uintarr = typeDeserialize.ReadValue<uint[], Serde.ArrayWrap.DeserializeImpl<uint, global::Serde.UInt32Wrap>>(_l_index_);
-                        _r_assignedValid |= ((ushort)1) << 12;
+                        _l_nullstringfield = typeDeserialize.ReadValue<string?, Serde.NullableRefWrap.DeserializeImpl<string, global::Serde.StringWrap>>(_l_index_);
+                        _r_assignedValid |= ((uint)1) << 12;
                         break;
                     case 13:
-                        _l_nestedarr = typeDeserialize.ReadValue<int[][], Serde.ArrayWrap.DeserializeImpl<int[], Serde.ArrayWrap.DeserializeImpl<int, global::Serde.Int32Wrap>>>(_l_index_);
-                        _r_assignedValid |= ((ushort)1) << 13;
+                        _l_uintarr = typeDeserialize.ReadValue<uint[], Serde.ArrayWrap.DeserializeImpl<uint, global::Serde.UInt32Wrap>>(_l_index_);
+                        _r_assignedValid |= ((uint)1) << 13;
                         break;
                     case 14:
-                        _l_intimm = typeDeserialize.ReadValue<System.Collections.Immutable.ImmutableArray<int>, Serde.ImmutableArrayWrap.DeserializeImpl<int, global::Serde.Int32Wrap>>(_l_index_);
-                        _r_assignedValid |= ((ushort)1) << 14;
+                        _l_nestedarr = typeDeserialize.ReadValue<int[][], Serde.ArrayWrap.DeserializeImpl<int[], Serde.ArrayWrap.DeserializeImpl<int, global::Serde.Int32Wrap>>>(_l_index_);
+                        _r_assignedValid |= ((uint)1) << 14;
                         break;
                     case 15:
+                        _l_intimm = typeDeserialize.ReadValue<System.Collections.Immutable.ImmutableArray<int>, Serde.ImmutableArrayWrap.DeserializeImpl<int, global::Serde.Int32Wrap>>(_l_index_);
+                        _r_assignedValid |= ((uint)1) << 15;
+                        break;
+                    case 16:
                         _l_color = typeDeserialize.ReadValue<Serde.Test.AllInOne.ColorEnum, Serde.Test.AllInOne.ColorEnumWrap>(_l_index_);
-                        _r_assignedValid |= ((ushort)1) << 15;
+                        _r_assignedValid |= ((uint)1) << 16;
                         break;
                     case Serde.IDeserializeType.IndexNotFound:
+                        typeDeserialize.SkipValue();
                         break;
                     default:
                         throw new InvalidOperationException("Unexpected index: " + _l_index_);
                 }
             }
 
-            if ((_r_assignedValid & 0b1111011111111111) != 0b1111011111111111)
+            if ((_r_assignedValid & 0b11110111111111111) != 0b11110111111111111)
             {
                 throw Serde.DeserializeException.UnassignedMember();
             }
@@ -122,6 +128,7 @@ namespace Serde.Test
                 IntField = _l_intfield,
                 LongField = _l_longfield,
                 StringField = _l_stringfield,
+                EscapedStringField = _l_escapedstringfield,
                 NullStringField = _l_nullstringfield,
                 UIntArr = _l_uintarr,
                 NestedArr = _l_nestedarr,

--- a/test/Serde.Xml.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.AllInOne.ISerdeInfoProvider.cs
+++ b/test/Serde.Xml.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.AllInOne.ISerdeInfoProvider.cs
@@ -18,6 +18,7 @@ partial record AllInOne : Serde.ISerdeInfoProvider
 ("intField", global::Serde.SerdeInfoProvider.GetInfo<global::Serde.Int32Wrap>(), typeof(Serde.Test.AllInOne).GetField("IntField")!),
 ("longField", global::Serde.SerdeInfoProvider.GetInfo<global::Serde.Int64Wrap>(), typeof(Serde.Test.AllInOne).GetField("LongField")!),
 ("stringField", global::Serde.SerdeInfoProvider.GetInfo<global::Serde.StringWrap>(), typeof(Serde.Test.AllInOne).GetField("StringField")!),
+("escapedStringField", global::Serde.SerdeInfoProvider.GetInfo<global::Serde.StringWrap>(), typeof(Serde.Test.AllInOne).GetField("EscapedStringField")!),
 ("nullStringField", global::Serde.SerdeInfoProvider.GetInfo<Serde.NullableRefWrap.SerializeImpl<string,global::Serde.StringWrap>>(), typeof(Serde.Test.AllInOne).GetField("NullStringField")!),
 ("uIntArr", global::Serde.SerdeInfoProvider.GetInfo<Serde.ArrayWrap.SerializeImpl<uint,global::Serde.UInt32Wrap>>(), typeof(Serde.Test.AllInOne).GetField("UIntArr")!),
 ("nestedArr", global::Serde.SerdeInfoProvider.GetInfo<Serde.ArrayWrap.SerializeImpl<int[],Serde.ArrayWrap.SerializeImpl<int,global::Serde.Int32Wrap>>>(), typeof(Serde.Test.AllInOne).GetField("NestedArr")!),

--- a/test/Serde.Xml.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.AllInOne.ISerialize.cs
+++ b/test/Serde.Xml.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.AllInOne.ISerialize.cs
@@ -22,11 +22,12 @@ namespace Serde.Test
             type.SerializeField<int, global::Serde.Int32Wrap>(_l_serdeInfo, 8, value.IntField);
             type.SerializeField<long, global::Serde.Int64Wrap>(_l_serdeInfo, 9, value.LongField);
             type.SerializeField<string, global::Serde.StringWrap>(_l_serdeInfo, 10, value.StringField);
-            type.SerializeFieldIfNotNull<string?, Serde.NullableRefWrap.SerializeImpl<string, global::Serde.StringWrap>>(_l_serdeInfo, 11, value.NullStringField);
-            type.SerializeField<uint[], Serde.ArrayWrap.SerializeImpl<uint, global::Serde.UInt32Wrap>>(_l_serdeInfo, 12, value.UIntArr);
-            type.SerializeField<int[][], Serde.ArrayWrap.SerializeImpl<int[], Serde.ArrayWrap.SerializeImpl<int, global::Serde.Int32Wrap>>>(_l_serdeInfo, 13, value.NestedArr);
-            type.SerializeField<System.Collections.Immutable.ImmutableArray<int>, Serde.ImmutableArrayWrap.SerializeImpl<int, global::Serde.Int32Wrap>>(_l_serdeInfo, 14, value.IntImm);
-            type.SerializeField<Serde.Test.AllInOne.ColorEnum, Serde.Test.AllInOne.ColorEnumWrap>(_l_serdeInfo, 15, value.Color);
+            type.SerializeField<string, global::Serde.StringWrap>(_l_serdeInfo, 11, value.EscapedStringField);
+            type.SerializeFieldIfNotNull<string?, Serde.NullableRefWrap.SerializeImpl<string, global::Serde.StringWrap>>(_l_serdeInfo, 12, value.NullStringField);
+            type.SerializeField<uint[], Serde.ArrayWrap.SerializeImpl<uint, global::Serde.UInt32Wrap>>(_l_serdeInfo, 13, value.UIntArr);
+            type.SerializeField<int[][], Serde.ArrayWrap.SerializeImpl<int[], Serde.ArrayWrap.SerializeImpl<int, global::Serde.Int32Wrap>>>(_l_serdeInfo, 14, value.NestedArr);
+            type.SerializeField<System.Collections.Immutable.ImmutableArray<int>, Serde.ImmutableArrayWrap.SerializeImpl<int, global::Serde.Int32Wrap>>(_l_serdeInfo, 15, value.IntImm);
+            type.SerializeField<Serde.Test.AllInOne.ColorEnum, Serde.Test.AllInOne.ColorEnumWrap>(_l_serdeInfo, 16, value.Color);
             type.End();
         }
     }


### PR DESCRIPTION
The existing reader was adapted from S.T.J and is not architected well for integration into Serde.Json. It's slower than it needs to be and supports features that Serde.Json will never have, like directly exposing the lexing API.

Also added is an IByteReader abstraction that will help address porting issues between different types of backing streams.