### PR TITLE
Add 'Read*' deserialize methods

### DIFF
--- a/perf/bench/SampleTypes.cs
+++ b/perf/bench/SampleTypes.cs
@@ -62,7 +62,7 @@ namespace Benchmarks
             "Location",
             typeof(Location).GetCustomAttributesData(),
             [
-                ("id", StringWrap.SerdeInfo, typeof(Location).GetProperty("Id")!),
+                ("id", Int32Wrap.SerdeInfo, typeof(Location).GetProperty("Id")!),
                 ("address1", StringWrap.SerdeInfo, typeof(Location).GetProperty("Address1")!),
                 ("address2", StringWrap.SerdeInfo, typeof(Location).GetProperty("Address2")!),
                 ("city", StringWrap.SerdeInfo, typeof(Location).GetProperty("City")!),
@@ -86,48 +86,54 @@ namespace Benchmarks
             string _l_country = default !;
             ushort _r_assignedValid = 0b0;
 
-            var typeDeserialize = deserializer.DeserializeType(SerdeInfo);
+            var _l_serdeInfo = SerdeInfo;
+            var typeDeserialize = deserializer.ReadType(_l_serdeInfo);
             int index;
-            while ((index = typeDeserialize.TryReadIndex(SerdeInfo, out _)) != IDeserializeType.EndOfType)
+            while ((index = typeDeserialize.TryReadIndex(_l_serdeInfo, out _)) != IDeserializeType.EndOfType)
             {
                 switch (index)
                 {
                     case 0:
-                        _l_id = typeDeserialize.ReadValue<int, Int32Wrap>(index);
+                        _l_id = typeDeserialize.ReadI32(index);
                         _r_assignedValid |= ((ushort)1) << 0;
                         break;
                     case 1:
-                        _l_address1 = typeDeserialize.ReadValue<string, StringWrap>(index);
+                        _l_address1 = typeDeserialize.ReadString(index);
                         _r_assignedValid |= ((ushort)1) << 1;
                         break;
                     case 2:
-                        _l_address2 = typeDeserialize.ReadValue<string, StringWrap>(index);
+                        _l_address2 = typeDeserialize.ReadString(index);
                         _r_assignedValid |= ((ushort)1) << 2;
                         break;
                     case 3:
-                        _l_city = typeDeserialize.ReadValue<string, StringWrap>(index);
+                        _l_city = typeDeserialize.ReadString(index);
                         _r_assignedValid |= ((ushort)1) << 3;
                         break;
                     case 4:
-                        _l_state = typeDeserialize.ReadValue<string, StringWrap>(index);
+                        _l_state = typeDeserialize.ReadString(index);
                         _r_assignedValid |= ((ushort)1) << 4;
                         break;
                     case 5:
-                        _l_postalcode = typeDeserialize.ReadValue<string, StringWrap>(index);
+                        _l_postalcode = typeDeserialize.ReadString(index);
                         _r_assignedValid |= ((ushort)1) << 5;
                         break;
                     case 6:
-                        _l_name = typeDeserialize.ReadValue<string, StringWrap>(index);
+                        _l_name = typeDeserialize.ReadString(index);
                         _r_assignedValid |= ((ushort)1) << 6;
                         break;
                     case 7:
-                        _l_phonenumber = typeDeserialize.ReadValue<string, StringWrap>(index);
+                        _l_phonenumber = typeDeserialize.ReadString(index);
                         _r_assignedValid |= ((ushort)1) << 7;
                         break;
                     case 8:
-                        _l_country = typeDeserialize.ReadValue<string, StringWrap>(index);
+                        _l_country = typeDeserialize.ReadString(index);
                         _r_assignedValid |= ((ushort)1) << 8;
                         break;
+                    case Serde.IDeserializeType.IndexNotFound:
+                        typeDeserialize.SkipValue();
+                        break;
+                    default:
+                        throw new InvalidOperationException("Unexpected index: " + index);
                 }
             }
 

--- a/src/serde/IDeserialize.cs
+++ b/src/serde/IDeserialize.cs
@@ -109,28 +109,42 @@ namespace Serde
         V ReadValue<V, D>(int index) where D : IDeserialize<V>;
 
         void SkipValue();
+
+        bool ReadBool(int index);
+        char ReadChar(int index);
+        byte ReadByte(int index);
+        ushort ReadU16(int index);
+        uint ReadU32(int index);
+        ulong ReadU64(int index);
+        sbyte ReadSByte(int index);
+        short ReadI16(int index);
+        int ReadI32(int index);
+        long ReadI64(int index);
+        float ReadFloat(int index);
+        double ReadDouble(int index);
+        decimal ReadDecimal(int index);
+        string ReadString(int index);
     }
 
     public interface IDeserializer : IDisposable
     {
-        T DeserializeAny<T>(IDeserializeVisitor<T> v);
-        T DeserializeBool<T>(IDeserializeVisitor<T> v);
-        T DeserializeChar<T>(IDeserializeVisitor<T> v);
-        T DeserializeByte<T>(IDeserializeVisitor<T> v);
-        T DeserializeU16<T>(IDeserializeVisitor<T> v);
-        T DeserializeU32<T>(IDeserializeVisitor<T> v);
-        T DeserializeU64<T>(IDeserializeVisitor<T> v);
-        T DeserializeSByte<T>(IDeserializeVisitor<T> v);
-        T DeserializeI16<T>(IDeserializeVisitor<T> v);
-        T DeserializeI32<T>(IDeserializeVisitor<T> v);
-        T DeserializeI64<T>(IDeserializeVisitor<T> v);
-        T DeserializeFloat<T>(IDeserializeVisitor<T> v);
-        T DeserializeDouble<T>(IDeserializeVisitor<T> v);
-        T DeserializeDecimal<T>(IDeserializeVisitor<T> v);
-        T DeserializeString<T>(IDeserializeVisitor<T> v);
-        T DeserializeIdentifier<T>(IDeserializeVisitor<T> v);
-        T DeserializeNullableRef<T>(IDeserializeVisitor<T> v);
-        IDeserializeCollection DeserializeCollection(ISerdeInfo typeInfo);
-        IDeserializeType DeserializeType(ISerdeInfo typeInfo);
+        T ReadAny<T>(IDeserializeVisitor<T> v);
+        T ReadNullableRef<T>(IDeserializeVisitor<T> v);
+        bool ReadBool();
+        char ReadChar();
+        byte ReadByte();
+        ushort ReadU16();
+        uint ReadU32();
+        ulong ReadU64();
+        sbyte ReadSByte();
+        short ReadI16();
+        int ReadI32();
+        long ReadI64();
+        float ReadFloat();
+        double ReadDouble();
+        decimal ReadDecimal();
+        string ReadString();
+        IDeserializeCollection ReadCollection(ISerdeInfo typeInfo);
+        IDeserializeType ReadType(ISerdeInfo typeInfo);
     }
 }

--- a/src/serde/Wrappers.Dictionary.cs
+++ b/src/serde/Wrappers.Dictionary.cs
@@ -38,7 +38,7 @@ public static class DictWrap
         public static Dictionary<TKey, TValue> Deserialize(IDeserializer deserializer)
         {
             var typeInfo = DictSerdeInfo<TKey, TValue>.Instance;
-            var deCollection = deserializer.DeserializeCollection(typeInfo);
+            var deCollection = deserializer.ReadCollection(typeInfo);
             Dictionary<TKey, TValue> dict;
             if (deCollection.SizeOpt is int size)
             {
@@ -96,7 +96,7 @@ public static class ImmutableDictWrap
         public static ImmutableDictionary<TKey, TValue> Deserialize(IDeserializer deserializer)
         {
             var typeInfo = DictSerdeInfo<TKey, TValue>.Instance;
-            var deCollection = deserializer.DeserializeCollection(typeInfo);
+            var deCollection = deserializer.ReadCollection(typeInfo);
             var builder = ImmutableDictionary.CreateBuilder<TKey, TValue>();
             while (deCollection.TryReadValue<TKey, TKeyWrap>(typeInfo, out var key))
             {

--- a/src/serde/Wrappers.List.cs
+++ b/src/serde/Wrappers.List.cs
@@ -50,7 +50,7 @@ namespace Serde
             public static T[] Deserialize(IDeserializer deserializer)
             {
                 var typeInfo = ArraySerdeTypeInfo<T>.TypeInfo;
-                var deCollection = deserializer.DeserializeCollection(typeInfo);
+                var deCollection = deserializer.ReadCollection(typeInfo);
                 if (deCollection.SizeOpt is int size)
                 {
                     var array = new T[size];
@@ -100,7 +100,7 @@ namespace Serde
             {
                 List<T> list;
                 var typeInfo = ListSerdeTypeInfo<T>.TypeInfo;
-                var deCollection = deserializer.DeserializeCollection(typeInfo);
+                var deCollection = deserializer.ReadCollection(typeInfo);
                 if (deCollection.SizeOpt is int size)
                 {
                     list = new List<T>(size);
@@ -146,7 +146,7 @@ namespace Serde
             {
                 ImmutableArray<T>.Builder builder;
                 var typeInfo = ImmutableArraySerdeTypeInfo<T>.TypeInfo;
-                var d = deserializer.DeserializeCollection(typeInfo);
+                var d = deserializer.ReadCollection(typeInfo);
                 if (d.SizeOpt is int size)
                 {
                     builder = ImmutableArray.CreateBuilder<T>(size);

--- a/src/serde/Wrappers.cs
+++ b/src/serde/Wrappers.cs
@@ -24,19 +24,11 @@ public readonly partial record struct BoolWrap
         => serializer.SerializeBool(value);
     static bool IDeserialize<bool>.Deserialize(IDeserializer deserializer)
     {
-        var visitor = SerdeVisitor.Instance;
-        return deserializer.DeserializeBool(visitor);
-    }
-
-    private sealed class SerdeVisitor : IDeserializeVisitor<bool>
-    {
-        public static readonly SerdeVisitor Instance = new SerdeVisitor();
-        public string ExpectedTypeName => s_typeName;
-        bool IDeserializeVisitor<bool>.VisitBool(bool x) => x;
+        return deserializer.ReadBool();
     }
 }
 
-public readonly partial record struct CharWrap(char Value)
+public readonly partial struct CharWrap
     : ISerialize<char>, IDeserialize<char>
 {
     public static ISerdeInfo SerdeInfo { get; } = Serde.SerdeInfo.MakePrimitive(s_typeName);
@@ -46,32 +38,11 @@ public readonly partial record struct CharWrap(char Value)
         => serializer.SerializeChar(value);
     static char IDeserialize<char>.Deserialize(IDeserializer deserializer)
     {
-        var visitor = SerdeVisitor.Instance;
-        return deserializer.DeserializeChar(visitor);
-    }
-
-    private sealed class SerdeVisitor : IDeserializeVisitor<char>
-    {
-        public static readonly SerdeVisitor Instance = new SerdeVisitor();
-        public string ExpectedTypeName => s_typeName;
-        char IDeserializeVisitor<char>.VisitChar(char c) => c;
-        char IDeserializeVisitor<char>.VisitString(string s) => GetChar(s);
-        private char GetChar(string s)
-        {
-            if (s.Length == 1)
-            {
-                return s[0];
-            }
-            throw new DeserializeException("Expected type " + ExpectedTypeName);
-        }
-        char IDeserializeVisitor<char>.VisitUtf8Span(Utf8Span s)
-        {
-            return GetChar(Encoding.UTF8.GetString(s));
-        }
+        return deserializer.ReadChar();
     }
 }
 
-public readonly partial record struct ByteWrap(byte Value)
+public readonly partial struct ByteWrap
     : ISerialize<byte>, IDeserialize<byte>
 {
     public static ISerdeInfo SerdeInfo { get; } = Serde.SerdeInfo.MakePrimitive(s_typeName);
@@ -82,26 +53,11 @@ public readonly partial record struct ByteWrap(byte Value)
     }
     static byte IDeserialize<byte>.Deserialize(IDeserializer deserializer)
     {
-        var visitor = SerdeVisitor.Instance;
-        return deserializer.DeserializeByte(visitor);
-    }
-
-    private sealed class SerdeVisitor : IDeserializeVisitor<byte>
-    {
-        public static readonly SerdeVisitor Instance = new SerdeVisitor();
-        public string ExpectedTypeName => ByteWrap.s_typeName;
-        byte IDeserializeVisitor<byte>.VisitByte(byte b)    => b;
-        byte IDeserializeVisitor<byte>.VisitU16(ushort u16) => Convert.ToByte(u16);
-        byte IDeserializeVisitor<byte>.VisitU32(uint u32)   => Convert.ToByte(u32);
-        byte IDeserializeVisitor<byte>.VisitU64(ulong u64)  => Convert.ToByte(u64);
-        byte IDeserializeVisitor<byte>.VisitSByte(sbyte b)  => Convert.ToByte(b);
-        byte IDeserializeVisitor<byte>.VisitI16(short i16)  => Convert.ToByte(i16);
-        byte IDeserializeVisitor<byte>.VisitI32(int i32)    => Convert.ToByte(i32);
-        byte IDeserializeVisitor<byte>.VisitI64(long i64)   => Convert.ToByte(i64);
+        return deserializer.ReadByte();
     }
 }
 
-public readonly partial record struct UInt16Wrap(ushort Value)
+public readonly partial struct UInt16Wrap
     : ISerialize<ushort>, IDeserialize<ushort>
 {
     public static ISerdeInfo SerdeInfo { get; } = Serde.SerdeInfo.MakePrimitive(s_typeName);
@@ -112,26 +68,11 @@ public readonly partial record struct UInt16Wrap(ushort Value)
     }
     static ushort IDeserialize<ushort>.Deserialize(IDeserializer deserializer)
     {
-        var visitor = SerdeVisitor.Instance;
-        return deserializer.DeserializeU16(visitor);
-    }
-
-    private sealed class SerdeVisitor : IDeserializeVisitor<ushort>
-    {
-        public static readonly SerdeVisitor Instance = new SerdeVisitor();
-        public string ExpectedTypeName => s_typeName;
-        ushort IDeserializeVisitor<ushort>.VisitByte(byte b)    => b;
-        ushort IDeserializeVisitor<ushort>.VisitU16(ushort u16) => u16;
-        ushort IDeserializeVisitor<ushort>.VisitU32(uint u32)   => Convert.ToUInt16(u32);
-        ushort IDeserializeVisitor<ushort>.VisitU64(ulong u64)  => Convert.ToUInt16(u64);
-        ushort IDeserializeVisitor<ushort>.VisitSByte(sbyte b)  => Convert.ToUInt16(b);
-        ushort IDeserializeVisitor<ushort>.VisitI16(short i16)  => Convert.ToUInt16(i16);
-        ushort IDeserializeVisitor<ushort>.VisitI32(int i32)    => Convert.ToUInt16(i32);
-        ushort IDeserializeVisitor<ushort>.VisitI64(long i64)   => Convert.ToUInt16(i64);
+        return deserializer.ReadU16();
     }
 }
 
-public readonly partial record struct UInt32Wrap
+public readonly partial struct UInt32Wrap
     : ISerialize<uint>, IDeserialize<uint>
 {
     public static ISerdeInfo SerdeInfo { get; } = Serde.SerdeInfo.MakePrimitive(s_typeName);
@@ -140,26 +81,11 @@ public readonly partial record struct UInt32Wrap
         => serializer.SerializeU32(value);
     static uint IDeserialize<uint>.Deserialize(IDeserializer deserializer)
     {
-        var visitor = SerdeVisitor.Instance;
-        return deserializer.DeserializeU32(visitor);
-    }
-
-    private sealed class SerdeVisitor : IDeserializeVisitor<uint>
-    {
-        public static readonly SerdeVisitor Instance = new SerdeVisitor();
-        public string ExpectedTypeName => s_typeName;
-        uint IDeserializeVisitor<uint>.VisitByte(byte b)    => b;
-        uint IDeserializeVisitor<uint>.VisitU16(ushort u16) => u16;
-        uint IDeserializeVisitor<uint>.VisitU32(uint u32)   => u32;
-        uint IDeserializeVisitor<uint>.VisitU64(ulong u64)  => Convert.ToUInt32(u64);
-        uint IDeserializeVisitor<uint>.VisitSByte(sbyte b)  => Convert.ToUInt32(b);
-        uint IDeserializeVisitor<uint>.VisitI16(short i16)  => Convert.ToUInt32(i16);
-        uint IDeserializeVisitor<uint>.VisitI32(int i32)    => Convert.ToUInt32(i32);
-        uint IDeserializeVisitor<uint>.VisitI64(long i64)   => Convert.ToUInt32(i64);
+        return deserializer.ReadU32();
     }
 }
 
-public readonly partial record struct UInt64Wrap(ulong Value)
+public readonly partial struct UInt64Wrap
     : ISerialize<ulong>, IDeserialize<ulong>
 {
     public static ISerdeInfo SerdeInfo { get; } = Serde.SerdeInfo.MakePrimitive(s_typeName);
@@ -168,26 +94,11 @@ public readonly partial record struct UInt64Wrap(ulong Value)
         => serializer.SerializeU64(value);
     static ulong IDeserialize<ulong>.Deserialize(IDeserializer deserializer)
     {
-        var visitor = SerdeVisitor.Instance;
-        return deserializer.DeserializeU64(visitor);
-    }
-
-    private sealed class SerdeVisitor : IDeserializeVisitor<ulong>
-    {
-        public static readonly SerdeVisitor Instance = new SerdeVisitor();
-        public string ExpectedTypeName => s_typeName;
-        ulong IDeserializeVisitor<ulong>.VisitByte(byte b)    => b;
-        ulong IDeserializeVisitor<ulong>.VisitU16(ushort u16) => u16;
-        ulong IDeserializeVisitor<ulong>.VisitU32(uint u32)   => u32;
-        ulong IDeserializeVisitor<ulong>.VisitU64(ulong u64)  => u64;
-        ulong IDeserializeVisitor<ulong>.VisitSByte(sbyte b)  => Convert.ToUInt64(b);
-        ulong IDeserializeVisitor<ulong>.VisitI16(short i16)  => Convert.ToUInt64(i16);
-        ulong IDeserializeVisitor<ulong>.VisitI32(int i32)    => Convert.ToUInt64(i32);
-        ulong IDeserializeVisitor<ulong>.VisitI64(long i64)   => Convert.ToUInt64(i64);
+        return deserializer.ReadU64();
     }
 }
 
-public readonly partial record struct SByteWrap(sbyte Value)
+public readonly partial struct SByteWrap
     : ISerialize<sbyte>, IDeserialize<sbyte>
 {
     public static ISerdeInfo SerdeInfo { get; } = Serde.SerdeInfo.MakePrimitive(s_typeName);
@@ -196,26 +107,11 @@ public readonly partial record struct SByteWrap(sbyte Value)
         => serializer.SerializeSByte(value);
     static sbyte IDeserialize<sbyte>.Deserialize(IDeserializer deserializer)
     {
-        var visitor = SerdeVisitor.Instance;
-        return deserializer.DeserializeSByte(visitor);
-    }
-
-    private sealed class SerdeVisitor : IDeserializeVisitor<sbyte>
-    {
-        public static readonly SerdeVisitor Instance = new SerdeVisitor();
-        public string ExpectedTypeName => s_typeName;
-        sbyte IDeserializeVisitor<sbyte>.VisitByte(byte b)    => Convert.ToSByte(b);
-        sbyte IDeserializeVisitor<sbyte>.VisitU16(ushort u16) => Convert.ToSByte(u16);
-        sbyte IDeserializeVisitor<sbyte>.VisitU32(uint u32)   => Convert.ToSByte(u32);
-        sbyte IDeserializeVisitor<sbyte>.VisitU64(ulong u64)  => Convert.ToSByte(u64);
-        sbyte IDeserializeVisitor<sbyte>.VisitSByte(sbyte b)  => b;
-        sbyte IDeserializeVisitor<sbyte>.VisitI16(short i16)  => Convert.ToSByte(i16);
-        sbyte IDeserializeVisitor<sbyte>.VisitI32(int i32)    => Convert.ToSByte(i32);
-        sbyte IDeserializeVisitor<sbyte>.VisitI64(long i64)   => Convert.ToSByte(i64);
+        return deserializer.ReadSByte();
     }
 }
 
-public readonly partial record struct Int16Wrap(short Value)
+public readonly partial struct Int16Wrap
     : ISerialize<short>, IDeserialize<short>
 {
     public static ISerdeInfo SerdeInfo { get; } = Serde.SerdeInfo.MakePrimitive(s_typeName);
@@ -226,26 +122,11 @@ public readonly partial record struct Int16Wrap(short Value)
     }
     static short IDeserialize<short>.Deserialize(IDeserializer deserializer)
     {
-        var visitor = SerdeVisitor.Instance;
-        return deserializer.DeserializeI16(visitor);
-    }
-
-    private sealed class SerdeVisitor : IDeserializeVisitor<short>
-    {
-        public static readonly SerdeVisitor Instance = new SerdeVisitor();
-        public string ExpectedTypeName => s_typeName;
-        short IDeserializeVisitor<short>.VisitByte(byte b)    => b;
-        short IDeserializeVisitor<short>.VisitU16(ushort u16) => Convert.ToInt16(u16);
-        short IDeserializeVisitor<short>.VisitU32(uint u32)   => Convert.ToInt16(u32);
-        short IDeserializeVisitor<short>.VisitU64(ulong u64)  => Convert.ToInt16(u64);
-        short IDeserializeVisitor<short>.VisitSByte(sbyte b)  => b;
-        short IDeserializeVisitor<short>.VisitI16(short i16)  => i16;
-        short IDeserializeVisitor<short>.VisitI32(int i32)    => Convert.ToInt16(i32);
-        short IDeserializeVisitor<short>.VisitI64(long i64)   => Convert.ToInt16(i64);
+        return deserializer.ReadI16();
     }
 }
 
-public readonly partial record struct Int32Wrap(int Value)
+public readonly partial struct Int32Wrap
     : ISerialize<int>, IDeserialize<int>
 {
     public static ISerdeInfo SerdeInfo { get; } = Serde.SerdeInfo.MakePrimitive(s_typeName);
@@ -256,26 +137,11 @@ public readonly partial record struct Int32Wrap(int Value)
     }
     static int IDeserialize<int>.Deserialize(IDeserializer deserializer)
     {
-        var visitor = SerdeVisitor.Instance;
-        return deserializer.DeserializeI32(visitor);
-    }
-
-    private sealed class SerdeVisitor : IDeserializeVisitor<int>
-    {
-        public static readonly SerdeVisitor Instance = new SerdeVisitor();
-        public string ExpectedTypeName => s_typeName;
-        int IDeserializeVisitor<int>.VisitByte(byte b)    => b;
-        int IDeserializeVisitor<int>.VisitU16(ushort u16) => u16;
-        int IDeserializeVisitor<int>.VisitU32(uint u32)   => Convert.ToInt32(u32);
-        int IDeserializeVisitor<int>.VisitU64(ulong u64)  => Convert.ToInt32(u64);
-        int IDeserializeVisitor<int>.VisitSByte(sbyte b)  => b;
-        int IDeserializeVisitor<int>.VisitI16(short i16)  => i16;
-        int IDeserializeVisitor<int>.VisitI32(int i32)    => i32;
-        int IDeserializeVisitor<int>.VisitI64(long i64)   => Convert.ToInt32(i64);
+        return deserializer.ReadI32();
     }
 }
 
-public readonly partial record struct Int64Wrap(long Value)
+public readonly partial struct Int64Wrap
     : ISerialize<long>, IDeserialize<long>
 {
     public static ISerdeInfo SerdeInfo { get; } = Serde.SerdeInfo.MakePrimitive(s_typeName);
@@ -284,8 +150,7 @@ public readonly partial record struct Int64Wrap(long Value)
         => serializer.SerializeI64(value);
     static long IDeserialize<long>.Deserialize(IDeserializer deserializer)
     {
-        var visitor = SerdeVisitor.Instance;
-        return deserializer.DeserializeI64(visitor);
+        return deserializer.ReadI64();
     }
 
     private sealed class SerdeVisitor : IDeserializeVisitor<long>
@@ -309,110 +174,48 @@ public readonly record struct SingleWrap : ISerialize<float>, IDeserialize<float
     public void Serialize(float value, ISerializer serializer)
         => serializer.SerializeFloat(value);
     public static float Deserialize(IDeserializer deserializer)
-        => deserializer.DeserializeFloat(SerdeVisitor.Instance);
-    private sealed class SerdeVisitor : IDeserializeVisitor<float>
-    {
-        public static readonly SerdeVisitor Instance = new SerdeVisitor();
-        public string ExpectedTypeName => "float";
-        float IDeserializeVisitor<float>.VisitByte(byte b)    => b;
-        float IDeserializeVisitor<float>.VisitU16(ushort u16) => u16;
-        float IDeserializeVisitor<float>.VisitU32(uint u32)   => u32;
-        float IDeserializeVisitor<float>.VisitU64(ulong u64)  => u64;
-        float IDeserializeVisitor<float>.VisitSByte(sbyte b)  => b;
-        float IDeserializeVisitor<float>.VisitI16(short i16)  => i16;
-        float IDeserializeVisitor<float>.VisitI32(int i32)    => i32;
-        float IDeserializeVisitor<float>.VisitI64(long i64)   => i64;
-        float IDeserializeVisitor<float>.VisitFloat(float f) => f;
-        float IDeserializeVisitor<float>.VisitDouble(double d) => Convert.ToSingle(d);
-    }
+        => deserializer.ReadFloat();
 }
 
-public readonly partial record struct DoubleWrap(double Value)
+public readonly partial record struct DoubleWrap
     : ISerialize<double>, IDeserialize<double>
 {
     public static ISerdeInfo SerdeInfo { get; } = Serde.SerdeInfo.MakePrimitive("double");
-    public static DoubleWrap Create(double d) => new DoubleWrap(d);
     void ISerialize<double>.Serialize(double value, ISerializer serializer)
     {
         serializer.SerializeDouble(value);
     }
     static double IDeserialize<double>.Deserialize(IDeserializer deserializer)
     {
-        var visitor = SerdeVisitor.Instance;
-        return deserializer.DeserializeDouble(visitor);
-    }
-
-    private sealed class SerdeVisitor : IDeserializeVisitor<double>
-    {
-        public static readonly SerdeVisitor Instance = new SerdeVisitor();
-        public string ExpectedTypeName => "double";
-        double IDeserializeVisitor<double>.VisitByte(byte b)    => b;
-        double IDeserializeVisitor<double>.VisitU16(ushort u16) => u16;
-        double IDeserializeVisitor<double>.VisitU32(uint u32)   => u32;
-        double IDeserializeVisitor<double>.VisitU64(ulong u64)  => Convert.ToDouble(u64);
-        double IDeserializeVisitor<double>.VisitSByte(sbyte b)  => b;
-        double IDeserializeVisitor<double>.VisitI16(short i16)  => i16;
-        double IDeserializeVisitor<double>.VisitI32(int i32)    => i32;
-        double IDeserializeVisitor<double>.VisitI64(long i64)   => Convert.ToDouble(i64);
-        double IDeserializeVisitor<double>.VisitFloat(float f) => f;
-        double IDeserializeVisitor<double>.VisitDouble(double d) => d;
+        return deserializer.ReadDouble();
     }
 }
 
-public readonly partial record struct DecimalWrap(decimal Value)
+public readonly partial struct DecimalWrap
     : ISerialize<decimal>, IDeserialize<decimal>
 {
     public static ISerdeInfo SerdeInfo { get; } = Serde.SerdeInfo.MakePrimitive("decimal");
-    public static DecimalWrap Create(decimal d) => new DecimalWrap(d);
     void ISerialize<decimal>.Serialize(decimal value, ISerializer serializer)
     {
         serializer.SerializeDecimal(value);
     }
     static decimal IDeserialize<decimal>.Deserialize(IDeserializer deserializer)
     {
-        var visitor = SerdeVisitor.Instance;
-        return deserializer.DeserializeDecimal(visitor);
-    }
-
-    private sealed class SerdeVisitor : IDeserializeVisitor<decimal>
-    {
-        public static readonly SerdeVisitor Instance = new SerdeVisitor();
-        public string ExpectedTypeName => "decimal";
-        decimal IDeserializeVisitor<decimal>.VisitByte(byte b)    => b;
-        decimal IDeserializeVisitor<decimal>.VisitU16(ushort u16) => u16;
-        decimal IDeserializeVisitor<decimal>.VisitU32(uint u32)   => u32;
-        decimal IDeserializeVisitor<decimal>.VisitU64(ulong u64)  => u64;
-        decimal IDeserializeVisitor<decimal>.VisitSByte(sbyte b)  => b;
-        decimal IDeserializeVisitor<decimal>.VisitI16(short i16)  => i16;
-        decimal IDeserializeVisitor<decimal>.VisitI32(int i32)    => i32;
-        decimal IDeserializeVisitor<decimal>.VisitI64(long i64)   => i64;
-        decimal IDeserializeVisitor<decimal>.VisitFloat(float f) => Convert.ToDecimal(f);
-        decimal IDeserializeVisitor<decimal>.VisitDouble(double d) => Convert.ToDecimal(d);
-        decimal IDeserializeVisitor<decimal>.VisitDecimal(decimal d) => d;
+        return deserializer.ReadDecimal();
     }
 }
-public readonly partial record struct StringWrap(string Value)
+public readonly partial struct StringWrap
     : ISerialize<string>, IDeserialize<string>
 {
     public static ISerdeInfo SerdeInfo { get; } = Serde.SerdeInfo.MakePrimitive(s_typeName);
     private const string s_typeName = "string";
-    public static StringWrap Create(string s) => new StringWrap(s);
     void ISerialize<string>.Serialize(string value, ISerializer serializer)
     {
         serializer.SerializeString(value);
     }
     public static string Deserialize(IDeserializer deserializer)
     {
-        return deserializer.DeserializeString(SerdeVisitor.Instance);
-    }
-
-    private sealed class SerdeVisitor : IDeserializeVisitor<string>
-    {
-        public static readonly SerdeVisitor Instance = new SerdeVisitor();
-        public string ExpectedTypeName => s_typeName;
-        public string VisitString(string s) => s;
-        string IDeserializeVisitor<string>.VisitChar(char c) => c.ToString();
-        string IDeserializeVisitor<string>.VisitUtf8Span(Utf8Span s) => Encoding.UTF8.GetString(s);
+        return deserializer.ReadString();
     }
 }
 
@@ -486,7 +289,7 @@ public static class NullableWrap
         public static ISerdeInfo SerdeInfo => NullableSerdeInfo<TWrap>.Instance;
         public static T? Deserialize(IDeserializer deserializer)
         {
-            return deserializer.DeserializeNullableRef(new Visitor());
+            return deserializer.ReadNullableRef(new Visitor());
         }
 
         private sealed class Visitor : IDeserializeVisitor<T?>
@@ -536,7 +339,7 @@ public static class NullableRefWrap
 
         public static T? Deserialize(IDeserializer deserializer)
         {
-            return deserializer.DeserializeNullableRef(new Visitor());
+            return deserializer.ReadNullableRef(new Visitor());
         }
 
         private sealed class Visitor : IDeserializeVisitor<T?>

--- a/src/serde/json/JsonValue.Deserialize.cs
+++ b/src/serde/json/JsonValue.Deserialize.cs
@@ -9,7 +9,7 @@ namespace Serde.Json
     {
         static JsonValue IDeserialize<JsonValue>.Deserialize(IDeserializer deserializer)
         {
-            return deserializer.DeserializeAny(Visitor.Instance);
+            return deserializer.ReadAny(Visitor.Instance);
         }
 
         private sealed class Visitor : IDeserializeVisitor<JsonValue>

--- a/src/serde/json/newreader/Utf8JsonLexer.cs
+++ b/src/serde/json/newreader/Utf8JsonLexer.cs
@@ -364,8 +364,6 @@ internal struct Utf8JsonLexer<TReader>(TReader byteReader)
             var s = byteReader.Peek();
             switch (s)
             {
-                case IByteReader.EndOfStream:
-                    return s;
                 case (short)' ':
                 case (short)'\t':
                 case (short)'\n':

--- a/test/Serde.Generation.Test/test_output/AllInOneTest.GeneratorTest/Serde.Test.AllInOne.ColorEnumWrap.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/AllInOneTest.GeneratorTest/Serde.Test.AllInOne.ColorEnumWrap.IDeserialize.verified.cs
@@ -13,7 +13,7 @@ namespace Serde.Test
             static Serde.Test.AllInOne.ColorEnum IDeserialize<Serde.Test.AllInOne.ColorEnum>.Deserialize(IDeserializer deserializer)
             {
                 var serdeInfo = global::Serde.SerdeInfoProvider.GetInfo<Serde.Test.AllInOne.ColorEnumWrap>();
-                var de = deserializer.DeserializeType(serdeInfo);
+                var de = deserializer.ReadType(serdeInfo);
                 int index;
                 if ((index = de.TryReadIndex(serdeInfo, out var errorName)) == IDeserializeType.IndexNotFound)
                 {

--- a/test/Serde.Generation.Test/test_output/AllInOneTest.GeneratorTest/Serde.Test.AllInOne.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/AllInOneTest.GeneratorTest/Serde.Test.AllInOne.IDeserialize.verified.cs
@@ -31,56 +31,56 @@ namespace Serde.Test
             var _l_serdeInfo = global::Serde.SerdeInfoProvider.GetInfo<AllInOne>();
             var typeDeserialize = deserializer.ReadType(_l_serdeInfo);
             int _l_index_;
-            while ((_l_index_ = typeDeserialize.TryReadIndex(_l_serdeInfo, out var _l_errorName)) != IDeserializeType.EndOfType)
+            while ((_l_index_ = typeDeserialize.TryReadIndex(_l_serdeInfo, out _)) != IDeserializeType.EndOfType)
             {
                 switch (_l_index_)
                 {
                     case 0:
-                        _l_boolfield = typeDeserialize.ReadValue<bool, global::Serde.BoolWrap>(_l_index_);
+                        _l_boolfield = typeDeserialize.ReadBool(_l_index_);
                         _r_assignedValid |= ((uint)1) << 0;
                         break;
                     case 1:
-                        _l_charfield = typeDeserialize.ReadValue<char, global::Serde.CharWrap>(_l_index_);
+                        _l_charfield = typeDeserialize.ReadChar(_l_index_);
                         _r_assignedValid |= ((uint)1) << 1;
                         break;
                     case 2:
-                        _l_bytefield = typeDeserialize.ReadValue<byte, global::Serde.ByteWrap>(_l_index_);
+                        _l_bytefield = typeDeserialize.ReadByte(_l_index_);
                         _r_assignedValid |= ((uint)1) << 2;
                         break;
                     case 3:
-                        _l_ushortfield = typeDeserialize.ReadValue<ushort, global::Serde.UInt16Wrap>(_l_index_);
+                        _l_ushortfield = typeDeserialize.ReadU16(_l_index_);
                         _r_assignedValid |= ((uint)1) << 3;
                         break;
                     case 4:
-                        _l_uintfield = typeDeserialize.ReadValue<uint, global::Serde.UInt32Wrap>(_l_index_);
+                        _l_uintfield = typeDeserialize.ReadU32(_l_index_);
                         _r_assignedValid |= ((uint)1) << 4;
                         break;
                     case 5:
-                        _l_ulongfield = typeDeserialize.ReadValue<ulong, global::Serde.UInt64Wrap>(_l_index_);
+                        _l_ulongfield = typeDeserialize.ReadU64(_l_index_);
                         _r_assignedValid |= ((uint)1) << 5;
                         break;
                     case 6:
-                        _l_sbytefield = typeDeserialize.ReadValue<sbyte, global::Serde.SByteWrap>(_l_index_);
+                        _l_sbytefield = typeDeserialize.ReadSByte(_l_index_);
                         _r_assignedValid |= ((uint)1) << 6;
                         break;
                     case 7:
-                        _l_shortfield = typeDeserialize.ReadValue<short, global::Serde.Int16Wrap>(_l_index_);
+                        _l_shortfield = typeDeserialize.ReadI16(_l_index_);
                         _r_assignedValid |= ((uint)1) << 7;
                         break;
                     case 8:
-                        _l_intfield = typeDeserialize.ReadValue<int, global::Serde.Int32Wrap>(_l_index_);
+                        _l_intfield = typeDeserialize.ReadI32(_l_index_);
                         _r_assignedValid |= ((uint)1) << 8;
                         break;
                     case 9:
-                        _l_longfield = typeDeserialize.ReadValue<long, global::Serde.Int64Wrap>(_l_index_);
+                        _l_longfield = typeDeserialize.ReadI64(_l_index_);
                         _r_assignedValid |= ((uint)1) << 9;
                         break;
                     case 10:
-                        _l_stringfield = typeDeserialize.ReadValue<string, global::Serde.StringWrap>(_l_index_);
+                        _l_stringfield = typeDeserialize.ReadString(_l_index_);
                         _r_assignedValid |= ((uint)1) << 10;
                         break;
                     case 11:
-                        _l_escapedstringfield = typeDeserialize.ReadValue<string, global::Serde.StringWrap>(_l_index_);
+                        _l_escapedstringfield = typeDeserialize.ReadString(_l_index_);
                         _r_assignedValid |= ((uint)1) << 11;
                         break;
                     case 12:

--- a/test/Serde.Generation.Test/test_output/AllInOneTest.GeneratorTest/Serde.Test.AllInOne.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/AllInOneTest.GeneratorTest/Serde.Test.AllInOne.IDeserialize.verified.cs
@@ -29,7 +29,7 @@ namespace Serde.Test
             Serde.Test.AllInOne.ColorEnum _l_color = default !;
             uint _r_assignedValid = 0;
             var _l_serdeInfo = global::Serde.SerdeInfoProvider.GetInfo<AllInOne>();
-            var typeDeserialize = deserializer.DeserializeType(_l_serdeInfo);
+            var typeDeserialize = deserializer.ReadType(_l_serdeInfo);
             int _l_index_;
             while ((_l_index_ = typeDeserialize.TryReadIndex(_l_serdeInfo, out var _l_errorName)) != IDeserializeType.EndOfType)
             {

--- a/test/Serde.Generation.Test/test_output/DeserializeTests.EnumMember/C.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/DeserializeTests.EnumMember/C.IDeserialize.verified.cs
@@ -14,7 +14,7 @@ partial class C : Serde.IDeserialize<C>
         ColorULong _l_colorulong = default !;
         byte _r_assignedValid = 0;
         var _l_serdeInfo = global::Serde.SerdeInfoProvider.GetInfo<C>();
-        var typeDeserialize = deserializer.DeserializeType(_l_serdeInfo);
+        var typeDeserialize = deserializer.ReadType(_l_serdeInfo);
         int _l_index_;
         while ((_l_index_ = typeDeserialize.TryReadIndex(_l_serdeInfo, out var _l_errorName)) != IDeserializeType.EndOfType)
         {

--- a/test/Serde.Generation.Test/test_output/DeserializeTests.EnumMember/C.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/DeserializeTests.EnumMember/C.IDeserialize.verified.cs
@@ -16,7 +16,7 @@ partial class C : Serde.IDeserialize<C>
         var _l_serdeInfo = global::Serde.SerdeInfoProvider.GetInfo<C>();
         var typeDeserialize = deserializer.ReadType(_l_serdeInfo);
         int _l_index_;
-        while ((_l_index_ = typeDeserialize.TryReadIndex(_l_serdeInfo, out var _l_errorName)) != IDeserializeType.EndOfType)
+        while ((_l_index_ = typeDeserialize.TryReadIndex(_l_serdeInfo, out _)) != IDeserializeType.EndOfType)
         {
             switch (_l_index_)
             {

--- a/test/Serde.Generation.Test/test_output/DeserializeTests.EnumMember/ColorByteWrap.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/DeserializeTests.EnumMember/ColorByteWrap.IDeserialize.verified.cs
@@ -9,7 +9,7 @@ partial struct ColorByteWrap : Serde.IDeserialize<ColorByte>
     static ColorByte IDeserialize<ColorByte>.Deserialize(IDeserializer deserializer)
     {
         var serdeInfo = global::Serde.SerdeInfoProvider.GetInfo<ColorByteWrap>();
-        var de = deserializer.DeserializeType(serdeInfo);
+        var de = deserializer.ReadType(serdeInfo);
         int index;
         if ((index = de.TryReadIndex(serdeInfo, out var errorName)) == IDeserializeType.IndexNotFound)
         {

--- a/test/Serde.Generation.Test/test_output/DeserializeTests.EnumMember/ColorIntWrap.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/DeserializeTests.EnumMember/ColorIntWrap.IDeserialize.verified.cs
@@ -9,7 +9,7 @@ partial struct ColorIntWrap : Serde.IDeserialize<ColorInt>
     static ColorInt IDeserialize<ColorInt>.Deserialize(IDeserializer deserializer)
     {
         var serdeInfo = global::Serde.SerdeInfoProvider.GetInfo<ColorIntWrap>();
-        var de = deserializer.DeserializeType(serdeInfo);
+        var de = deserializer.ReadType(serdeInfo);
         int index;
         if ((index = de.TryReadIndex(serdeInfo, out var errorName)) == IDeserializeType.IndexNotFound)
         {

--- a/test/Serde.Generation.Test/test_output/DeserializeTests.EnumMember/ColorLongWrap.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/DeserializeTests.EnumMember/ColorLongWrap.IDeserialize.verified.cs
@@ -9,7 +9,7 @@ partial struct ColorLongWrap : Serde.IDeserialize<ColorLong>
     static ColorLong IDeserialize<ColorLong>.Deserialize(IDeserializer deserializer)
     {
         var serdeInfo = global::Serde.SerdeInfoProvider.GetInfo<ColorLongWrap>();
-        var de = deserializer.DeserializeType(serdeInfo);
+        var de = deserializer.ReadType(serdeInfo);
         int index;
         if ((index = de.TryReadIndex(serdeInfo, out var errorName)) == IDeserializeType.IndexNotFound)
         {

--- a/test/Serde.Generation.Test/test_output/DeserializeTests.EnumMember/ColorULongWrap.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/DeserializeTests.EnumMember/ColorULongWrap.IDeserialize.verified.cs
@@ -9,7 +9,7 @@ partial struct ColorULongWrap : Serde.IDeserialize<ColorULong>
     static ColorULong IDeserialize<ColorULong>.Deserialize(IDeserializer deserializer)
     {
         var serdeInfo = global::Serde.SerdeInfoProvider.GetInfo<ColorULongWrap>();
-        var de = deserializer.DeserializeType(serdeInfo);
+        var de = deserializer.ReadType(serdeInfo);
         int index;
         if ((index = de.TryReadIndex(serdeInfo, out var errorName)) == IDeserializeType.IndexNotFound)
         {

--- a/test/Serde.Generation.Test/test_output/DeserializeTests.NestedExplicitDeserializeWrapper/OptsWrap.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/DeserializeTests.NestedExplicitDeserializeWrapper/OptsWrap.IDeserialize.verified.cs
@@ -14,7 +14,7 @@ partial record struct OptsWrap : Serde.IDeserialize<System.Runtime.InteropServic
         int _l_grfmode = default !;
         byte _r_assignedValid = 0;
         var _l_serdeInfo = global::Serde.SerdeInfoProvider.GetInfo<OptsWrap>();
-        var typeDeserialize = deserializer.DeserializeType(_l_serdeInfo);
+        var typeDeserialize = deserializer.ReadType(_l_serdeInfo);
         int _l_index_;
         while ((_l_index_ = typeDeserialize.TryReadIndex(_l_serdeInfo, out var _l_errorName)) != IDeserializeType.EndOfType)
         {

--- a/test/Serde.Generation.Test/test_output/DeserializeTests.NestedExplicitDeserializeWrapper/OptsWrap.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/DeserializeTests.NestedExplicitDeserializeWrapper/OptsWrap.IDeserialize.verified.cs
@@ -16,24 +16,24 @@ partial record struct OptsWrap : Serde.IDeserialize<System.Runtime.InteropServic
         var _l_serdeInfo = global::Serde.SerdeInfoProvider.GetInfo<OptsWrap>();
         var typeDeserialize = deserializer.ReadType(_l_serdeInfo);
         int _l_index_;
-        while ((_l_index_ = typeDeserialize.TryReadIndex(_l_serdeInfo, out var _l_errorName)) != IDeserializeType.EndOfType)
+        while ((_l_index_ = typeDeserialize.TryReadIndex(_l_serdeInfo, out _)) != IDeserializeType.EndOfType)
         {
             switch (_l_index_)
             {
                 case 0:
-                    _l_cbstruct = typeDeserialize.ReadValue<int, global::Serde.Int32Wrap>(_l_index_);
+                    _l_cbstruct = typeDeserialize.ReadI32(_l_index_);
                     _r_assignedValid |= ((byte)1) << 0;
                     break;
                 case 1:
-                    _l_dwtickcountdeadline = typeDeserialize.ReadValue<int, global::Serde.Int32Wrap>(_l_index_);
+                    _l_dwtickcountdeadline = typeDeserialize.ReadI32(_l_index_);
                     _r_assignedValid |= ((byte)1) << 1;
                     break;
                 case 2:
-                    _l_grfflags = typeDeserialize.ReadValue<int, global::Serde.Int32Wrap>(_l_index_);
+                    _l_grfflags = typeDeserialize.ReadI32(_l_index_);
                     _r_assignedValid |= ((byte)1) << 2;
                     break;
                 case 3:
-                    _l_grfmode = typeDeserialize.ReadValue<int, global::Serde.Int32Wrap>(_l_index_);
+                    _l_grfmode = typeDeserialize.ReadI32(_l_index_);
                     _r_assignedValid |= ((byte)1) << 3;
                     break;
                 case Serde.IDeserializeType.IndexNotFound:

--- a/test/Serde.Generation.Test/test_output/DeserializeTests.NestedExplicitDeserializeWrapper/S.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/DeserializeTests.NestedExplicitDeserializeWrapper/S.IDeserialize.verified.cs
@@ -11,7 +11,7 @@ partial struct S : Serde.IDeserialize<S>
         System.Collections.Immutable.ImmutableArray<System.Runtime.InteropServices.ComTypes.BIND_OPTS> _l_opts = default !;
         byte _r_assignedValid = 0;
         var _l_serdeInfo = global::Serde.SerdeInfoProvider.GetInfo<S>();
-        var typeDeserialize = deserializer.DeserializeType(_l_serdeInfo);
+        var typeDeserialize = deserializer.ReadType(_l_serdeInfo);
         int _l_index_;
         while ((_l_index_ = typeDeserialize.TryReadIndex(_l_serdeInfo, out var _l_errorName)) != IDeserializeType.EndOfType)
         {

--- a/test/Serde.Generation.Test/test_output/DeserializeTests.NestedExplicitDeserializeWrapper/S.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/DeserializeTests.NestedExplicitDeserializeWrapper/S.IDeserialize.verified.cs
@@ -13,7 +13,7 @@ partial struct S : Serde.IDeserialize<S>
         var _l_serdeInfo = global::Serde.SerdeInfoProvider.GetInfo<S>();
         var typeDeserialize = deserializer.ReadType(_l_serdeInfo);
         int _l_index_;
-        while ((_l_index_ = typeDeserialize.TryReadIndex(_l_serdeInfo, out var _l_errorName)) != IDeserializeType.EndOfType)
+        while ((_l_index_ = typeDeserialize.TryReadIndex(_l_serdeInfo, out _)) != IDeserializeType.EndOfType)
         {
             switch (_l_index_)
             {

--- a/test/Serde.Generation.Test/test_output/DeserializeTests/Array#ArrayField.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/DeserializeTests/Array#ArrayField.IDeserialize.verified.cs
@@ -13,7 +13,7 @@ partial class ArrayField : Serde.IDeserialize<ArrayField>
         var _l_serdeInfo = global::Serde.SerdeInfoProvider.GetInfo<ArrayField>();
         var typeDeserialize = deserializer.ReadType(_l_serdeInfo);
         int _l_index_;
-        while ((_l_index_ = typeDeserialize.TryReadIndex(_l_serdeInfo, out var _l_errorName)) != IDeserializeType.EndOfType)
+        while ((_l_index_ = typeDeserialize.TryReadIndex(_l_serdeInfo, out _)) != IDeserializeType.EndOfType)
         {
             switch (_l_index_)
             {

--- a/test/Serde.Generation.Test/test_output/DeserializeTests/Array#ArrayField.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/DeserializeTests/Array#ArrayField.IDeserialize.verified.cs
@@ -11,7 +11,7 @@ partial class ArrayField : Serde.IDeserialize<ArrayField>
         int[] _l_intarr = default !;
         byte _r_assignedValid = 0;
         var _l_serdeInfo = global::Serde.SerdeInfoProvider.GetInfo<ArrayField>();
-        var typeDeserialize = deserializer.DeserializeType(_l_serdeInfo);
+        var typeDeserialize = deserializer.ReadType(_l_serdeInfo);
         int _l_index_;
         while ((_l_index_ = typeDeserialize.TryReadIndex(_l_serdeInfo, out var _l_errorName)) != IDeserializeType.EndOfType)
         {

--- a/test/Serde.Generation.Test/test_output/DeserializeTests/DeserializeMissing#SetToNull.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/DeserializeTests/DeserializeMissing#SetToNull.IDeserialize.verified.cs
@@ -15,12 +15,12 @@ partial record struct SetToNull : Serde.IDeserialize<SetToNull>
         var _l_serdeInfo = global::Serde.SerdeInfoProvider.GetInfo<SetToNull>();
         var typeDeserialize = deserializer.ReadType(_l_serdeInfo);
         int _l_index_;
-        while ((_l_index_ = typeDeserialize.TryReadIndex(_l_serdeInfo, out var _l_errorName)) != IDeserializeType.EndOfType)
+        while ((_l_index_ = typeDeserialize.TryReadIndex(_l_serdeInfo, out _)) != IDeserializeType.EndOfType)
         {
             switch (_l_index_)
             {
                 case 0:
-                    _l_present = typeDeserialize.ReadValue<string, global::Serde.StringWrap>(_l_index_);
+                    _l_present = typeDeserialize.ReadString(_l_index_);
                     _r_assignedValid |= ((byte)1) << 0;
                     break;
                 case 1:

--- a/test/Serde.Generation.Test/test_output/DeserializeTests/DeserializeMissing#SetToNull.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/DeserializeTests/DeserializeMissing#SetToNull.IDeserialize.verified.cs
@@ -13,7 +13,7 @@ partial record struct SetToNull : Serde.IDeserialize<SetToNull>
         string? _l_throwmissing = default !;
         byte _r_assignedValid = 0;
         var _l_serdeInfo = global::Serde.SerdeInfoProvider.GetInfo<SetToNull>();
-        var typeDeserialize = deserializer.DeserializeType(_l_serdeInfo);
+        var typeDeserialize = deserializer.ReadType(_l_serdeInfo);
         int _l_index_;
         while ((_l_index_ = typeDeserialize.TryReadIndex(_l_serdeInfo, out var _l_errorName)) != IDeserializeType.EndOfType)
         {

--- a/test/Serde.Generation.Test/test_output/DeserializeTests/DeserializeOnlyWrap#Wrap.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/DeserializeTests/DeserializeOnlyWrap#Wrap.IDeserialize.verified.cs
@@ -14,7 +14,7 @@ partial record struct Wrap : Serde.IDeserialize<System.Runtime.InteropServices.C
         int _l_grfmode = default !;
         byte _r_assignedValid = 0;
         var _l_serdeInfo = global::Serde.SerdeInfoProvider.GetInfo<Wrap>();
-        var typeDeserialize = deserializer.DeserializeType(_l_serdeInfo);
+        var typeDeserialize = deserializer.ReadType(_l_serdeInfo);
         int _l_index_;
         while ((_l_index_ = typeDeserialize.TryReadIndex(_l_serdeInfo, out var _l_errorName)) != IDeserializeType.EndOfType)
         {

--- a/test/Serde.Generation.Test/test_output/DeserializeTests/DeserializeOnlyWrap#Wrap.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/DeserializeTests/DeserializeOnlyWrap#Wrap.IDeserialize.verified.cs
@@ -16,24 +16,24 @@ partial record struct Wrap : Serde.IDeserialize<System.Runtime.InteropServices.C
         var _l_serdeInfo = global::Serde.SerdeInfoProvider.GetInfo<Wrap>();
         var typeDeserialize = deserializer.ReadType(_l_serdeInfo);
         int _l_index_;
-        while ((_l_index_ = typeDeserialize.TryReadIndex(_l_serdeInfo, out var _l_errorName)) != IDeserializeType.EndOfType)
+        while ((_l_index_ = typeDeserialize.TryReadIndex(_l_serdeInfo, out _)) != IDeserializeType.EndOfType)
         {
             switch (_l_index_)
             {
                 case 0:
-                    _l_cbstruct = typeDeserialize.ReadValue<int, global::Serde.Int32Wrap>(_l_index_);
+                    _l_cbstruct = typeDeserialize.ReadI32(_l_index_);
                     _r_assignedValid |= ((byte)1) << 0;
                     break;
                 case 1:
-                    _l_dwtickcountdeadline = typeDeserialize.ReadValue<int, global::Serde.Int32Wrap>(_l_index_);
+                    _l_dwtickcountdeadline = typeDeserialize.ReadI32(_l_index_);
                     _r_assignedValid |= ((byte)1) << 1;
                     break;
                 case 2:
-                    _l_grfflags = typeDeserialize.ReadValue<int, global::Serde.Int32Wrap>(_l_index_);
+                    _l_grfflags = typeDeserialize.ReadI32(_l_index_);
                     _r_assignedValid |= ((byte)1) << 2;
                     break;
                 case 3:
-                    _l_grfmode = typeDeserialize.ReadValue<int, global::Serde.Int32Wrap>(_l_index_);
+                    _l_grfmode = typeDeserialize.ReadI32(_l_index_);
                     _r_assignedValid |= ((byte)1) << 3;
                     break;
                 case Serde.IDeserializeType.IndexNotFound:

--- a/test/Serde.Generation.Test/test_output/DeserializeTests/MemberSkip#Rgb.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/DeserializeTests/MemberSkip#Rgb.IDeserialize.verified.cs
@@ -12,7 +12,7 @@ partial struct Rgb : Serde.IDeserialize<Rgb>
         byte _l_blue = default !;
         byte _r_assignedValid = 0;
         var _l_serdeInfo = global::Serde.SerdeInfoProvider.GetInfo<Rgb>();
-        var typeDeserialize = deserializer.DeserializeType(_l_serdeInfo);
+        var typeDeserialize = deserializer.ReadType(_l_serdeInfo);
         int _l_index_;
         while ((_l_index_ = typeDeserialize.TryReadIndex(_l_serdeInfo, out var _l_errorName)) != IDeserializeType.EndOfType)
         {

--- a/test/Serde.Generation.Test/test_output/DeserializeTests/MemberSkip#Rgb.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/DeserializeTests/MemberSkip#Rgb.IDeserialize.verified.cs
@@ -14,16 +14,16 @@ partial struct Rgb : Serde.IDeserialize<Rgb>
         var _l_serdeInfo = global::Serde.SerdeInfoProvider.GetInfo<Rgb>();
         var typeDeserialize = deserializer.ReadType(_l_serdeInfo);
         int _l_index_;
-        while ((_l_index_ = typeDeserialize.TryReadIndex(_l_serdeInfo, out var _l_errorName)) != IDeserializeType.EndOfType)
+        while ((_l_index_ = typeDeserialize.TryReadIndex(_l_serdeInfo, out _)) != IDeserializeType.EndOfType)
         {
             switch (_l_index_)
             {
                 case 0:
-                    _l_red = typeDeserialize.ReadValue<byte, global::Serde.ByteWrap>(_l_index_);
+                    _l_red = typeDeserialize.ReadByte(_l_index_);
                     _r_assignedValid |= ((byte)1) << 0;
                     break;
                 case 1:
-                    _l_blue = typeDeserialize.ReadValue<byte, global::Serde.ByteWrap>(_l_index_);
+                    _l_blue = typeDeserialize.ReadByte(_l_index_);
                     _r_assignedValid |= ((byte)1) << 1;
                     break;
                 case Serde.IDeserializeType.IndexNotFound:

--- a/test/Serde.Generation.Test/test_output/DeserializeTests/MemberSkipDeserialize#Rgb.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/DeserializeTests/MemberSkipDeserialize#Rgb.IDeserialize.verified.cs
@@ -12,7 +12,7 @@ partial struct Rgb : Serde.IDeserialize<Rgb>
         byte _l_blue = default !;
         byte _r_assignedValid = 0;
         var _l_serdeInfo = global::Serde.SerdeInfoProvider.GetInfo<Rgb>();
-        var typeDeserialize = deserializer.DeserializeType(_l_serdeInfo);
+        var typeDeserialize = deserializer.ReadType(_l_serdeInfo);
         int _l_index_;
         while ((_l_index_ = typeDeserialize.TryReadIndex(_l_serdeInfo, out var _l_errorName)) != IDeserializeType.EndOfType)
         {

--- a/test/Serde.Generation.Test/test_output/DeserializeTests/MemberSkipDeserialize#Rgb.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/DeserializeTests/MemberSkipDeserialize#Rgb.IDeserialize.verified.cs
@@ -14,16 +14,16 @@ partial struct Rgb : Serde.IDeserialize<Rgb>
         var _l_serdeInfo = global::Serde.SerdeInfoProvider.GetInfo<Rgb>();
         var typeDeserialize = deserializer.ReadType(_l_serdeInfo);
         int _l_index_;
-        while ((_l_index_ = typeDeserialize.TryReadIndex(_l_serdeInfo, out var _l_errorName)) != IDeserializeType.EndOfType)
+        while ((_l_index_ = typeDeserialize.TryReadIndex(_l_serdeInfo, out _)) != IDeserializeType.EndOfType)
         {
             switch (_l_index_)
             {
                 case 0:
-                    _l_red = typeDeserialize.ReadValue<byte, global::Serde.ByteWrap>(_l_index_);
+                    _l_red = typeDeserialize.ReadByte(_l_index_);
                     _r_assignedValid |= ((byte)1) << 0;
                     break;
                 case 2:
-                    _l_blue = typeDeserialize.ReadValue<byte, global::Serde.ByteWrap>(_l_index_);
+                    _l_blue = typeDeserialize.ReadByte(_l_index_);
                     _r_assignedValid |= ((byte)1) << 2;
                     break;
                 case 1:

--- a/test/Serde.Generation.Test/test_output/DeserializeTests/MemberSkipSerialize#Rgb.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/DeserializeTests/MemberSkipSerialize#Rgb.IDeserialize.verified.cs
@@ -15,20 +15,20 @@ partial struct Rgb : Serde.IDeserialize<Rgb>
         var _l_serdeInfo = global::Serde.SerdeInfoProvider.GetInfo<Rgb>();
         var typeDeserialize = deserializer.ReadType(_l_serdeInfo);
         int _l_index_;
-        while ((_l_index_ = typeDeserialize.TryReadIndex(_l_serdeInfo, out var _l_errorName)) != IDeserializeType.EndOfType)
+        while ((_l_index_ = typeDeserialize.TryReadIndex(_l_serdeInfo, out _)) != IDeserializeType.EndOfType)
         {
             switch (_l_index_)
             {
                 case 0:
-                    _l_red = typeDeserialize.ReadValue<byte, global::Serde.ByteWrap>(_l_index_);
+                    _l_red = typeDeserialize.ReadByte(_l_index_);
                     _r_assignedValid |= ((byte)1) << 0;
                     break;
                 case 1:
-                    _l_green = typeDeserialize.ReadValue<byte, global::Serde.ByteWrap>(_l_index_);
+                    _l_green = typeDeserialize.ReadByte(_l_index_);
                     _r_assignedValid |= ((byte)1) << 1;
                     break;
                 case 2:
-                    _l_blue = typeDeserialize.ReadValue<byte, global::Serde.ByteWrap>(_l_index_);
+                    _l_blue = typeDeserialize.ReadByte(_l_index_);
                     _r_assignedValid |= ((byte)1) << 2;
                     break;
                 case Serde.IDeserializeType.IndexNotFound:

--- a/test/Serde.Generation.Test/test_output/DeserializeTests/MemberSkipSerialize#Rgb.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/DeserializeTests/MemberSkipSerialize#Rgb.IDeserialize.verified.cs
@@ -13,7 +13,7 @@ partial struct Rgb : Serde.IDeserialize<Rgb>
         byte _l_blue = default !;
         byte _r_assignedValid = 0;
         var _l_serdeInfo = global::Serde.SerdeInfoProvider.GetInfo<Rgb>();
-        var typeDeserialize = deserializer.DeserializeType(_l_serdeInfo);
+        var typeDeserialize = deserializer.ReadType(_l_serdeInfo);
         int _l_index_;
         while ((_l_index_ = typeDeserialize.TryReadIndex(_l_serdeInfo, out var _l_errorName)) != IDeserializeType.EndOfType)
         {

--- a/test/Serde.Generation.Test/test_output/DeserializeTests/NestedPartialClasses#A.B.C.D.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/DeserializeTests/NestedPartialClasses#A.B.C.D.IDeserialize.verified.cs
@@ -19,12 +19,12 @@ partial class A
                     var _l_serdeInfo = global::Serde.SerdeInfoProvider.GetInfo<D>();
                     var typeDeserialize = deserializer.ReadType(_l_serdeInfo);
                     int _l_index_;
-                    while ((_l_index_ = typeDeserialize.TryReadIndex(_l_serdeInfo, out var _l_errorName)) != IDeserializeType.EndOfType)
+                    while ((_l_index_ = typeDeserialize.TryReadIndex(_l_serdeInfo, out _)) != IDeserializeType.EndOfType)
                     {
                         switch (_l_index_)
                         {
                             case 0:
-                                _l_field = typeDeserialize.ReadValue<int, global::Serde.Int32Wrap>(_l_index_);
+                                _l_field = typeDeserialize.ReadI32(_l_index_);
                                 _r_assignedValid |= ((byte)1) << 0;
                                 break;
                             case Serde.IDeserializeType.IndexNotFound:

--- a/test/Serde.Generation.Test/test_output/DeserializeTests/NestedPartialClasses#A.B.C.D.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/DeserializeTests/NestedPartialClasses#A.B.C.D.IDeserialize.verified.cs
@@ -17,7 +17,7 @@ partial class A
                     int _l_field = default !;
                     byte _r_assignedValid = 0;
                     var _l_serdeInfo = global::Serde.SerdeInfoProvider.GetInfo<D>();
-                    var typeDeserialize = deserializer.DeserializeType(_l_serdeInfo);
+                    var typeDeserialize = deserializer.ReadType(_l_serdeInfo);
                     int _l_index_;
                     while ((_l_index_ = typeDeserialize.TryReadIndex(_l_serdeInfo, out var _l_errorName)) != IDeserializeType.EndOfType)
                     {

--- a/test/Serde.Generation.Test/test_output/DeserializeTests/NullableRefField#S.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/DeserializeTests/NullableRefField#S.IDeserialize.verified.cs
@@ -11,7 +11,7 @@ partial struct S : Serde.IDeserialize<S>
         string? _l_f = default !;
         byte _r_assignedValid = 0;
         var _l_serdeInfo = global::Serde.SerdeInfoProvider.GetInfo<S>();
-        var typeDeserialize = deserializer.DeserializeType(_l_serdeInfo);
+        var typeDeserialize = deserializer.ReadType(_l_serdeInfo);
         int _l_index_;
         while ((_l_index_ = typeDeserialize.TryReadIndex(_l_serdeInfo, out var _l_errorName)) != IDeserializeType.EndOfType)
         {

--- a/test/Serde.Generation.Test/test_output/DeserializeTests/NullableRefField#S.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/DeserializeTests/NullableRefField#S.IDeserialize.verified.cs
@@ -13,7 +13,7 @@ partial struct S : Serde.IDeserialize<S>
         var _l_serdeInfo = global::Serde.SerdeInfoProvider.GetInfo<S>();
         var typeDeserialize = deserializer.ReadType(_l_serdeInfo);
         int _l_index_;
-        while ((_l_index_ = typeDeserialize.TryReadIndex(_l_serdeInfo, out var _l_errorName)) != IDeserializeType.EndOfType)
+        while ((_l_index_ = typeDeserialize.TryReadIndex(_l_serdeInfo, out _)) != IDeserializeType.EndOfType)
         {
             switch (_l_index_)
             {

--- a/test/Serde.Generation.Test/test_output/DeserializeTests/Rgb#Rgb.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/DeserializeTests/Rgb#Rgb.IDeserialize.verified.cs
@@ -15,20 +15,20 @@ partial struct Rgb : Serde.IDeserialize<Rgb>
         var _l_serdeInfo = global::Serde.SerdeInfoProvider.GetInfo<Rgb>();
         var typeDeserialize = deserializer.ReadType(_l_serdeInfo);
         int _l_index_;
-        while ((_l_index_ = typeDeserialize.TryReadIndex(_l_serdeInfo, out var _l_errorName)) != IDeserializeType.EndOfType)
+        while ((_l_index_ = typeDeserialize.TryReadIndex(_l_serdeInfo, out _)) != IDeserializeType.EndOfType)
         {
             switch (_l_index_)
             {
                 case 0:
-                    _l_red = typeDeserialize.ReadValue<byte, global::Serde.ByteWrap>(_l_index_);
+                    _l_red = typeDeserialize.ReadByte(_l_index_);
                     _r_assignedValid |= ((byte)1) << 0;
                     break;
                 case 1:
-                    _l_green = typeDeserialize.ReadValue<byte, global::Serde.ByteWrap>(_l_index_);
+                    _l_green = typeDeserialize.ReadByte(_l_index_);
                     _r_assignedValid |= ((byte)1) << 1;
                     break;
                 case 2:
-                    _l_blue = typeDeserialize.ReadValue<byte, global::Serde.ByteWrap>(_l_index_);
+                    _l_blue = typeDeserialize.ReadByte(_l_index_);
                     _r_assignedValid |= ((byte)1) << 2;
                     break;
                 case Serde.IDeserializeType.IndexNotFound:

--- a/test/Serde.Generation.Test/test_output/DeserializeTests/Rgb#Rgb.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/DeserializeTests/Rgb#Rgb.IDeserialize.verified.cs
@@ -13,7 +13,7 @@ partial struct Rgb : Serde.IDeserialize<Rgb>
         byte _l_blue = default !;
         byte _r_assignedValid = 0;
         var _l_serdeInfo = global::Serde.SerdeInfoProvider.GetInfo<Rgb>();
-        var typeDeserialize = deserializer.DeserializeType(_l_serdeInfo);
+        var typeDeserialize = deserializer.ReadType(_l_serdeInfo);
         int _l_index_;
         while ((_l_index_ = typeDeserialize.TryReadIndex(_l_serdeInfo, out var _l_errorName)) != IDeserializeType.EndOfType)
         {

--- a/test/Serde.Generation.Test/test_output/MemberFormatTests.EnumFormat/ColorEnumWrap.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/MemberFormatTests.EnumFormat/ColorEnumWrap.IDeserialize.verified.cs
@@ -9,7 +9,7 @@ partial struct ColorEnumWrap : Serde.IDeserialize<ColorEnum>
     static ColorEnum IDeserialize<ColorEnum>.Deserialize(IDeserializer deserializer)
     {
         var serdeInfo = global::Serde.SerdeInfoProvider.GetInfo<ColorEnumWrap>();
-        var de = deserializer.DeserializeType(serdeInfo);
+        var de = deserializer.ReadType(serdeInfo);
         int index;
         if ((index = de.TryReadIndex(serdeInfo, out var errorName)) == IDeserializeType.IndexNotFound)
         {

--- a/test/Serde.Generation.Test/test_output/MemberFormatTests.EnumValues/ColorEnumWrap.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/MemberFormatTests.EnumValues/ColorEnumWrap.IDeserialize.verified.cs
@@ -9,7 +9,7 @@ partial struct ColorEnumWrap : Serde.IDeserialize<ColorEnum>
     static ColorEnum IDeserialize<ColorEnum>.Deserialize(IDeserializer deserializer)
     {
         var serdeInfo = global::Serde.SerdeInfoProvider.GetInfo<ColorEnumWrap>();
-        var de = deserializer.DeserializeType(serdeInfo);
+        var de = deserializer.ReadType(serdeInfo);
         int index;
         if ((index = de.TryReadIndex(serdeInfo, out var errorName)) == IDeserializeType.IndexNotFound)
         {

--- a/test/Serde.Generation.Test/test_output/MemberFormatTests.EnumValues/S.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/MemberFormatTests.EnumValues/S.IDeserialize.verified.cs
@@ -11,7 +11,7 @@ partial struct S : Serde.IDeserialize<S>
         ColorEnum _l_e = default !;
         byte _r_assignedValid = 0;
         var _l_serdeInfo = global::Serde.SerdeInfoProvider.GetInfo<S>();
-        var typeDeserialize = deserializer.DeserializeType(_l_serdeInfo);
+        var typeDeserialize = deserializer.ReadType(_l_serdeInfo);
         int _l_index_;
         while ((_l_index_ = typeDeserialize.TryReadIndex(_l_serdeInfo, out var _l_errorName)) != IDeserializeType.EndOfType)
         {

--- a/test/Serde.Generation.Test/test_output/MemberFormatTests.EnumValues/S.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/MemberFormatTests.EnumValues/S.IDeserialize.verified.cs
@@ -13,7 +13,7 @@ partial struct S : Serde.IDeserialize<S>
         var _l_serdeInfo = global::Serde.SerdeInfoProvider.GetInfo<S>();
         var typeDeserialize = deserializer.ReadType(_l_serdeInfo);
         int _l_index_;
-        while ((_l_index_ = typeDeserialize.TryReadIndex(_l_serdeInfo, out var _l_errorName)) != IDeserializeType.EndOfType)
+        while ((_l_index_ = typeDeserialize.TryReadIndex(_l_serdeInfo, out _)) != IDeserializeType.EndOfType)
         {
             switch (_l_index_)
             {

--- a/test/Serde.Generation.Test/test_output/MemberFormatTests.EnumValues/S2.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/MemberFormatTests.EnumValues/S2.IDeserialize.verified.cs
@@ -11,7 +11,7 @@ partial struct S2 : Serde.IDeserialize<S2>
         ColorEnum _l_e = default !;
         byte _r_assignedValid = 0;
         var _l_serdeInfo = global::Serde.SerdeInfoProvider.GetInfo<S2>();
-        var typeDeserialize = deserializer.DeserializeType(_l_serdeInfo);
+        var typeDeserialize = deserializer.ReadType(_l_serdeInfo);
         int _l_index_;
         while ((_l_index_ = typeDeserialize.TryReadIndex(_l_serdeInfo, out var _l_errorName)) != IDeserializeType.EndOfType)
         {

--- a/test/Serde.Generation.Test/test_output/MemberFormatTests.EnumValues/S2.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/MemberFormatTests.EnumValues/S2.IDeserialize.verified.cs
@@ -13,7 +13,7 @@ partial struct S2 : Serde.IDeserialize<S2>
         var _l_serdeInfo = global::Serde.SerdeInfoProvider.GetInfo<S2>();
         var typeDeserialize = deserializer.ReadType(_l_serdeInfo);
         int _l_index_;
-        while ((_l_index_ = typeDeserialize.TryReadIndex(_l_serdeInfo, out var _l_errorName)) != IDeserializeType.EndOfType)
+        while ((_l_index_ = typeDeserialize.TryReadIndex(_l_serdeInfo, out _)) != IDeserializeType.EndOfType)
         {
             switch (_l_index_)
             {

--- a/test/Serde.Generation.Test/test_output/MemberFormatTests.KebabCase/S.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/MemberFormatTests.KebabCase/S.IDeserialize.verified.cs
@@ -12,7 +12,7 @@ partial struct S : Serde.IDeserialize<S>
         int _l_twoword = default !;
         byte _r_assignedValid = 0;
         var _l_serdeInfo = global::Serde.SerdeInfoProvider.GetInfo<S>();
-        var typeDeserialize = deserializer.DeserializeType(_l_serdeInfo);
+        var typeDeserialize = deserializer.ReadType(_l_serdeInfo);
         int _l_index_;
         while ((_l_index_ = typeDeserialize.TryReadIndex(_l_serdeInfo, out var _l_errorName)) != IDeserializeType.EndOfType)
         {

--- a/test/Serde.Generation.Test/test_output/MemberFormatTests.KebabCase/S.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/MemberFormatTests.KebabCase/S.IDeserialize.verified.cs
@@ -14,16 +14,16 @@ partial struct S : Serde.IDeserialize<S>
         var _l_serdeInfo = global::Serde.SerdeInfoProvider.GetInfo<S>();
         var typeDeserialize = deserializer.ReadType(_l_serdeInfo);
         int _l_index_;
-        while ((_l_index_ = typeDeserialize.TryReadIndex(_l_serdeInfo, out var _l_errorName)) != IDeserializeType.EndOfType)
+        while ((_l_index_ = typeDeserialize.TryReadIndex(_l_serdeInfo, out _)) != IDeserializeType.EndOfType)
         {
             switch (_l_index_)
             {
                 case 0:
-                    _l_one = typeDeserialize.ReadValue<int, global::Serde.Int32Wrap>(_l_index_);
+                    _l_one = typeDeserialize.ReadI32(_l_index_);
                     _r_assignedValid |= ((byte)1) << 0;
                     break;
                 case 1:
-                    _l_twoword = typeDeserialize.ReadValue<int, global::Serde.Int32Wrap>(_l_index_);
+                    _l_twoword = typeDeserialize.ReadI32(_l_index_);
                     _r_assignedValid |= ((byte)1) << 1;
                     break;
                 case Serde.IDeserializeType.IndexNotFound:

--- a/test/Serde.Generation.Test/test_output/SerializeTests.NestedExplicitSerializeWrapper/OPTSWrap.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/SerializeTests.NestedExplicitSerializeWrapper/OPTSWrap.IDeserialize.verified.cs
@@ -14,7 +14,7 @@ partial record struct OPTSWrap : Serde.IDeserialize<System.Runtime.InteropServic
         int _l_grfmode = default !;
         byte _r_assignedValid = 0;
         var _l_serdeInfo = global::Serde.SerdeInfoProvider.GetInfo<OPTSWrap>();
-        var typeDeserialize = deserializer.DeserializeType(_l_serdeInfo);
+        var typeDeserialize = deserializer.ReadType(_l_serdeInfo);
         int _l_index_;
         while ((_l_index_ = typeDeserialize.TryReadIndex(_l_serdeInfo, out var _l_errorName)) != IDeserializeType.EndOfType)
         {

--- a/test/Serde.Generation.Test/test_output/SerializeTests.NestedExplicitSerializeWrapper/OPTSWrap.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/SerializeTests.NestedExplicitSerializeWrapper/OPTSWrap.IDeserialize.verified.cs
@@ -16,24 +16,24 @@ partial record struct OPTSWrap : Serde.IDeserialize<System.Runtime.InteropServic
         var _l_serdeInfo = global::Serde.SerdeInfoProvider.GetInfo<OPTSWrap>();
         var typeDeserialize = deserializer.ReadType(_l_serdeInfo);
         int _l_index_;
-        while ((_l_index_ = typeDeserialize.TryReadIndex(_l_serdeInfo, out var _l_errorName)) != IDeserializeType.EndOfType)
+        while ((_l_index_ = typeDeserialize.TryReadIndex(_l_serdeInfo, out _)) != IDeserializeType.EndOfType)
         {
             switch (_l_index_)
             {
                 case 0:
-                    _l_cbstruct = typeDeserialize.ReadValue<int, global::Serde.Int32Wrap>(_l_index_);
+                    _l_cbstruct = typeDeserialize.ReadI32(_l_index_);
                     _r_assignedValid |= ((byte)1) << 0;
                     break;
                 case 1:
-                    _l_dwtickcountdeadline = typeDeserialize.ReadValue<int, global::Serde.Int32Wrap>(_l_index_);
+                    _l_dwtickcountdeadline = typeDeserialize.ReadI32(_l_index_);
                     _r_assignedValid |= ((byte)1) << 1;
                     break;
                 case 2:
-                    _l_grfflags = typeDeserialize.ReadValue<int, global::Serde.Int32Wrap>(_l_index_);
+                    _l_grfflags = typeDeserialize.ReadI32(_l_index_);
                     _r_assignedValid |= ((byte)1) << 2;
                     break;
                 case 3:
-                    _l_grfmode = typeDeserialize.ReadValue<int, global::Serde.Int32Wrap>(_l_index_);
+                    _l_grfmode = typeDeserialize.ReadI32(_l_index_);
                     _r_assignedValid |= ((byte)1) << 3;
                     break;
                 case Serde.IDeserializeType.IndexNotFound:

--- a/test/Serde.Generation.Test/test_output/SerializeTests.NestedExplicitSerializeWrapper/S.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/SerializeTests.NestedExplicitSerializeWrapper/S.IDeserialize.verified.cs
@@ -11,7 +11,7 @@ partial struct S : Serde.IDeserialize<S>
         System.Collections.Immutable.ImmutableArray<System.Runtime.InteropServices.ComTypes.BIND_OPTS> _l_opts = default !;
         byte _r_assignedValid = 0;
         var _l_serdeInfo = global::Serde.SerdeInfoProvider.GetInfo<S>();
-        var typeDeserialize = deserializer.DeserializeType(_l_serdeInfo);
+        var typeDeserialize = deserializer.ReadType(_l_serdeInfo);
         int _l_index_;
         while ((_l_index_ = typeDeserialize.TryReadIndex(_l_serdeInfo, out var _l_errorName)) != IDeserializeType.EndOfType)
         {

--- a/test/Serde.Generation.Test/test_output/SerializeTests.NestedExplicitSerializeWrapper/S.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/SerializeTests.NestedExplicitSerializeWrapper/S.IDeserialize.verified.cs
@@ -13,7 +13,7 @@ partial struct S : Serde.IDeserialize<S>
         var _l_serdeInfo = global::Serde.SerdeInfoProvider.GetInfo<S>();
         var typeDeserialize = deserializer.ReadType(_l_serdeInfo);
         int _l_index_;
-        while ((_l_index_ = typeDeserialize.TryReadIndex(_l_serdeInfo, out var _l_errorName)) != IDeserializeType.EndOfType)
+        while ((_l_index_ = typeDeserialize.TryReadIndex(_l_serdeInfo, out _)) != IDeserializeType.EndOfType)
         {
             switch (_l_index_)
             {

--- a/test/Serde.Generation.Test/test_output/WrapperTests.ExplicitInvalidGenericWrapper/Container.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/WrapperTests.ExplicitInvalidGenericWrapper/Container.IDeserialize.verified.cs
@@ -11,7 +11,7 @@ partial record Container : Serde.IDeserialize<Container>
         Original? _l_sdkdir = default !;
         byte _r_assignedValid = 0;
         var _l_serdeInfo = global::Serde.SerdeInfoProvider.GetInfo<Container>();
-        var typeDeserialize = deserializer.DeserializeType(_l_serdeInfo);
+        var typeDeserialize = deserializer.ReadType(_l_serdeInfo);
         int _l_index_;
         while ((_l_index_ = typeDeserialize.TryReadIndex(_l_serdeInfo, out var _l_errorName)) != IDeserializeType.EndOfType)
         {

--- a/test/Serde.Generation.Test/test_output/WrapperTests.ExplicitInvalidGenericWrapper/Container.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/WrapperTests.ExplicitInvalidGenericWrapper/Container.IDeserialize.verified.cs
@@ -13,7 +13,7 @@ partial record Container : Serde.IDeserialize<Container>
         var _l_serdeInfo = global::Serde.SerdeInfoProvider.GetInfo<Container>();
         var typeDeserialize = deserializer.ReadType(_l_serdeInfo);
         int _l_index_;
-        while ((_l_index_ = typeDeserialize.TryReadIndex(_l_serdeInfo, out var _l_errorName)) != IDeserializeType.EndOfType)
+        while ((_l_index_ = typeDeserialize.TryReadIndex(_l_serdeInfo, out _)) != IDeserializeType.EndOfType)
         {
             switch (_l_index_)
             {

--- a/test/Serde.Generation.Test/test_output/WrapperTests.ExplicitInvalidGenericWrapper/Original.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/WrapperTests.ExplicitInvalidGenericWrapper/Original.IDeserialize.verified.cs
@@ -13,12 +13,12 @@ partial record struct Original : Serde.IDeserialize<Original>
         var _l_serdeInfo = global::Serde.SerdeInfoProvider.GetInfo<Original>();
         var typeDeserialize = deserializer.ReadType(_l_serdeInfo);
         int _l_index_;
-        while ((_l_index_ = typeDeserialize.TryReadIndex(_l_serdeInfo, out var _l_errorName)) != IDeserializeType.EndOfType)
+        while ((_l_index_ = typeDeserialize.TryReadIndex(_l_serdeInfo, out _)) != IDeserializeType.EndOfType)
         {
             switch (_l_index_)
             {
                 case 0:
-                    _l_name = typeDeserialize.ReadValue<string, global::Serde.StringWrap>(_l_index_);
+                    _l_name = typeDeserialize.ReadString(_l_index_);
                     _r_assignedValid |= ((byte)1) << 0;
                     break;
                 case Serde.IDeserializeType.IndexNotFound:

--- a/test/Serde.Generation.Test/test_output/WrapperTests.ExplicitInvalidGenericWrapper/Original.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/WrapperTests.ExplicitInvalidGenericWrapper/Original.IDeserialize.verified.cs
@@ -11,7 +11,7 @@ partial record struct Original : Serde.IDeserialize<Original>
         string _l_name = default !;
         byte _r_assignedValid = 0;
         var _l_serdeInfo = global::Serde.SerdeInfoProvider.GetInfo<Original>();
-        var typeDeserialize = deserializer.DeserializeType(_l_serdeInfo);
+        var typeDeserialize = deserializer.ReadType(_l_serdeInfo);
         int _l_index_;
         while ((_l_index_ = typeDeserialize.TryReadIndex(_l_serdeInfo, out var _l_errorName)) != IDeserializeType.EndOfType)
         {

--- a/test/Serde.Generation.Test/test_output/WrapperTests.ExplicitNullableProxy/Container.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/WrapperTests.ExplicitNullableProxy/Container.IDeserialize.verified.cs
@@ -11,7 +11,7 @@ partial record Container : Serde.IDeserialize<Container>
         Original? _l_sdkdir = default !;
         byte _r_assignedValid = 0;
         var _l_serdeInfo = global::Serde.SerdeInfoProvider.GetInfo<Container>();
-        var typeDeserialize = deserializer.DeserializeType(_l_serdeInfo);
+        var typeDeserialize = deserializer.ReadType(_l_serdeInfo);
         int _l_index_;
         while ((_l_index_ = typeDeserialize.TryReadIndex(_l_serdeInfo, out var _l_errorName)) != IDeserializeType.EndOfType)
         {

--- a/test/Serde.Generation.Test/test_output/WrapperTests.ExplicitNullableProxy/Container.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/WrapperTests.ExplicitNullableProxy/Container.IDeserialize.verified.cs
@@ -13,7 +13,7 @@ partial record Container : Serde.IDeserialize<Container>
         var _l_serdeInfo = global::Serde.SerdeInfoProvider.GetInfo<Container>();
         var typeDeserialize = deserializer.ReadType(_l_serdeInfo);
         int _l_index_;
-        while ((_l_index_ = typeDeserialize.TryReadIndex(_l_serdeInfo, out var _l_errorName)) != IDeserializeType.EndOfType)
+        while ((_l_index_ = typeDeserialize.TryReadIndex(_l_serdeInfo, out _)) != IDeserializeType.EndOfType)
         {
             switch (_l_index_)
             {

--- a/test/Serde.Generation.Test/test_output/WrapperTests.ExplicitNullableProxy/Original.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/WrapperTests.ExplicitNullableProxy/Original.IDeserialize.verified.cs
@@ -13,12 +13,12 @@ partial record struct Original : Serde.IDeserialize<Original>
         var _l_serdeInfo = global::Serde.SerdeInfoProvider.GetInfo<Original>();
         var typeDeserialize = deserializer.ReadType(_l_serdeInfo);
         int _l_index_;
-        while ((_l_index_ = typeDeserialize.TryReadIndex(_l_serdeInfo, out var _l_errorName)) != IDeserializeType.EndOfType)
+        while ((_l_index_ = typeDeserialize.TryReadIndex(_l_serdeInfo, out _)) != IDeserializeType.EndOfType)
         {
             switch (_l_index_)
             {
                 case 0:
-                    _l_name = typeDeserialize.ReadValue<string, global::Serde.StringWrap>(_l_index_);
+                    _l_name = typeDeserialize.ReadString(_l_index_);
                     _r_assignedValid |= ((byte)1) << 0;
                     break;
                 case Serde.IDeserializeType.IndexNotFound:

--- a/test/Serde.Generation.Test/test_output/WrapperTests.ExplicitNullableProxy/Original.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/WrapperTests.ExplicitNullableProxy/Original.IDeserialize.verified.cs
@@ -11,7 +11,7 @@ partial record struct Original : Serde.IDeserialize<Original>
         string _l_name = default !;
         byte _r_assignedValid = 0;
         var _l_serdeInfo = global::Serde.SerdeInfoProvider.GetInfo<Original>();
-        var typeDeserialize = deserializer.DeserializeType(_l_serdeInfo);
+        var typeDeserialize = deserializer.ReadType(_l_serdeInfo);
         int _l_index_;
         while ((_l_index_ = typeDeserialize.TryReadIndex(_l_serdeInfo, out var _l_errorName)) != IDeserializeType.EndOfType)
         {

--- a/test/Serde.Generation.Test/test_output/WrapperTests.GenerateSerdeWrap/OPTSWrap.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/WrapperTests.GenerateSerdeWrap/OPTSWrap.IDeserialize.verified.cs
@@ -14,7 +14,7 @@ partial record struct OPTSWrap : Serde.IDeserialize<System.Runtime.InteropServic
         int _l_grfmode = default !;
         byte _r_assignedValid = 0;
         var _l_serdeInfo = global::Serde.SerdeInfoProvider.GetInfo<OPTSWrap>();
-        var typeDeserialize = deserializer.DeserializeType(_l_serdeInfo);
+        var typeDeserialize = deserializer.ReadType(_l_serdeInfo);
         int _l_index_;
         while ((_l_index_ = typeDeserialize.TryReadIndex(_l_serdeInfo, out var _l_errorName)) != IDeserializeType.EndOfType)
         {

--- a/test/Serde.Generation.Test/test_output/WrapperTests.GenerateSerdeWrap/OPTSWrap.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/WrapperTests.GenerateSerdeWrap/OPTSWrap.IDeserialize.verified.cs
@@ -16,24 +16,24 @@ partial record struct OPTSWrap : Serde.IDeserialize<System.Runtime.InteropServic
         var _l_serdeInfo = global::Serde.SerdeInfoProvider.GetInfo<OPTSWrap>();
         var typeDeserialize = deserializer.ReadType(_l_serdeInfo);
         int _l_index_;
-        while ((_l_index_ = typeDeserialize.TryReadIndex(_l_serdeInfo, out var _l_errorName)) != IDeserializeType.EndOfType)
+        while ((_l_index_ = typeDeserialize.TryReadIndex(_l_serdeInfo, out _)) != IDeserializeType.EndOfType)
         {
             switch (_l_index_)
             {
                 case 0:
-                    _l_cbstruct = typeDeserialize.ReadValue<int, global::Serde.Int32Wrap>(_l_index_);
+                    _l_cbstruct = typeDeserialize.ReadI32(_l_index_);
                     _r_assignedValid |= ((byte)1) << 0;
                     break;
                 case 1:
-                    _l_dwtickcountdeadline = typeDeserialize.ReadValue<int, global::Serde.Int32Wrap>(_l_index_);
+                    _l_dwtickcountdeadline = typeDeserialize.ReadI32(_l_index_);
                     _r_assignedValid |= ((byte)1) << 1;
                     break;
                 case 2:
-                    _l_grfflags = typeDeserialize.ReadValue<int, global::Serde.Int32Wrap>(_l_index_);
+                    _l_grfflags = typeDeserialize.ReadI32(_l_index_);
                     _r_assignedValid |= ((byte)1) << 2;
                     break;
                 case 3:
-                    _l_grfmode = typeDeserialize.ReadValue<int, global::Serde.Int32Wrap>(_l_index_);
+                    _l_grfmode = typeDeserialize.ReadI32(_l_index_);
                     _r_assignedValid |= ((byte)1) << 3;
                     break;
                 case Serde.IDeserializeType.IndexNotFound:

--- a/test/Serde.Generation.Test/test_output/WrapperTests.ImmutableArrayEnumDeserialize/Test.ChannelList.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/WrapperTests.ImmutableArrayEnumDeserialize/Test.ChannelList.IDeserialize.verified.cs
@@ -13,7 +13,7 @@ namespace Test
             System.Collections.Immutable.ImmutableArray<Test.Channel> _l_channels = default !;
             byte _r_assignedValid = 0;
             var _l_serdeInfo = global::Serde.SerdeInfoProvider.GetInfo<ChannelList>();
-            var typeDeserialize = deserializer.DeserializeType(_l_serdeInfo);
+            var typeDeserialize = deserializer.ReadType(_l_serdeInfo);
             int _l_index_;
             while ((_l_index_ = typeDeserialize.TryReadIndex(_l_serdeInfo, out var _l_errorName)) != IDeserializeType.EndOfType)
             {

--- a/test/Serde.Generation.Test/test_output/WrapperTests.ImmutableArrayEnumDeserialize/Test.ChannelList.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/WrapperTests.ImmutableArrayEnumDeserialize/Test.ChannelList.IDeserialize.verified.cs
@@ -15,7 +15,7 @@ namespace Test
             var _l_serdeInfo = global::Serde.SerdeInfoProvider.GetInfo<ChannelList>();
             var typeDeserialize = deserializer.ReadType(_l_serdeInfo);
             int _l_index_;
-            while ((_l_index_ = typeDeserialize.TryReadIndex(_l_serdeInfo, out var _l_errorName)) != IDeserializeType.EndOfType)
+            while ((_l_index_ = typeDeserialize.TryReadIndex(_l_serdeInfo, out _)) != IDeserializeType.EndOfType)
             {
                 switch (_l_index_)
                 {

--- a/test/Serde.Generation.Test/test_output/WrapperTests.ImmutableArrayEnumDeserialize/Test.ChannelWrap.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/WrapperTests.ImmutableArrayEnumDeserialize/Test.ChannelWrap.IDeserialize.verified.cs
@@ -11,7 +11,7 @@ namespace Test
         static Test.Channel IDeserialize<Test.Channel>.Deserialize(IDeserializer deserializer)
         {
             var serdeInfo = global::Serde.SerdeInfoProvider.GetInfo<Test.ChannelWrap>();
-            var de = deserializer.DeserializeType(serdeInfo);
+            var de = deserializer.ReadType(serdeInfo);
             int index;
             if ((index = de.TryReadIndex(serdeInfo, out var errorName)) == IDeserializeType.IndexNotFound)
             {

--- a/test/Serde.Generation.Test/test_output/WrapperTests.NestedDeserializeWrap/C.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/WrapperTests.NestedDeserializeWrap/C.IDeserialize.verified.cs
@@ -13,7 +13,7 @@ partial class C : Serde.IDeserialize<C>
         var _l_serdeInfo = global::Serde.SerdeInfoProvider.GetInfo<C>();
         var typeDeserialize = deserializer.ReadType(_l_serdeInfo);
         int _l_index_;
-        while ((_l_index_ = typeDeserialize.TryReadIndex(_l_serdeInfo, out var _l_errorName)) != IDeserializeType.EndOfType)
+        while ((_l_index_ = typeDeserialize.TryReadIndex(_l_serdeInfo, out _)) != IDeserializeType.EndOfType)
         {
             switch (_l_index_)
             {

--- a/test/Serde.Generation.Test/test_output/WrapperTests.NestedDeserializeWrap/C.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/WrapperTests.NestedDeserializeWrap/C.IDeserialize.verified.cs
@@ -11,7 +11,7 @@ partial class C : Serde.IDeserialize<C>
         System.Runtime.InteropServices.ComTypes.BIND_OPTS _l_s = default !;
         byte _r_assignedValid = 0;
         var _l_serdeInfo = global::Serde.SerdeInfoProvider.GetInfo<C>();
-        var typeDeserialize = deserializer.DeserializeType(_l_serdeInfo);
+        var typeDeserialize = deserializer.ReadType(_l_serdeInfo);
         int _l_index_;
         while ((_l_index_ = typeDeserialize.TryReadIndex(_l_serdeInfo, out var _l_errorName)) != IDeserializeType.EndOfType)
         {

--- a/test/Serde.Generation.Test/test_output/WrapperTests.NestedDeserializeWrap/OPTSWrap.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/WrapperTests.NestedDeserializeWrap/OPTSWrap.IDeserialize.verified.cs
@@ -14,7 +14,7 @@ partial record struct OPTSWrap : Serde.IDeserialize<System.Runtime.InteropServic
         int _l_grfmode = default !;
         byte _r_assignedValid = 0;
         var _l_serdeInfo = global::Serde.SerdeInfoProvider.GetInfo<OPTSWrap>();
-        var typeDeserialize = deserializer.DeserializeType(_l_serdeInfo);
+        var typeDeserialize = deserializer.ReadType(_l_serdeInfo);
         int _l_index_;
         while ((_l_index_ = typeDeserialize.TryReadIndex(_l_serdeInfo, out var _l_errorName)) != IDeserializeType.EndOfType)
         {

--- a/test/Serde.Generation.Test/test_output/WrapperTests.NestedDeserializeWrap/OPTSWrap.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/WrapperTests.NestedDeserializeWrap/OPTSWrap.IDeserialize.verified.cs
@@ -16,24 +16,24 @@ partial record struct OPTSWrap : Serde.IDeserialize<System.Runtime.InteropServic
         var _l_serdeInfo = global::Serde.SerdeInfoProvider.GetInfo<OPTSWrap>();
         var typeDeserialize = deserializer.ReadType(_l_serdeInfo);
         int _l_index_;
-        while ((_l_index_ = typeDeserialize.TryReadIndex(_l_serdeInfo, out var _l_errorName)) != IDeserializeType.EndOfType)
+        while ((_l_index_ = typeDeserialize.TryReadIndex(_l_serdeInfo, out _)) != IDeserializeType.EndOfType)
         {
             switch (_l_index_)
             {
                 case 0:
-                    _l_cbstruct = typeDeserialize.ReadValue<int, global::Serde.Int32Wrap>(_l_index_);
+                    _l_cbstruct = typeDeserialize.ReadI32(_l_index_);
                     _r_assignedValid |= ((byte)1) << 0;
                     break;
                 case 1:
-                    _l_dwtickcountdeadline = typeDeserialize.ReadValue<int, global::Serde.Int32Wrap>(_l_index_);
+                    _l_dwtickcountdeadline = typeDeserialize.ReadI32(_l_index_);
                     _r_assignedValid |= ((byte)1) << 1;
                     break;
                 case 2:
-                    _l_grfflags = typeDeserialize.ReadValue<int, global::Serde.Int32Wrap>(_l_index_);
+                    _l_grfflags = typeDeserialize.ReadI32(_l_index_);
                     _r_assignedValid |= ((byte)1) << 2;
                     break;
                 case 3:
-                    _l_grfmode = typeDeserialize.ReadValue<int, global::Serde.Int32Wrap>(_l_index_);
+                    _l_grfmode = typeDeserialize.ReadI32(_l_index_);
                     _r_assignedValid |= ((byte)1) << 3;
                     break;
                 case Serde.IDeserializeType.IndexNotFound:

--- a/test/Serde.Generation.Test/test_output/WrapperTests.PointWrap/PointWrap.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/WrapperTests.PointWrap/PointWrap.IDeserialize.verified.cs
@@ -12,7 +12,7 @@ partial struct PointWrap : Serde.IDeserialize<Point>
         int _l_y = default !;
         byte _r_assignedValid = 0;
         var _l_serdeInfo = global::Serde.SerdeInfoProvider.GetInfo<PointWrap>();
-        var typeDeserialize = deserializer.DeserializeType(_l_serdeInfo);
+        var typeDeserialize = deserializer.ReadType(_l_serdeInfo);
         int _l_index_;
         while ((_l_index_ = typeDeserialize.TryReadIndex(_l_serdeInfo, out var _l_errorName)) != IDeserializeType.EndOfType)
         {

--- a/test/Serde.Generation.Test/test_output/WrapperTests.PointWrap/PointWrap.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/WrapperTests.PointWrap/PointWrap.IDeserialize.verified.cs
@@ -14,16 +14,16 @@ partial struct PointWrap : Serde.IDeserialize<Point>
         var _l_serdeInfo = global::Serde.SerdeInfoProvider.GetInfo<PointWrap>();
         var typeDeserialize = deserializer.ReadType(_l_serdeInfo);
         int _l_index_;
-        while ((_l_index_ = typeDeserialize.TryReadIndex(_l_serdeInfo, out var _l_errorName)) != IDeserializeType.EndOfType)
+        while ((_l_index_ = typeDeserialize.TryReadIndex(_l_serdeInfo, out _)) != IDeserializeType.EndOfType)
         {
             switch (_l_index_)
             {
                 case 0:
-                    _l_x = typeDeserialize.ReadValue<int, global::Serde.Int32Wrap>(_l_index_);
+                    _l_x = typeDeserialize.ReadI32(_l_index_);
                     _r_assignedValid |= ((byte)1) << 0;
                     break;
                 case 1:
-                    _l_y = typeDeserialize.ReadValue<int, global::Serde.Int32Wrap>(_l_index_);
+                    _l_y = typeDeserialize.ReadI32(_l_index_);
                     _r_assignedValid |= ((byte)1) << 1;
                     break;
                 case Serde.IDeserializeType.IndexNotFound:

--- a/test/Serde.Generation.Test/test_output/WrapperTests.PositionalRecordDeserialize/R.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/WrapperTests.PositionalRecordDeserialize/R.IDeserialize.verified.cs
@@ -14,16 +14,16 @@ partial record R : Serde.IDeserialize<R>
         var _l_serdeInfo = global::Serde.SerdeInfoProvider.GetInfo<R>();
         var typeDeserialize = deserializer.ReadType(_l_serdeInfo);
         int _l_index_;
-        while ((_l_index_ = typeDeserialize.TryReadIndex(_l_serdeInfo, out var _l_errorName)) != IDeserializeType.EndOfType)
+        while ((_l_index_ = typeDeserialize.TryReadIndex(_l_serdeInfo, out _)) != IDeserializeType.EndOfType)
         {
             switch (_l_index_)
             {
                 case 0:
-                    _l_a = typeDeserialize.ReadValue<int, global::Serde.Int32Wrap>(_l_index_);
+                    _l_a = typeDeserialize.ReadI32(_l_index_);
                     _r_assignedValid |= ((byte)1) << 0;
                     break;
                 case 1:
-                    _l_b = typeDeserialize.ReadValue<string, global::Serde.StringWrap>(_l_index_);
+                    _l_b = typeDeserialize.ReadString(_l_index_);
                     _r_assignedValid |= ((byte)1) << 1;
                     break;
                 case Serde.IDeserializeType.IndexNotFound:

--- a/test/Serde.Generation.Test/test_output/WrapperTests.PositionalRecordDeserialize/R.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/WrapperTests.PositionalRecordDeserialize/R.IDeserialize.verified.cs
@@ -12,7 +12,7 @@ partial record R : Serde.IDeserialize<R>
         string _l_b = default !;
         byte _r_assignedValid = 0;
         var _l_serdeInfo = global::Serde.SerdeInfoProvider.GetInfo<R>();
-        var typeDeserialize = deserializer.DeserializeType(_l_serdeInfo);
+        var typeDeserialize = deserializer.ReadType(_l_serdeInfo);
         int _l_index_;
         while ((_l_index_ = typeDeserialize.TryReadIndex(_l_serdeInfo, out var _l_errorName)) != IDeserializeType.EndOfType)
         {

--- a/test/Serde.Generation.Test/test_output/WrapperTests.RecursiveType/Test.Parent.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/WrapperTests.RecursiveType/Test.Parent.IDeserialize.verified.cs
@@ -13,7 +13,7 @@ namespace Test
             Recursive _l_r = default !;
             byte _r_assignedValid = 0;
             var _l_serdeInfo = global::Serde.SerdeInfoProvider.GetInfo<Parent>();
-            var typeDeserialize = deserializer.DeserializeType(_l_serdeInfo);
+            var typeDeserialize = deserializer.ReadType(_l_serdeInfo);
             int _l_index_;
             while ((_l_index_ = typeDeserialize.TryReadIndex(_l_serdeInfo, out var _l_errorName)) != IDeserializeType.EndOfType)
             {

--- a/test/Serde.Generation.Test/test_output/WrapperTests.RecursiveType/Test.Parent.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/WrapperTests.RecursiveType/Test.Parent.IDeserialize.verified.cs
@@ -15,7 +15,7 @@ namespace Test
             var _l_serdeInfo = global::Serde.SerdeInfoProvider.GetInfo<Parent>();
             var typeDeserialize = deserializer.ReadType(_l_serdeInfo);
             int _l_index_;
-            while ((_l_index_ = typeDeserialize.TryReadIndex(_l_serdeInfo, out var _l_errorName)) != IDeserializeType.EndOfType)
+            while ((_l_index_ = typeDeserialize.TryReadIndex(_l_serdeInfo, out _)) != IDeserializeType.EndOfType)
             {
                 switch (_l_index_)
                 {

--- a/test/Serde.Generation.Test/test_output/WrapperTests.RecursiveType/Test.RecursiveWrap.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/WrapperTests.RecursiveType/Test.RecursiveWrap.IDeserialize.verified.cs
@@ -15,7 +15,7 @@ namespace Test
             var _l_serdeInfo = global::Serde.SerdeInfoProvider.GetInfo<RecursiveWrap>();
             var typeDeserialize = deserializer.ReadType(_l_serdeInfo);
             int _l_index_;
-            while ((_l_index_ = typeDeserialize.TryReadIndex(_l_serdeInfo, out var _l_errorName)) != IDeserializeType.EndOfType)
+            while ((_l_index_ = typeDeserialize.TryReadIndex(_l_serdeInfo, out _)) != IDeserializeType.EndOfType)
             {
                 switch (_l_index_)
                 {

--- a/test/Serde.Generation.Test/test_output/WrapperTests.RecursiveType/Test.RecursiveWrap.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/WrapperTests.RecursiveType/Test.RecursiveWrap.IDeserialize.verified.cs
@@ -13,7 +13,7 @@ namespace Test
             Recursive? _l_next = default !;
             byte _r_assignedValid = 0;
             var _l_serdeInfo = global::Serde.SerdeInfoProvider.GetInfo<RecursiveWrap>();
-            var typeDeserialize = deserializer.DeserializeType(_l_serdeInfo);
+            var typeDeserialize = deserializer.ReadType(_l_serdeInfo);
             int _l_index_;
             while ((_l_index_ = typeDeserialize.TryReadIndex(_l_serdeInfo, out var _l_errorName)) != IDeserializeType.EndOfType)
             {

--- a/test/Serde.Test/CustomImplTests.cs
+++ b/test/Serde.Test/CustomImplTests.cs
@@ -24,7 +24,7 @@ public sealed partial class CustomImplTests
         static RgbWithFieldMap IDeserialize<RgbWithFieldMap>.Deserialize(IDeserializer deserializer)
         {
             var fieldMap = SerdeInfo;
-            var deType = deserializer.DeserializeType(fieldMap);
+            var deType = deserializer.ReadType(fieldMap);
             int red = default;
             int green = default;
             int blue = default;

--- a/test/Serde.Test/GenericWrapperTests.cs
+++ b/test/Serde.Test/GenericWrapperTests.cs
@@ -112,7 +112,7 @@ public sealed partial class GenericWrapperTests
             {
                 var serdeInfo = s_typeInfo;
                 ImmutableArray<T>.Builder builder;
-                var d = deserializer.DeserializeCollection(serdeInfo);
+                var d = deserializer.ReadCollection(serdeInfo);
                 if (d.SizeOpt is int size)
                 {
                     builder = ImmutableArray.CreateBuilder<T>(size);
@@ -159,7 +159,7 @@ public sealed partial class GenericWrapperTests
             {
                 ImmutableArray<T>.Builder builder;
                 var typeInfo = s_typeInfo;
-                var d = deserializer.DeserializeCollection(typeInfo);
+                var d = deserializer.ReadCollection(typeInfo);
                 if (d.SizeOpt is int size)
                 {
                     builder = ImmutableArray.CreateBuilder<T>(size);

--- a/test/Serde.Test/JsonDeserializeTests.cs
+++ b/test/Serde.Test/JsonDeserializeTests.cs
@@ -344,7 +344,7 @@ namespace Serde.Test
             static ColorEnum IDeserialize<ColorEnum>.Deserialize(IDeserializer deserializer)
             {
                 var typeInfo = SerdeInfo;
-                var de = deserializer.DeserializeType(typeInfo);
+                var de = deserializer.ReadType(typeInfo);
                 int index;
                 if ((index = de.TryReadIndex(typeInfo, out var errorName)) == IDeserializeType.IndexNotFound)
                 {

--- a/test/Serde.Test/JsonSerializerTests.cs
+++ b/test/Serde.Test/JsonSerializerTests.cs
@@ -120,7 +120,7 @@ namespace Serde.Test
                 foreach (var (k,v) in value._d)
                 {
                     sd.SerializeElement(k.ToString(), new StringWrap());
-                    sd.SerializeElement(v, new Int32Wrap(v));
+                    sd.SerializeElement(v, new Int32Wrap());
                 }
                 sd.End(typeInfo);
             }

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Json.Test.InvalidJsonTests.ClassWithDictionaryOfIntArray.IDeserialize.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Json.Test.InvalidJsonTests.ClassWithDictionaryOfIntArray.IDeserialize.cs
@@ -14,7 +14,7 @@ namespace Serde.Json.Test
                 System.Collections.Generic.Dictionary<string, int[]> _l_obj = default !;
                 byte _r_assignedValid = 0;
                 var _l_serdeInfo = global::Serde.SerdeInfoProvider.GetInfo<ClassWithDictionaryOfIntArray>();
-                var typeDeserialize = deserializer.DeserializeType(_l_serdeInfo);
+                var typeDeserialize = deserializer.ReadType(_l_serdeInfo);
                 int _l_index_;
                 while ((_l_index_ = typeDeserialize.TryReadIndex(_l_serdeInfo, out var _l_errorName)) != IDeserializeType.EndOfType)
                 {

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Json.Test.InvalidJsonTests.ClassWithDictionaryOfIntArray.IDeserialize.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Json.Test.InvalidJsonTests.ClassWithDictionaryOfIntArray.IDeserialize.cs
@@ -16,7 +16,7 @@ namespace Serde.Json.Test
                 var _l_serdeInfo = global::Serde.SerdeInfoProvider.GetInfo<ClassWithDictionaryOfIntArray>();
                 var typeDeserialize = deserializer.ReadType(_l_serdeInfo);
                 int _l_index_;
-                while ((_l_index_ = typeDeserialize.TryReadIndex(_l_serdeInfo, out var _l_errorName)) != IDeserializeType.EndOfType)
+                while ((_l_index_ = typeDeserialize.TryReadIndex(_l_serdeInfo, out _)) != IDeserializeType.EndOfType)
                 {
                     switch (_l_index_)
                     {

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Json.Test.InvalidJsonTests.ClassWithDictionaryOfPoco.IDeserialize.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Json.Test.InvalidJsonTests.ClassWithDictionaryOfPoco.IDeserialize.cs
@@ -16,7 +16,7 @@ namespace Serde.Json.Test
                 var _l_serdeInfo = global::Serde.SerdeInfoProvider.GetInfo<ClassWithDictionaryOfPoco>();
                 var typeDeserialize = deserializer.ReadType(_l_serdeInfo);
                 int _l_index_;
-                while ((_l_index_ = typeDeserialize.TryReadIndex(_l_serdeInfo, out var _l_errorName)) != IDeserializeType.EndOfType)
+                while ((_l_index_ = typeDeserialize.TryReadIndex(_l_serdeInfo, out _)) != IDeserializeType.EndOfType)
                 {
                     switch (_l_index_)
                     {

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Json.Test.InvalidJsonTests.ClassWithDictionaryOfPoco.IDeserialize.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Json.Test.InvalidJsonTests.ClassWithDictionaryOfPoco.IDeserialize.cs
@@ -14,7 +14,7 @@ namespace Serde.Json.Test
                 System.Collections.Generic.Dictionary<string, Serde.Json.Test.Poco> _l_obj = default !;
                 byte _r_assignedValid = 0;
                 var _l_serdeInfo = global::Serde.SerdeInfoProvider.GetInfo<ClassWithDictionaryOfPoco>();
-                var typeDeserialize = deserializer.DeserializeType(_l_serdeInfo);
+                var typeDeserialize = deserializer.ReadType(_l_serdeInfo);
                 int _l_index_;
                 while ((_l_index_ = typeDeserialize.TryReadIndex(_l_serdeInfo, out var _l_errorName)) != IDeserializeType.EndOfType)
                 {

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Json.Test.InvalidJsonTests.ClassWithDictionaryOfPocoList.IDeserialize.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Json.Test.InvalidJsonTests.ClassWithDictionaryOfPocoList.IDeserialize.cs
@@ -14,7 +14,7 @@ namespace Serde.Json.Test
                 System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<Serde.Json.Test.Poco>> _l_obj = default !;
                 byte _r_assignedValid = 0;
                 var _l_serdeInfo = global::Serde.SerdeInfoProvider.GetInfo<ClassWithDictionaryOfPocoList>();
-                var typeDeserialize = deserializer.DeserializeType(_l_serdeInfo);
+                var typeDeserialize = deserializer.ReadType(_l_serdeInfo);
                 int _l_index_;
                 while ((_l_index_ = typeDeserialize.TryReadIndex(_l_serdeInfo, out var _l_errorName)) != IDeserializeType.EndOfType)
                 {

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Json.Test.InvalidJsonTests.ClassWithDictionaryOfPocoList.IDeserialize.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Json.Test.InvalidJsonTests.ClassWithDictionaryOfPocoList.IDeserialize.cs
@@ -16,7 +16,7 @@ namespace Serde.Json.Test
                 var _l_serdeInfo = global::Serde.SerdeInfoProvider.GetInfo<ClassWithDictionaryOfPocoList>();
                 var typeDeserialize = deserializer.ReadType(_l_serdeInfo);
                 int _l_index_;
-                while ((_l_index_ = typeDeserialize.TryReadIndex(_l_serdeInfo, out var _l_errorName)) != IDeserializeType.EndOfType)
+                while ((_l_index_ = typeDeserialize.TryReadIndex(_l_serdeInfo, out _)) != IDeserializeType.EndOfType)
                 {
                     switch (_l_index_)
                     {

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Json.Test.InvalidJsonTests.ClassWithInt.IDeserialize.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Json.Test.InvalidJsonTests.ClassWithInt.IDeserialize.cs
@@ -14,7 +14,7 @@ namespace Serde.Json.Test
                 int _l_obj = default !;
                 byte _r_assignedValid = 0;
                 var _l_serdeInfo = global::Serde.SerdeInfoProvider.GetInfo<ClassWithInt>();
-                var typeDeserialize = deserializer.DeserializeType(_l_serdeInfo);
+                var typeDeserialize = deserializer.ReadType(_l_serdeInfo);
                 int _l_index_;
                 while ((_l_index_ = typeDeserialize.TryReadIndex(_l_serdeInfo, out var _l_errorName)) != IDeserializeType.EndOfType)
                 {

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Json.Test.InvalidJsonTests.ClassWithInt.IDeserialize.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Json.Test.InvalidJsonTests.ClassWithInt.IDeserialize.cs
@@ -16,12 +16,12 @@ namespace Serde.Json.Test
                 var _l_serdeInfo = global::Serde.SerdeInfoProvider.GetInfo<ClassWithInt>();
                 var typeDeserialize = deserializer.ReadType(_l_serdeInfo);
                 int _l_index_;
-                while ((_l_index_ = typeDeserialize.TryReadIndex(_l_serdeInfo, out var _l_errorName)) != IDeserializeType.EndOfType)
+                while ((_l_index_ = typeDeserialize.TryReadIndex(_l_serdeInfo, out _)) != IDeserializeType.EndOfType)
                 {
                     switch (_l_index_)
                     {
                         case 0:
-                            _l_obj = typeDeserialize.ReadValue<int, global::Serde.Int32Wrap>(_l_index_);
+                            _l_obj = typeDeserialize.ReadI32(_l_index_);
                             _r_assignedValid |= ((byte)1) << 0;
                             break;
                         case Serde.IDeserializeType.IndexNotFound:

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Json.Test.InvalidJsonTests.ClassWithIntArray.IDeserialize.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Json.Test.InvalidJsonTests.ClassWithIntArray.IDeserialize.cs
@@ -14,7 +14,7 @@ namespace Serde.Json.Test
                 int[] _l_obj = default !;
                 byte _r_assignedValid = 0;
                 var _l_serdeInfo = global::Serde.SerdeInfoProvider.GetInfo<ClassWithIntArray>();
-                var typeDeserialize = deserializer.DeserializeType(_l_serdeInfo);
+                var typeDeserialize = deserializer.ReadType(_l_serdeInfo);
                 int _l_index_;
                 while ((_l_index_ = typeDeserialize.TryReadIndex(_l_serdeInfo, out var _l_errorName)) != IDeserializeType.EndOfType)
                 {

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Json.Test.InvalidJsonTests.ClassWithIntArray.IDeserialize.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Json.Test.InvalidJsonTests.ClassWithIntArray.IDeserialize.cs
@@ -16,7 +16,7 @@ namespace Serde.Json.Test
                 var _l_serdeInfo = global::Serde.SerdeInfoProvider.GetInfo<ClassWithIntArray>();
                 var typeDeserialize = deserializer.ReadType(_l_serdeInfo);
                 int _l_index_;
-                while ((_l_index_ = typeDeserialize.TryReadIndex(_l_serdeInfo, out var _l_errorName)) != IDeserializeType.EndOfType)
+                while ((_l_index_ = typeDeserialize.TryReadIndex(_l_serdeInfo, out _)) != IDeserializeType.EndOfType)
                 {
                     switch (_l_index_)
                     {

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Json.Test.InvalidJsonTests.ClassWithIntList.IDeserialize.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Json.Test.InvalidJsonTests.ClassWithIntList.IDeserialize.cs
@@ -16,7 +16,7 @@ namespace Serde.Json.Test
                 var _l_serdeInfo = global::Serde.SerdeInfoProvider.GetInfo<ClassWithIntList>();
                 var typeDeserialize = deserializer.ReadType(_l_serdeInfo);
                 int _l_index_;
-                while ((_l_index_ = typeDeserialize.TryReadIndex(_l_serdeInfo, out var _l_errorName)) != IDeserializeType.EndOfType)
+                while ((_l_index_ = typeDeserialize.TryReadIndex(_l_serdeInfo, out _)) != IDeserializeType.EndOfType)
                 {
                     switch (_l_index_)
                     {

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Json.Test.InvalidJsonTests.ClassWithIntList.IDeserialize.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Json.Test.InvalidJsonTests.ClassWithIntList.IDeserialize.cs
@@ -14,7 +14,7 @@ namespace Serde.Json.Test
                 System.Collections.Generic.List<int> _l_obj = default !;
                 byte _r_assignedValid = 0;
                 var _l_serdeInfo = global::Serde.SerdeInfoProvider.GetInfo<ClassWithIntList>();
-                var typeDeserialize = deserializer.DeserializeType(_l_serdeInfo);
+                var typeDeserialize = deserializer.ReadType(_l_serdeInfo);
                 int _l_index_;
                 while ((_l_index_ = typeDeserialize.TryReadIndex(_l_serdeInfo, out var _l_errorName)) != IDeserializeType.EndOfType)
                 {

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Json.Test.InvalidJsonTests.ClassWithPoco.IDeserialize.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Json.Test.InvalidJsonTests.ClassWithPoco.IDeserialize.cs
@@ -16,7 +16,7 @@ namespace Serde.Json.Test
                 var _l_serdeInfo = global::Serde.SerdeInfoProvider.GetInfo<ClassWithPoco>();
                 var typeDeserialize = deserializer.ReadType(_l_serdeInfo);
                 int _l_index_;
-                while ((_l_index_ = typeDeserialize.TryReadIndex(_l_serdeInfo, out var _l_errorName)) != IDeserializeType.EndOfType)
+                while ((_l_index_ = typeDeserialize.TryReadIndex(_l_serdeInfo, out _)) != IDeserializeType.EndOfType)
                 {
                     switch (_l_index_)
                     {

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Json.Test.InvalidJsonTests.ClassWithPoco.IDeserialize.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Json.Test.InvalidJsonTests.ClassWithPoco.IDeserialize.cs
@@ -14,7 +14,7 @@ namespace Serde.Json.Test
                 Serde.Json.Test.Poco _l_obj = default !;
                 byte _r_assignedValid = 0;
                 var _l_serdeInfo = global::Serde.SerdeInfoProvider.GetInfo<ClassWithPoco>();
-                var typeDeserialize = deserializer.DeserializeType(_l_serdeInfo);
+                var typeDeserialize = deserializer.ReadType(_l_serdeInfo);
                 int _l_index_;
                 while ((_l_index_ = typeDeserialize.TryReadIndex(_l_serdeInfo, out var _l_errorName)) != IDeserializeType.EndOfType)
                 {

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Json.Test.InvalidJsonTests.ClassWithPocoArray.IDeserialize.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Json.Test.InvalidJsonTests.ClassWithPocoArray.IDeserialize.cs
@@ -14,7 +14,7 @@ namespace Serde.Json.Test
                 Serde.Json.Test.Poco[] _l_obj = default !;
                 byte _r_assignedValid = 0;
                 var _l_serdeInfo = global::Serde.SerdeInfoProvider.GetInfo<ClassWithPocoArray>();
-                var typeDeserialize = deserializer.DeserializeType(_l_serdeInfo);
+                var typeDeserialize = deserializer.ReadType(_l_serdeInfo);
                 int _l_index_;
                 while ((_l_index_ = typeDeserialize.TryReadIndex(_l_serdeInfo, out var _l_errorName)) != IDeserializeType.EndOfType)
                 {

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Json.Test.InvalidJsonTests.ClassWithPocoArray.IDeserialize.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Json.Test.InvalidJsonTests.ClassWithPocoArray.IDeserialize.cs
@@ -16,7 +16,7 @@ namespace Serde.Json.Test
                 var _l_serdeInfo = global::Serde.SerdeInfoProvider.GetInfo<ClassWithPocoArray>();
                 var typeDeserialize = deserializer.ReadType(_l_serdeInfo);
                 int _l_index_;
-                while ((_l_index_ = typeDeserialize.TryReadIndex(_l_serdeInfo, out var _l_errorName)) != IDeserializeType.EndOfType)
+                while ((_l_index_ = typeDeserialize.TryReadIndex(_l_serdeInfo, out _)) != IDeserializeType.EndOfType)
                 {
                     switch (_l_index_)
                     {

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Json.Test.InvalidJsonTests.PocoWithParameterizedCtor.IDeserialize.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Json.Test.InvalidJsonTests.PocoWithParameterizedCtor.IDeserialize.cs
@@ -14,7 +14,7 @@ namespace Serde.Json.Test
                 int _l_obj = default !;
                 byte _r_assignedValid = 0;
                 var _l_serdeInfo = global::Serde.SerdeInfoProvider.GetInfo<PocoWithParameterizedCtor>();
-                var typeDeserialize = deserializer.DeserializeType(_l_serdeInfo);
+                var typeDeserialize = deserializer.ReadType(_l_serdeInfo);
                 int _l_index_;
                 while ((_l_index_ = typeDeserialize.TryReadIndex(_l_serdeInfo, out var _l_errorName)) != IDeserializeType.EndOfType)
                 {

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Json.Test.InvalidJsonTests.PocoWithParameterizedCtor.IDeserialize.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Json.Test.InvalidJsonTests.PocoWithParameterizedCtor.IDeserialize.cs
@@ -16,12 +16,12 @@ namespace Serde.Json.Test
                 var _l_serdeInfo = global::Serde.SerdeInfoProvider.GetInfo<PocoWithParameterizedCtor>();
                 var typeDeserialize = deserializer.ReadType(_l_serdeInfo);
                 int _l_index_;
-                while ((_l_index_ = typeDeserialize.TryReadIndex(_l_serdeInfo, out var _l_errorName)) != IDeserializeType.EndOfType)
+                while ((_l_index_ = typeDeserialize.TryReadIndex(_l_serdeInfo, out _)) != IDeserializeType.EndOfType)
                 {
                     switch (_l_index_)
                     {
                         case 0:
-                            _l_obj = typeDeserialize.ReadValue<int, global::Serde.Int32Wrap>(_l_index_);
+                            _l_obj = typeDeserialize.ReadI32(_l_index_);
                             _r_assignedValid |= ((byte)1) << 0;
                             break;
                         case Serde.IDeserializeType.IndexNotFound:

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Json.Test.InvalidJsonTests.SkipClass.IDeserialize.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Json.Test.InvalidJsonTests.SkipClass.IDeserialize.cs
@@ -14,7 +14,7 @@ namespace Serde.Json.Test
                 int _l_c = default !;
                 byte _r_assignedValid = 0;
                 var _l_serdeInfo = global::Serde.SerdeInfoProvider.GetInfo<SkipClass>();
-                var typeDeserialize = deserializer.DeserializeType(_l_serdeInfo);
+                var typeDeserialize = deserializer.ReadType(_l_serdeInfo);
                 int _l_index_;
                 while ((_l_index_ = typeDeserialize.TryReadIndex(_l_serdeInfo, out var _l_errorName)) != IDeserializeType.EndOfType)
                 {

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Json.Test.InvalidJsonTests.SkipClass.IDeserialize.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Json.Test.InvalidJsonTests.SkipClass.IDeserialize.cs
@@ -16,12 +16,12 @@ namespace Serde.Json.Test
                 var _l_serdeInfo = global::Serde.SerdeInfoProvider.GetInfo<SkipClass>();
                 var typeDeserialize = deserializer.ReadType(_l_serdeInfo);
                 int _l_index_;
-                while ((_l_index_ = typeDeserialize.TryReadIndex(_l_serdeInfo, out var _l_errorName)) != IDeserializeType.EndOfType)
+                while ((_l_index_ = typeDeserialize.TryReadIndex(_l_serdeInfo, out _)) != IDeserializeType.EndOfType)
                 {
                     switch (_l_index_)
                     {
                         case 0:
-                            _l_c = typeDeserialize.ReadValue<int, global::Serde.Int32Wrap>(_l_index_);
+                            _l_c = typeDeserialize.ReadI32(_l_index_);
                             _r_assignedValid |= ((byte)1) << 0;
                             break;
                         case Serde.IDeserializeType.IndexNotFound:

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Json.Test.Poco.IDeserialize.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Json.Test.Poco.IDeserialize.cs
@@ -14,12 +14,12 @@ namespace Serde.Json.Test
             var _l_serdeInfo = global::Serde.SerdeInfoProvider.GetInfo<Poco>();
             var typeDeserialize = deserializer.ReadType(_l_serdeInfo);
             int _l_index_;
-            while ((_l_index_ = typeDeserialize.TryReadIndex(_l_serdeInfo, out var _l_errorName)) != IDeserializeType.EndOfType)
+            while ((_l_index_ = typeDeserialize.TryReadIndex(_l_serdeInfo, out _)) != IDeserializeType.EndOfType)
             {
                 switch (_l_index_)
                 {
                     case 0:
-                        _l_id = typeDeserialize.ReadValue<int, global::Serde.Int32Wrap>(_l_index_);
+                        _l_id = typeDeserialize.ReadI32(_l_index_);
                         _r_assignedValid |= ((byte)1) << 0;
                         break;
                     case Serde.IDeserializeType.IndexNotFound:

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Json.Test.Poco.IDeserialize.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Json.Test.Poco.IDeserialize.cs
@@ -12,7 +12,7 @@ namespace Serde.Json.Test
             int _l_id = default !;
             byte _r_assignedValid = 0;
             var _l_serdeInfo = global::Serde.SerdeInfoProvider.GetInfo<Poco>();
-            var typeDeserialize = deserializer.DeserializeType(_l_serdeInfo);
+            var typeDeserialize = deserializer.ReadType(_l_serdeInfo);
             int _l_index_;
             while ((_l_index_ = typeDeserialize.TryReadIndex(_l_serdeInfo, out var _l_errorName)) != IDeserializeType.EndOfType)
             {

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Json.Test.PocoDictionary.IDeserialize.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Json.Test.PocoDictionary.IDeserialize.cs
@@ -12,7 +12,7 @@ namespace Serde.Json.Test
             System.Collections.Generic.Dictionary<string, string> _l_key = default !;
             byte _r_assignedValid = 0;
             var _l_serdeInfo = global::Serde.SerdeInfoProvider.GetInfo<PocoDictionary>();
-            var typeDeserialize = deserializer.DeserializeType(_l_serdeInfo);
+            var typeDeserialize = deserializer.ReadType(_l_serdeInfo);
             int _l_index_;
             while ((_l_index_ = typeDeserialize.TryReadIndex(_l_serdeInfo, out var _l_errorName)) != IDeserializeType.EndOfType)
             {

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Json.Test.PocoDictionary.IDeserialize.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Json.Test.PocoDictionary.IDeserialize.cs
@@ -14,7 +14,7 @@ namespace Serde.Json.Test
             var _l_serdeInfo = global::Serde.SerdeInfoProvider.GetInfo<PocoDictionary>();
             var typeDeserialize = deserializer.ReadType(_l_serdeInfo);
             int _l_index_;
-            while ((_l_index_ = typeDeserialize.TryReadIndex(_l_serdeInfo, out var _l_errorName)) != IDeserializeType.EndOfType)
+            while ((_l_index_ = typeDeserialize.TryReadIndex(_l_serdeInfo, out _)) != IDeserializeType.EndOfType)
             {
                 switch (_l_index_)
                 {

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.AllInOne.ColorEnumWrap.IDeserialize.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.AllInOne.ColorEnumWrap.IDeserialize.cs
@@ -12,7 +12,7 @@ namespace Serde.Test
             static Serde.Test.AllInOne.ColorEnum IDeserialize<Serde.Test.AllInOne.ColorEnum>.Deserialize(IDeserializer deserializer)
             {
                 var serdeInfo = global::Serde.SerdeInfoProvider.GetInfo<Serde.Test.AllInOne.ColorEnumWrap>();
-                var de = deserializer.DeserializeType(serdeInfo);
+                var de = deserializer.ReadType(serdeInfo);
                 int index;
                 if ((index = de.TryReadIndex(serdeInfo, out var errorName)) == IDeserializeType.IndexNotFound)
                 {

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.AllInOne.IDeserialize.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.AllInOne.IDeserialize.cs
@@ -28,7 +28,7 @@ namespace Serde.Test
             Serde.Test.AllInOne.ColorEnum _l_color = default !;
             uint _r_assignedValid = 0;
             var _l_serdeInfo = global::Serde.SerdeInfoProvider.GetInfo<AllInOne>();
-            var typeDeserialize = deserializer.DeserializeType(_l_serdeInfo);
+            var typeDeserialize = deserializer.ReadType(_l_serdeInfo);
             int _l_index_;
             while ((_l_index_ = typeDeserialize.TryReadIndex(_l_serdeInfo, out var _l_errorName)) != IDeserializeType.EndOfType)
             {

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.AllInOne.IDeserialize.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.AllInOne.IDeserialize.cs
@@ -30,56 +30,56 @@ namespace Serde.Test
             var _l_serdeInfo = global::Serde.SerdeInfoProvider.GetInfo<AllInOne>();
             var typeDeserialize = deserializer.ReadType(_l_serdeInfo);
             int _l_index_;
-            while ((_l_index_ = typeDeserialize.TryReadIndex(_l_serdeInfo, out var _l_errorName)) != IDeserializeType.EndOfType)
+            while ((_l_index_ = typeDeserialize.TryReadIndex(_l_serdeInfo, out _)) != IDeserializeType.EndOfType)
             {
                 switch (_l_index_)
                 {
                     case 0:
-                        _l_boolfield = typeDeserialize.ReadValue<bool, global::Serde.BoolWrap>(_l_index_);
+                        _l_boolfield = typeDeserialize.ReadBool(_l_index_);
                         _r_assignedValid |= ((uint)1) << 0;
                         break;
                     case 1:
-                        _l_charfield = typeDeserialize.ReadValue<char, global::Serde.CharWrap>(_l_index_);
+                        _l_charfield = typeDeserialize.ReadChar(_l_index_);
                         _r_assignedValid |= ((uint)1) << 1;
                         break;
                     case 2:
-                        _l_bytefield = typeDeserialize.ReadValue<byte, global::Serde.ByteWrap>(_l_index_);
+                        _l_bytefield = typeDeserialize.ReadByte(_l_index_);
                         _r_assignedValid |= ((uint)1) << 2;
                         break;
                     case 3:
-                        _l_ushortfield = typeDeserialize.ReadValue<ushort, global::Serde.UInt16Wrap>(_l_index_);
+                        _l_ushortfield = typeDeserialize.ReadU16(_l_index_);
                         _r_assignedValid |= ((uint)1) << 3;
                         break;
                     case 4:
-                        _l_uintfield = typeDeserialize.ReadValue<uint, global::Serde.UInt32Wrap>(_l_index_);
+                        _l_uintfield = typeDeserialize.ReadU32(_l_index_);
                         _r_assignedValid |= ((uint)1) << 4;
                         break;
                     case 5:
-                        _l_ulongfield = typeDeserialize.ReadValue<ulong, global::Serde.UInt64Wrap>(_l_index_);
+                        _l_ulongfield = typeDeserialize.ReadU64(_l_index_);
                         _r_assignedValid |= ((uint)1) << 5;
                         break;
                     case 6:
-                        _l_sbytefield = typeDeserialize.ReadValue<sbyte, global::Serde.SByteWrap>(_l_index_);
+                        _l_sbytefield = typeDeserialize.ReadSByte(_l_index_);
                         _r_assignedValid |= ((uint)1) << 6;
                         break;
                     case 7:
-                        _l_shortfield = typeDeserialize.ReadValue<short, global::Serde.Int16Wrap>(_l_index_);
+                        _l_shortfield = typeDeserialize.ReadI16(_l_index_);
                         _r_assignedValid |= ((uint)1) << 7;
                         break;
                     case 8:
-                        _l_intfield = typeDeserialize.ReadValue<int, global::Serde.Int32Wrap>(_l_index_);
+                        _l_intfield = typeDeserialize.ReadI32(_l_index_);
                         _r_assignedValid |= ((uint)1) << 8;
                         break;
                     case 9:
-                        _l_longfield = typeDeserialize.ReadValue<long, global::Serde.Int64Wrap>(_l_index_);
+                        _l_longfield = typeDeserialize.ReadI64(_l_index_);
                         _r_assignedValid |= ((uint)1) << 9;
                         break;
                     case 10:
-                        _l_stringfield = typeDeserialize.ReadValue<string, global::Serde.StringWrap>(_l_index_);
+                        _l_stringfield = typeDeserialize.ReadString(_l_index_);
                         _r_assignedValid |= ((uint)1) << 10;
                         break;
                     case 11:
-                        _l_escapedstringfield = typeDeserialize.ReadValue<string, global::Serde.StringWrap>(_l_index_);
+                        _l_escapedstringfield = typeDeserialize.ReadString(_l_index_);
                         _r_assignedValid |= ((uint)1) << 11;
                         break;
                     case 12:

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.GenericWrapperTests.CustomArrayWrapExplicitOnType.IDeserialize.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.GenericWrapperTests.CustomArrayWrapExplicitOnType.IDeserialize.cs
@@ -14,7 +14,7 @@ namespace Serde.Test
                 Serde.Test.GenericWrapperTests.CustomImArray2<int> _l_a = default !;
                 byte _r_assignedValid = 0;
                 var _l_serdeInfo = global::Serde.SerdeInfoProvider.GetInfo<CustomArrayWrapExplicitOnType>();
-                var typeDeserialize = deserializer.DeserializeType(_l_serdeInfo);
+                var typeDeserialize = deserializer.ReadType(_l_serdeInfo);
                 int _l_index_;
                 while ((_l_index_ = typeDeserialize.TryReadIndex(_l_serdeInfo, out var _l_errorName)) != IDeserializeType.EndOfType)
                 {

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.GenericWrapperTests.CustomArrayWrapExplicitOnType.IDeserialize.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.GenericWrapperTests.CustomArrayWrapExplicitOnType.IDeserialize.cs
@@ -16,7 +16,7 @@ namespace Serde.Test
                 var _l_serdeInfo = global::Serde.SerdeInfoProvider.GetInfo<CustomArrayWrapExplicitOnType>();
                 var typeDeserialize = deserializer.ReadType(_l_serdeInfo);
                 int _l_index_;
-                while ((_l_index_ = typeDeserialize.TryReadIndex(_l_serdeInfo, out var _l_errorName)) != IDeserializeType.EndOfType)
+                while ((_l_index_ = typeDeserialize.TryReadIndex(_l_serdeInfo, out _)) != IDeserializeType.EndOfType)
                 {
                     switch (_l_index_)
                     {

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.GenericWrapperTests.CustomImArrayExplicitWrapOnMember.IDeserialize.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.GenericWrapperTests.CustomImArrayExplicitWrapOnMember.IDeserialize.cs
@@ -14,7 +14,7 @@ namespace Serde.Test
                 Serde.Test.GenericWrapperTests.CustomImArray<int> _l_a = default !;
                 byte _r_assignedValid = 0;
                 var _l_serdeInfo = global::Serde.SerdeInfoProvider.GetInfo<CustomImArrayExplicitWrapOnMember>();
-                var typeDeserialize = deserializer.DeserializeType(_l_serdeInfo);
+                var typeDeserialize = deserializer.ReadType(_l_serdeInfo);
                 int _l_index_;
                 while ((_l_index_ = typeDeserialize.TryReadIndex(_l_serdeInfo, out var _l_errorName)) != IDeserializeType.EndOfType)
                 {

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.GenericWrapperTests.CustomImArrayExplicitWrapOnMember.IDeserialize.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.GenericWrapperTests.CustomImArrayExplicitWrapOnMember.IDeserialize.cs
@@ -16,7 +16,7 @@ namespace Serde.Test
                 var _l_serdeInfo = global::Serde.SerdeInfoProvider.GetInfo<CustomImArrayExplicitWrapOnMember>();
                 var typeDeserialize = deserializer.ReadType(_l_serdeInfo);
                 int _l_index_;
-                while ((_l_index_ = typeDeserialize.TryReadIndex(_l_serdeInfo, out var _l_errorName)) != IDeserializeType.EndOfType)
+                while ((_l_index_ = typeDeserialize.TryReadIndex(_l_serdeInfo, out _)) != IDeserializeType.EndOfType)
                 {
                     switch (_l_index_)
                     {

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonDeserializeTests.DenyUnknown.IDeserialize.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonDeserializeTests.DenyUnknown.IDeserialize.cs
@@ -22,7 +22,7 @@ namespace Serde.Test
                     switch (_l_index_)
                     {
                         case 0:
-                            _l_present = typeDeserialize.ReadValue<string, global::Serde.StringWrap>(_l_index_);
+                            _l_present = typeDeserialize.ReadString(_l_index_);
                             _r_assignedValid |= ((byte)1) << 0;
                             break;
                         case 1:

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonDeserializeTests.DenyUnknown.IDeserialize.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonDeserializeTests.DenyUnknown.IDeserialize.cs
@@ -15,7 +15,7 @@ namespace Serde.Test
                 string? _l_missing = default !;
                 byte _r_assignedValid = 0;
                 var _l_serdeInfo = global::Serde.SerdeInfoProvider.GetInfo<DenyUnknown>();
-                var typeDeserialize = deserializer.DeserializeType(_l_serdeInfo);
+                var typeDeserialize = deserializer.ReadType(_l_serdeInfo);
                 int _l_index_;
                 while ((_l_index_ = typeDeserialize.TryReadIndex(_l_serdeInfo, out var _l_errorName)) != IDeserializeType.EndOfType)
                 {

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonDeserializeTests.ExtraMembers.IDeserialize.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonDeserializeTests.ExtraMembers.IDeserialize.cs
@@ -16,12 +16,12 @@ namespace Serde.Test
                 var _l_serdeInfo = global::Serde.SerdeInfoProvider.GetInfo<ExtraMembers>();
                 var typeDeserialize = deserializer.ReadType(_l_serdeInfo);
                 int _l_index_;
-                while ((_l_index_ = typeDeserialize.TryReadIndex(_l_serdeInfo, out var _l_errorName)) != IDeserializeType.EndOfType)
+                while ((_l_index_ = typeDeserialize.TryReadIndex(_l_serdeInfo, out _)) != IDeserializeType.EndOfType)
                 {
                     switch (_l_index_)
                     {
                         case 0:
-                            _l_b = typeDeserialize.ReadValue<int, global::Serde.Int32Wrap>(_l_index_);
+                            _l_b = typeDeserialize.ReadI32(_l_index_);
                             _r_assignedValid |= ((byte)1) << 0;
                             break;
                         case Serde.IDeserializeType.IndexNotFound:

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonDeserializeTests.ExtraMembers.IDeserialize.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonDeserializeTests.ExtraMembers.IDeserialize.cs
@@ -14,7 +14,7 @@ namespace Serde.Test
                 int _l_b = default !;
                 byte _r_assignedValid = 0;
                 var _l_serdeInfo = global::Serde.SerdeInfoProvider.GetInfo<ExtraMembers>();
-                var typeDeserialize = deserializer.DeserializeType(_l_serdeInfo);
+                var typeDeserialize = deserializer.ReadType(_l_serdeInfo);
                 int _l_index_;
                 while ((_l_index_ = typeDeserialize.TryReadIndex(_l_serdeInfo, out var _l_errorName)) != IDeserializeType.EndOfType)
                 {

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonDeserializeTests.IdStruct.IDeserialize.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonDeserializeTests.IdStruct.IDeserialize.cs
@@ -14,7 +14,7 @@ namespace Serde.Test
                 int _l_id = default !;
                 byte _r_assignedValid = 0;
                 var _l_serdeInfo = global::Serde.SerdeInfoProvider.GetInfo<IdStruct>();
-                var typeDeserialize = deserializer.DeserializeType(_l_serdeInfo);
+                var typeDeserialize = deserializer.ReadType(_l_serdeInfo);
                 int _l_index_;
                 while ((_l_index_ = typeDeserialize.TryReadIndex(_l_serdeInfo, out var _l_errorName)) != IDeserializeType.EndOfType)
                 {

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonDeserializeTests.IdStruct.IDeserialize.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonDeserializeTests.IdStruct.IDeserialize.cs
@@ -16,12 +16,12 @@ namespace Serde.Test
                 var _l_serdeInfo = global::Serde.SerdeInfoProvider.GetInfo<IdStruct>();
                 var typeDeserialize = deserializer.ReadType(_l_serdeInfo);
                 int _l_index_;
-                while ((_l_index_ = typeDeserialize.TryReadIndex(_l_serdeInfo, out var _l_errorName)) != IDeserializeType.EndOfType)
+                while ((_l_index_ = typeDeserialize.TryReadIndex(_l_serdeInfo, out _)) != IDeserializeType.EndOfType)
                 {
                     switch (_l_index_)
                     {
                         case 0:
-                            _l_id = typeDeserialize.ReadValue<int, global::Serde.Int32Wrap>(_l_index_);
+                            _l_id = typeDeserialize.ReadI32(_l_index_);
                             _r_assignedValid |= ((byte)1) << 0;
                             break;
                         case Serde.IDeserializeType.IndexNotFound:

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonDeserializeTests.IdStructList.IDeserialize.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonDeserializeTests.IdStructList.IDeserialize.cs
@@ -17,12 +17,12 @@ namespace Serde.Test
                 var _l_serdeInfo = global::Serde.SerdeInfoProvider.GetInfo<IdStructList>();
                 var typeDeserialize = deserializer.ReadType(_l_serdeInfo);
                 int _l_index_;
-                while ((_l_index_ = typeDeserialize.TryReadIndex(_l_serdeInfo, out var _l_errorName)) != IDeserializeType.EndOfType)
+                while ((_l_index_ = typeDeserialize.TryReadIndex(_l_serdeInfo, out _)) != IDeserializeType.EndOfType)
                 {
                     switch (_l_index_)
                     {
                         case 0:
-                            _l_count = typeDeserialize.ReadValue<int, global::Serde.Int32Wrap>(_l_index_);
+                            _l_count = typeDeserialize.ReadI32(_l_index_);
                             _r_assignedValid |= ((byte)1) << 0;
                             break;
                         case 1:

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonDeserializeTests.IdStructList.IDeserialize.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonDeserializeTests.IdStructList.IDeserialize.cs
@@ -15,7 +15,7 @@ namespace Serde.Test
                 System.Collections.Generic.List<Serde.Test.JsonDeserializeTests.IdStruct> _l_list = default !;
                 byte _r_assignedValid = 0;
                 var _l_serdeInfo = global::Serde.SerdeInfoProvider.GetInfo<IdStructList>();
-                var typeDeserialize = deserializer.DeserializeType(_l_serdeInfo);
+                var typeDeserialize = deserializer.ReadType(_l_serdeInfo);
                 int _l_index_;
                 while ((_l_index_ = typeDeserialize.TryReadIndex(_l_serdeInfo, out var _l_errorName)) != IDeserializeType.EndOfType)
                 {

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonDeserializeTests.Location.IDeserialize.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonDeserializeTests.Location.IDeserialize.cs
@@ -24,44 +24,44 @@ namespace Serde.Test
                 var _l_serdeInfo = global::Serde.SerdeInfoProvider.GetInfo<Location>();
                 var typeDeserialize = deserializer.ReadType(_l_serdeInfo);
                 int _l_index_;
-                while ((_l_index_ = typeDeserialize.TryReadIndex(_l_serdeInfo, out var _l_errorName)) != IDeserializeType.EndOfType)
+                while ((_l_index_ = typeDeserialize.TryReadIndex(_l_serdeInfo, out _)) != IDeserializeType.EndOfType)
                 {
                     switch (_l_index_)
                     {
                         case 0:
-                            _l_id = typeDeserialize.ReadValue<int, global::Serde.Int32Wrap>(_l_index_);
+                            _l_id = typeDeserialize.ReadI32(_l_index_);
                             _r_assignedValid |= ((ushort)1) << 0;
                             break;
                         case 1:
-                            _l_address1 = typeDeserialize.ReadValue<string, global::Serde.StringWrap>(_l_index_);
+                            _l_address1 = typeDeserialize.ReadString(_l_index_);
                             _r_assignedValid |= ((ushort)1) << 1;
                             break;
                         case 2:
-                            _l_address2 = typeDeserialize.ReadValue<string, global::Serde.StringWrap>(_l_index_);
+                            _l_address2 = typeDeserialize.ReadString(_l_index_);
                             _r_assignedValid |= ((ushort)1) << 2;
                             break;
                         case 3:
-                            _l_city = typeDeserialize.ReadValue<string, global::Serde.StringWrap>(_l_index_);
+                            _l_city = typeDeserialize.ReadString(_l_index_);
                             _r_assignedValid |= ((ushort)1) << 3;
                             break;
                         case 4:
-                            _l_state = typeDeserialize.ReadValue<string, global::Serde.StringWrap>(_l_index_);
+                            _l_state = typeDeserialize.ReadString(_l_index_);
                             _r_assignedValid |= ((ushort)1) << 4;
                             break;
                         case 5:
-                            _l_postalcode = typeDeserialize.ReadValue<string, global::Serde.StringWrap>(_l_index_);
+                            _l_postalcode = typeDeserialize.ReadString(_l_index_);
                             _r_assignedValid |= ((ushort)1) << 5;
                             break;
                         case 6:
-                            _l_name = typeDeserialize.ReadValue<string, global::Serde.StringWrap>(_l_index_);
+                            _l_name = typeDeserialize.ReadString(_l_index_);
                             _r_assignedValid |= ((ushort)1) << 6;
                             break;
                         case 7:
-                            _l_phonenumber = typeDeserialize.ReadValue<string, global::Serde.StringWrap>(_l_index_);
+                            _l_phonenumber = typeDeserialize.ReadString(_l_index_);
                             _r_assignedValid |= ((ushort)1) << 7;
                             break;
                         case 8:
-                            _l_country = typeDeserialize.ReadValue<string, global::Serde.StringWrap>(_l_index_);
+                            _l_country = typeDeserialize.ReadString(_l_index_);
                             _r_assignedValid |= ((ushort)1) << 8;
                             break;
                         case Serde.IDeserializeType.IndexNotFound:

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonDeserializeTests.Location.IDeserialize.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonDeserializeTests.Location.IDeserialize.cs
@@ -22,7 +22,7 @@ namespace Serde.Test
                 string _l_country = default !;
                 ushort _r_assignedValid = 0;
                 var _l_serdeInfo = global::Serde.SerdeInfoProvider.GetInfo<Location>();
-                var typeDeserialize = deserializer.DeserializeType(_l_serdeInfo);
+                var typeDeserialize = deserializer.ReadType(_l_serdeInfo);
                 int _l_index_;
                 while ((_l_index_ = typeDeserialize.TryReadIndex(_l_serdeInfo, out var _l_errorName)) != IDeserializeType.EndOfType)
                 {

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonDeserializeTests.NullableFields.IDeserialize.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonDeserializeTests.NullableFields.IDeserialize.cs
@@ -17,7 +17,7 @@ namespace Serde.Test
                 var _l_serdeInfo = global::Serde.SerdeInfoProvider.GetInfo<NullableFields>();
                 var typeDeserialize = deserializer.ReadType(_l_serdeInfo);
                 int _l_index_;
-                while ((_l_index_ = typeDeserialize.TryReadIndex(_l_serdeInfo, out var _l_errorName)) != IDeserializeType.EndOfType)
+                while ((_l_index_ = typeDeserialize.TryReadIndex(_l_serdeInfo, out _)) != IDeserializeType.EndOfType)
                 {
                     switch (_l_index_)
                     {

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonDeserializeTests.NullableFields.IDeserialize.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonDeserializeTests.NullableFields.IDeserialize.cs
@@ -15,7 +15,7 @@ namespace Serde.Test
                 System.Collections.Generic.Dictionary<string, string?> _l_dict = default !;
                 byte _r_assignedValid = 0;
                 var _l_serdeInfo = global::Serde.SerdeInfoProvider.GetInfo<NullableFields>();
-                var typeDeserialize = deserializer.DeserializeType(_l_serdeInfo);
+                var typeDeserialize = deserializer.ReadType(_l_serdeInfo);
                 int _l_index_;
                 while ((_l_index_ = typeDeserialize.TryReadIndex(_l_serdeInfo, out var _l_errorName)) != IDeserializeType.EndOfType)
                 {

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonDeserializeTests.SetToNull.IDeserialize.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonDeserializeTests.SetToNull.IDeserialize.cs
@@ -15,7 +15,7 @@ namespace Serde.Test
                 string? _l_missing = default !;
                 byte _r_assignedValid = 0;
                 var _l_serdeInfo = global::Serde.SerdeInfoProvider.GetInfo<SetToNull>();
-                var typeDeserialize = deserializer.DeserializeType(_l_serdeInfo);
+                var typeDeserialize = deserializer.ReadType(_l_serdeInfo);
                 int _l_index_;
                 while ((_l_index_ = typeDeserialize.TryReadIndex(_l_serdeInfo, out var _l_errorName)) != IDeserializeType.EndOfType)
                 {

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonDeserializeTests.SetToNull.IDeserialize.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonDeserializeTests.SetToNull.IDeserialize.cs
@@ -17,12 +17,12 @@ namespace Serde.Test
                 var _l_serdeInfo = global::Serde.SerdeInfoProvider.GetInfo<SetToNull>();
                 var typeDeserialize = deserializer.ReadType(_l_serdeInfo);
                 int _l_index_;
-                while ((_l_index_ = typeDeserialize.TryReadIndex(_l_serdeInfo, out var _l_errorName)) != IDeserializeType.EndOfType)
+                while ((_l_index_ = typeDeserialize.TryReadIndex(_l_serdeInfo, out _)) != IDeserializeType.EndOfType)
                 {
                     switch (_l_index_)
                     {
                         case 0:
-                            _l_present = typeDeserialize.ReadValue<string, global::Serde.StringWrap>(_l_index_);
+                            _l_present = typeDeserialize.ReadString(_l_index_);
                             _r_assignedValid |= ((byte)1) << 0;
                             break;
                         case 1:

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonDeserializeTests.SkipDeserialize.IDeserialize.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonDeserializeTests.SkipDeserialize.IDeserialize.cs
@@ -16,12 +16,12 @@ namespace Serde.Test
                 var _l_serdeInfo = global::Serde.SerdeInfoProvider.GetInfo<SkipDeserialize>();
                 var typeDeserialize = deserializer.ReadType(_l_serdeInfo);
                 int _l_index_;
-                while ((_l_index_ = typeDeserialize.TryReadIndex(_l_serdeInfo, out var _l_errorName)) != IDeserializeType.EndOfType)
+                while ((_l_index_ = typeDeserialize.TryReadIndex(_l_serdeInfo, out _)) != IDeserializeType.EndOfType)
                 {
                     switch (_l_index_)
                     {
                         case 0:
-                            _l_required = typeDeserialize.ReadValue<string, global::Serde.StringWrap>(_l_index_);
+                            _l_required = typeDeserialize.ReadString(_l_index_);
                             _r_assignedValid |= ((byte)1) << 0;
                             break;
                         case 1:

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonDeserializeTests.SkipDeserialize.IDeserialize.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonDeserializeTests.SkipDeserialize.IDeserialize.cs
@@ -14,7 +14,7 @@ namespace Serde.Test
                 string _l_required = default !;
                 byte _r_assignedValid = 0;
                 var _l_serdeInfo = global::Serde.SerdeInfoProvider.GetInfo<SkipDeserialize>();
-                var typeDeserialize = deserializer.DeserializeType(_l_serdeInfo);
+                var typeDeserialize = deserializer.ReadType(_l_serdeInfo);
                 int _l_index_;
                 while ((_l_index_ = typeDeserialize.TryReadIndex(_l_serdeInfo, out var _l_errorName)) != IDeserializeType.EndOfType)
                 {

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonDeserializeTests.ThrowMissing.IDeserialize.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonDeserializeTests.ThrowMissing.IDeserialize.cs
@@ -15,7 +15,7 @@ namespace Serde.Test
                 string? _l_missing = default !;
                 byte _r_assignedValid = 0;
                 var _l_serdeInfo = global::Serde.SerdeInfoProvider.GetInfo<ThrowMissing>();
-                var typeDeserialize = deserializer.DeserializeType(_l_serdeInfo);
+                var typeDeserialize = deserializer.ReadType(_l_serdeInfo);
                 int _l_index_;
                 while ((_l_index_ = typeDeserialize.TryReadIndex(_l_serdeInfo, out var _l_errorName)) != IDeserializeType.EndOfType)
                 {

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonDeserializeTests.ThrowMissing.IDeserialize.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonDeserializeTests.ThrowMissing.IDeserialize.cs
@@ -17,12 +17,12 @@ namespace Serde.Test
                 var _l_serdeInfo = global::Serde.SerdeInfoProvider.GetInfo<ThrowMissing>();
                 var typeDeserialize = deserializer.ReadType(_l_serdeInfo);
                 int _l_index_;
-                while ((_l_index_ = typeDeserialize.TryReadIndex(_l_serdeInfo, out var _l_errorName)) != IDeserializeType.EndOfType)
+                while ((_l_index_ = typeDeserialize.TryReadIndex(_l_serdeInfo, out _)) != IDeserializeType.EndOfType)
                 {
                     switch (_l_index_)
                     {
                         case 0:
-                            _l_present = typeDeserialize.ReadValue<string, global::Serde.StringWrap>(_l_index_);
+                            _l_present = typeDeserialize.ReadString(_l_index_);
                             _r_assignedValid |= ((byte)1) << 0;
                             break;
                         case 1:

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonDeserializeTests.ThrowMissingFalse.IDeserialize.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonDeserializeTests.ThrowMissingFalse.IDeserialize.cs
@@ -17,16 +17,16 @@ namespace Serde.Test
                 var _l_serdeInfo = global::Serde.SerdeInfoProvider.GetInfo<ThrowMissingFalse>();
                 var typeDeserialize = deserializer.ReadType(_l_serdeInfo);
                 int _l_index_;
-                while ((_l_index_ = typeDeserialize.TryReadIndex(_l_serdeInfo, out var _l_errorName)) != IDeserializeType.EndOfType)
+                while ((_l_index_ = typeDeserialize.TryReadIndex(_l_serdeInfo, out _)) != IDeserializeType.EndOfType)
                 {
                     switch (_l_index_)
                     {
                         case 0:
-                            _l_present = typeDeserialize.ReadValue<string, global::Serde.StringWrap>(_l_index_);
+                            _l_present = typeDeserialize.ReadString(_l_index_);
                             _r_assignedValid |= ((byte)1) << 0;
                             break;
                         case 1:
-                            _l_missing = typeDeserialize.ReadValue<bool, global::Serde.BoolWrap>(_l_index_);
+                            _l_missing = typeDeserialize.ReadBool(_l_index_);
                             _r_assignedValid |= ((byte)1) << 1;
                             break;
                         case Serde.IDeserializeType.IndexNotFound:

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonDeserializeTests.ThrowMissingFalse.IDeserialize.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonDeserializeTests.ThrowMissingFalse.IDeserialize.cs
@@ -15,7 +15,7 @@ namespace Serde.Test
                 bool _l_missing = default !;
                 byte _r_assignedValid = 0;
                 var _l_serdeInfo = global::Serde.SerdeInfoProvider.GetInfo<ThrowMissingFalse>();
-                var typeDeserialize = deserializer.DeserializeType(_l_serdeInfo);
+                var typeDeserialize = deserializer.ReadType(_l_serdeInfo);
                 int _l_index_;
                 while ((_l_index_ = typeDeserialize.TryReadIndex(_l_serdeInfo, out var _l_errorName)) != IDeserializeType.EndOfType)
                 {

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.MaxSizeType.IDeserialize.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.MaxSizeType.IDeserialize.cs
@@ -77,264 +77,264 @@ namespace Serde.Test
             var _l_serdeInfo = global::Serde.SerdeInfoProvider.GetInfo<MaxSizeType>();
             var typeDeserialize = deserializer.ReadType(_l_serdeInfo);
             int _l_index_;
-            while ((_l_index_ = typeDeserialize.TryReadIndex(_l_serdeInfo, out var _l_errorName)) != IDeserializeType.EndOfType)
+            while ((_l_index_ = typeDeserialize.TryReadIndex(_l_serdeInfo, out _)) != IDeserializeType.EndOfType)
             {
                 switch (_l_index_)
                 {
                     case 0:
-                        _l_field1 = typeDeserialize.ReadValue<byte, global::Serde.ByteWrap>(_l_index_);
+                        _l_field1 = typeDeserialize.ReadByte(_l_index_);
                         _r_assignedValid |= ((ulong)1) << 0;
                         break;
                     case 1:
-                        _l_field2 = typeDeserialize.ReadValue<byte, global::Serde.ByteWrap>(_l_index_);
+                        _l_field2 = typeDeserialize.ReadByte(_l_index_);
                         _r_assignedValid |= ((ulong)1) << 1;
                         break;
                     case 2:
-                        _l_field3 = typeDeserialize.ReadValue<byte, global::Serde.ByteWrap>(_l_index_);
+                        _l_field3 = typeDeserialize.ReadByte(_l_index_);
                         _r_assignedValid |= ((ulong)1) << 2;
                         break;
                     case 3:
-                        _l_field4 = typeDeserialize.ReadValue<byte, global::Serde.ByteWrap>(_l_index_);
+                        _l_field4 = typeDeserialize.ReadByte(_l_index_);
                         _r_assignedValid |= ((ulong)1) << 3;
                         break;
                     case 4:
-                        _l_field5 = typeDeserialize.ReadValue<byte, global::Serde.ByteWrap>(_l_index_);
+                        _l_field5 = typeDeserialize.ReadByte(_l_index_);
                         _r_assignedValid |= ((ulong)1) << 4;
                         break;
                     case 5:
-                        _l_field6 = typeDeserialize.ReadValue<byte, global::Serde.ByteWrap>(_l_index_);
+                        _l_field6 = typeDeserialize.ReadByte(_l_index_);
                         _r_assignedValid |= ((ulong)1) << 5;
                         break;
                     case 6:
-                        _l_field7 = typeDeserialize.ReadValue<byte, global::Serde.ByteWrap>(_l_index_);
+                        _l_field7 = typeDeserialize.ReadByte(_l_index_);
                         _r_assignedValid |= ((ulong)1) << 6;
                         break;
                     case 7:
-                        _l_field8 = typeDeserialize.ReadValue<byte, global::Serde.ByteWrap>(_l_index_);
+                        _l_field8 = typeDeserialize.ReadByte(_l_index_);
                         _r_assignedValid |= ((ulong)1) << 7;
                         break;
                     case 8:
-                        _l_field9 = typeDeserialize.ReadValue<byte, global::Serde.ByteWrap>(_l_index_);
+                        _l_field9 = typeDeserialize.ReadByte(_l_index_);
                         _r_assignedValid |= ((ulong)1) << 8;
                         break;
                     case 9:
-                        _l_field10 = typeDeserialize.ReadValue<byte, global::Serde.ByteWrap>(_l_index_);
+                        _l_field10 = typeDeserialize.ReadByte(_l_index_);
                         _r_assignedValid |= ((ulong)1) << 9;
                         break;
                     case 10:
-                        _l_field11 = typeDeserialize.ReadValue<byte, global::Serde.ByteWrap>(_l_index_);
+                        _l_field11 = typeDeserialize.ReadByte(_l_index_);
                         _r_assignedValid |= ((ulong)1) << 10;
                         break;
                     case 11:
-                        _l_field12 = typeDeserialize.ReadValue<byte, global::Serde.ByteWrap>(_l_index_);
+                        _l_field12 = typeDeserialize.ReadByte(_l_index_);
                         _r_assignedValid |= ((ulong)1) << 11;
                         break;
                     case 12:
-                        _l_field13 = typeDeserialize.ReadValue<byte, global::Serde.ByteWrap>(_l_index_);
+                        _l_field13 = typeDeserialize.ReadByte(_l_index_);
                         _r_assignedValid |= ((ulong)1) << 12;
                         break;
                     case 13:
-                        _l_field14 = typeDeserialize.ReadValue<byte, global::Serde.ByteWrap>(_l_index_);
+                        _l_field14 = typeDeserialize.ReadByte(_l_index_);
                         _r_assignedValid |= ((ulong)1) << 13;
                         break;
                     case 14:
-                        _l_field15 = typeDeserialize.ReadValue<byte, global::Serde.ByteWrap>(_l_index_);
+                        _l_field15 = typeDeserialize.ReadByte(_l_index_);
                         _r_assignedValid |= ((ulong)1) << 14;
                         break;
                     case 15:
-                        _l_field16 = typeDeserialize.ReadValue<byte, global::Serde.ByteWrap>(_l_index_);
+                        _l_field16 = typeDeserialize.ReadByte(_l_index_);
                         _r_assignedValid |= ((ulong)1) << 15;
                         break;
                     case 16:
-                        _l_field17 = typeDeserialize.ReadValue<byte, global::Serde.ByteWrap>(_l_index_);
+                        _l_field17 = typeDeserialize.ReadByte(_l_index_);
                         _r_assignedValid |= ((ulong)1) << 16;
                         break;
                     case 17:
-                        _l_field18 = typeDeserialize.ReadValue<byte, global::Serde.ByteWrap>(_l_index_);
+                        _l_field18 = typeDeserialize.ReadByte(_l_index_);
                         _r_assignedValid |= ((ulong)1) << 17;
                         break;
                     case 18:
-                        _l_field19 = typeDeserialize.ReadValue<byte, global::Serde.ByteWrap>(_l_index_);
+                        _l_field19 = typeDeserialize.ReadByte(_l_index_);
                         _r_assignedValid |= ((ulong)1) << 18;
                         break;
                     case 19:
-                        _l_field20 = typeDeserialize.ReadValue<byte, global::Serde.ByteWrap>(_l_index_);
+                        _l_field20 = typeDeserialize.ReadByte(_l_index_);
                         _r_assignedValid |= ((ulong)1) << 19;
                         break;
                     case 20:
-                        _l_field21 = typeDeserialize.ReadValue<byte, global::Serde.ByteWrap>(_l_index_);
+                        _l_field21 = typeDeserialize.ReadByte(_l_index_);
                         _r_assignedValid |= ((ulong)1) << 20;
                         break;
                     case 21:
-                        _l_field22 = typeDeserialize.ReadValue<byte, global::Serde.ByteWrap>(_l_index_);
+                        _l_field22 = typeDeserialize.ReadByte(_l_index_);
                         _r_assignedValid |= ((ulong)1) << 21;
                         break;
                     case 22:
-                        _l_field23 = typeDeserialize.ReadValue<byte, global::Serde.ByteWrap>(_l_index_);
+                        _l_field23 = typeDeserialize.ReadByte(_l_index_);
                         _r_assignedValid |= ((ulong)1) << 22;
                         break;
                     case 23:
-                        _l_field24 = typeDeserialize.ReadValue<byte, global::Serde.ByteWrap>(_l_index_);
+                        _l_field24 = typeDeserialize.ReadByte(_l_index_);
                         _r_assignedValid |= ((ulong)1) << 23;
                         break;
                     case 24:
-                        _l_field25 = typeDeserialize.ReadValue<byte, global::Serde.ByteWrap>(_l_index_);
+                        _l_field25 = typeDeserialize.ReadByte(_l_index_);
                         _r_assignedValid |= ((ulong)1) << 24;
                         break;
                     case 25:
-                        _l_field26 = typeDeserialize.ReadValue<byte, global::Serde.ByteWrap>(_l_index_);
+                        _l_field26 = typeDeserialize.ReadByte(_l_index_);
                         _r_assignedValid |= ((ulong)1) << 25;
                         break;
                     case 26:
-                        _l_field27 = typeDeserialize.ReadValue<byte, global::Serde.ByteWrap>(_l_index_);
+                        _l_field27 = typeDeserialize.ReadByte(_l_index_);
                         _r_assignedValid |= ((ulong)1) << 26;
                         break;
                     case 27:
-                        _l_field28 = typeDeserialize.ReadValue<byte, global::Serde.ByteWrap>(_l_index_);
+                        _l_field28 = typeDeserialize.ReadByte(_l_index_);
                         _r_assignedValid |= ((ulong)1) << 27;
                         break;
                     case 28:
-                        _l_field29 = typeDeserialize.ReadValue<byte, global::Serde.ByteWrap>(_l_index_);
+                        _l_field29 = typeDeserialize.ReadByte(_l_index_);
                         _r_assignedValid |= ((ulong)1) << 28;
                         break;
                     case 29:
-                        _l_field30 = typeDeserialize.ReadValue<byte, global::Serde.ByteWrap>(_l_index_);
+                        _l_field30 = typeDeserialize.ReadByte(_l_index_);
                         _r_assignedValid |= ((ulong)1) << 29;
                         break;
                     case 30:
-                        _l_field31 = typeDeserialize.ReadValue<byte, global::Serde.ByteWrap>(_l_index_);
+                        _l_field31 = typeDeserialize.ReadByte(_l_index_);
                         _r_assignedValid |= ((ulong)1) << 30;
                         break;
                     case 31:
-                        _l_field32 = typeDeserialize.ReadValue<byte, global::Serde.ByteWrap>(_l_index_);
+                        _l_field32 = typeDeserialize.ReadByte(_l_index_);
                         _r_assignedValid |= ((ulong)1) << 31;
                         break;
                     case 32:
-                        _l_field33 = typeDeserialize.ReadValue<byte, global::Serde.ByteWrap>(_l_index_);
+                        _l_field33 = typeDeserialize.ReadByte(_l_index_);
                         _r_assignedValid |= ((ulong)1) << 32;
                         break;
                     case 33:
-                        _l_field34 = typeDeserialize.ReadValue<byte, global::Serde.ByteWrap>(_l_index_);
+                        _l_field34 = typeDeserialize.ReadByte(_l_index_);
                         _r_assignedValid |= ((ulong)1) << 33;
                         break;
                     case 34:
-                        _l_field35 = typeDeserialize.ReadValue<byte, global::Serde.ByteWrap>(_l_index_);
+                        _l_field35 = typeDeserialize.ReadByte(_l_index_);
                         _r_assignedValid |= ((ulong)1) << 34;
                         break;
                     case 35:
-                        _l_field36 = typeDeserialize.ReadValue<byte, global::Serde.ByteWrap>(_l_index_);
+                        _l_field36 = typeDeserialize.ReadByte(_l_index_);
                         _r_assignedValid |= ((ulong)1) << 35;
                         break;
                     case 36:
-                        _l_field37 = typeDeserialize.ReadValue<byte, global::Serde.ByteWrap>(_l_index_);
+                        _l_field37 = typeDeserialize.ReadByte(_l_index_);
                         _r_assignedValid |= ((ulong)1) << 36;
                         break;
                     case 37:
-                        _l_field38 = typeDeserialize.ReadValue<byte, global::Serde.ByteWrap>(_l_index_);
+                        _l_field38 = typeDeserialize.ReadByte(_l_index_);
                         _r_assignedValid |= ((ulong)1) << 37;
                         break;
                     case 38:
-                        _l_field39 = typeDeserialize.ReadValue<byte, global::Serde.ByteWrap>(_l_index_);
+                        _l_field39 = typeDeserialize.ReadByte(_l_index_);
                         _r_assignedValid |= ((ulong)1) << 38;
                         break;
                     case 39:
-                        _l_field40 = typeDeserialize.ReadValue<byte, global::Serde.ByteWrap>(_l_index_);
+                        _l_field40 = typeDeserialize.ReadByte(_l_index_);
                         _r_assignedValid |= ((ulong)1) << 39;
                         break;
                     case 40:
-                        _l_field41 = typeDeserialize.ReadValue<byte, global::Serde.ByteWrap>(_l_index_);
+                        _l_field41 = typeDeserialize.ReadByte(_l_index_);
                         _r_assignedValid |= ((ulong)1) << 40;
                         break;
                     case 41:
-                        _l_field42 = typeDeserialize.ReadValue<byte, global::Serde.ByteWrap>(_l_index_);
+                        _l_field42 = typeDeserialize.ReadByte(_l_index_);
                         _r_assignedValid |= ((ulong)1) << 41;
                         break;
                     case 42:
-                        _l_field43 = typeDeserialize.ReadValue<byte, global::Serde.ByteWrap>(_l_index_);
+                        _l_field43 = typeDeserialize.ReadByte(_l_index_);
                         _r_assignedValid |= ((ulong)1) << 42;
                         break;
                     case 43:
-                        _l_field44 = typeDeserialize.ReadValue<byte, global::Serde.ByteWrap>(_l_index_);
+                        _l_field44 = typeDeserialize.ReadByte(_l_index_);
                         _r_assignedValid |= ((ulong)1) << 43;
                         break;
                     case 44:
-                        _l_field45 = typeDeserialize.ReadValue<byte, global::Serde.ByteWrap>(_l_index_);
+                        _l_field45 = typeDeserialize.ReadByte(_l_index_);
                         _r_assignedValid |= ((ulong)1) << 44;
                         break;
                     case 45:
-                        _l_field46 = typeDeserialize.ReadValue<byte, global::Serde.ByteWrap>(_l_index_);
+                        _l_field46 = typeDeserialize.ReadByte(_l_index_);
                         _r_assignedValid |= ((ulong)1) << 45;
                         break;
                     case 46:
-                        _l_field47 = typeDeserialize.ReadValue<byte, global::Serde.ByteWrap>(_l_index_);
+                        _l_field47 = typeDeserialize.ReadByte(_l_index_);
                         _r_assignedValid |= ((ulong)1) << 46;
                         break;
                     case 47:
-                        _l_field48 = typeDeserialize.ReadValue<byte, global::Serde.ByteWrap>(_l_index_);
+                        _l_field48 = typeDeserialize.ReadByte(_l_index_);
                         _r_assignedValid |= ((ulong)1) << 47;
                         break;
                     case 48:
-                        _l_field49 = typeDeserialize.ReadValue<byte, global::Serde.ByteWrap>(_l_index_);
+                        _l_field49 = typeDeserialize.ReadByte(_l_index_);
                         _r_assignedValid |= ((ulong)1) << 48;
                         break;
                     case 49:
-                        _l_field50 = typeDeserialize.ReadValue<byte, global::Serde.ByteWrap>(_l_index_);
+                        _l_field50 = typeDeserialize.ReadByte(_l_index_);
                         _r_assignedValid |= ((ulong)1) << 49;
                         break;
                     case 50:
-                        _l_field51 = typeDeserialize.ReadValue<byte, global::Serde.ByteWrap>(_l_index_);
+                        _l_field51 = typeDeserialize.ReadByte(_l_index_);
                         _r_assignedValid |= ((ulong)1) << 50;
                         break;
                     case 51:
-                        _l_field52 = typeDeserialize.ReadValue<byte, global::Serde.ByteWrap>(_l_index_);
+                        _l_field52 = typeDeserialize.ReadByte(_l_index_);
                         _r_assignedValid |= ((ulong)1) << 51;
                         break;
                     case 52:
-                        _l_field53 = typeDeserialize.ReadValue<byte, global::Serde.ByteWrap>(_l_index_);
+                        _l_field53 = typeDeserialize.ReadByte(_l_index_);
                         _r_assignedValid |= ((ulong)1) << 52;
                         break;
                     case 53:
-                        _l_field54 = typeDeserialize.ReadValue<byte, global::Serde.ByteWrap>(_l_index_);
+                        _l_field54 = typeDeserialize.ReadByte(_l_index_);
                         _r_assignedValid |= ((ulong)1) << 53;
                         break;
                     case 54:
-                        _l_field55 = typeDeserialize.ReadValue<byte, global::Serde.ByteWrap>(_l_index_);
+                        _l_field55 = typeDeserialize.ReadByte(_l_index_);
                         _r_assignedValid |= ((ulong)1) << 54;
                         break;
                     case 55:
-                        _l_field56 = typeDeserialize.ReadValue<byte, global::Serde.ByteWrap>(_l_index_);
+                        _l_field56 = typeDeserialize.ReadByte(_l_index_);
                         _r_assignedValid |= ((ulong)1) << 55;
                         break;
                     case 56:
-                        _l_field57 = typeDeserialize.ReadValue<byte, global::Serde.ByteWrap>(_l_index_);
+                        _l_field57 = typeDeserialize.ReadByte(_l_index_);
                         _r_assignedValid |= ((ulong)1) << 56;
                         break;
                     case 57:
-                        _l_field58 = typeDeserialize.ReadValue<byte, global::Serde.ByteWrap>(_l_index_);
+                        _l_field58 = typeDeserialize.ReadByte(_l_index_);
                         _r_assignedValid |= ((ulong)1) << 57;
                         break;
                     case 58:
-                        _l_field59 = typeDeserialize.ReadValue<byte, global::Serde.ByteWrap>(_l_index_);
+                        _l_field59 = typeDeserialize.ReadByte(_l_index_);
                         _r_assignedValid |= ((ulong)1) << 58;
                         break;
                     case 59:
-                        _l_field60 = typeDeserialize.ReadValue<byte, global::Serde.ByteWrap>(_l_index_);
+                        _l_field60 = typeDeserialize.ReadByte(_l_index_);
                         _r_assignedValid |= ((ulong)1) << 59;
                         break;
                     case 60:
-                        _l_field61 = typeDeserialize.ReadValue<byte, global::Serde.ByteWrap>(_l_index_);
+                        _l_field61 = typeDeserialize.ReadByte(_l_index_);
                         _r_assignedValid |= ((ulong)1) << 60;
                         break;
                     case 61:
-                        _l_field62 = typeDeserialize.ReadValue<byte, global::Serde.ByteWrap>(_l_index_);
+                        _l_field62 = typeDeserialize.ReadByte(_l_index_);
                         _r_assignedValid |= ((ulong)1) << 61;
                         break;
                     case 62:
-                        _l_field63 = typeDeserialize.ReadValue<byte, global::Serde.ByteWrap>(_l_index_);
+                        _l_field63 = typeDeserialize.ReadByte(_l_index_);
                         _r_assignedValid |= ((ulong)1) << 62;
                         break;
                     case 63:
-                        _l_field64 = typeDeserialize.ReadValue<byte, global::Serde.ByteWrap>(_l_index_);
+                        _l_field64 = typeDeserialize.ReadByte(_l_index_);
                         _r_assignedValid |= ((ulong)1) << 63;
                         break;
                     case Serde.IDeserializeType.IndexNotFound:

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.MaxSizeType.IDeserialize.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.MaxSizeType.IDeserialize.cs
@@ -75,7 +75,7 @@ namespace Serde.Test
             byte _l_field64 = default !;
             ulong _r_assignedValid = 0;
             var _l_serdeInfo = global::Serde.SerdeInfoProvider.GetInfo<MaxSizeType>();
-            var typeDeserialize = deserializer.DeserializeType(_l_serdeInfo);
+            var typeDeserialize = deserializer.ReadType(_l_serdeInfo);
             int _l_index_;
             while ((_l_index_ = typeDeserialize.TryReadIndex(_l_serdeInfo, out var _l_errorName)) != IDeserializeType.EndOfType)
             {

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.SerdeInfoTests.EmptyRecord.IDeserialize.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.SerdeInfoTests.EmptyRecord.IDeserialize.cs
@@ -15,7 +15,7 @@ namespace Serde.Test
                 var _l_serdeInfo = global::Serde.SerdeInfoProvider.GetInfo<EmptyRecord>();
                 var typeDeserialize = deserializer.ReadType(_l_serdeInfo);
                 int _l_index_;
-                while ((_l_index_ = typeDeserialize.TryReadIndex(_l_serdeInfo, out var _l_errorName)) != IDeserializeType.EndOfType)
+                while ((_l_index_ = typeDeserialize.TryReadIndex(_l_serdeInfo, out _)) != IDeserializeType.EndOfType)
                 {
                     switch (_l_index_)
                     {

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.SerdeInfoTests.EmptyRecord.IDeserialize.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.SerdeInfoTests.EmptyRecord.IDeserialize.cs
@@ -13,7 +13,7 @@ namespace Serde.Test
             {
                 byte _r_assignedValid = 0;
                 var _l_serdeInfo = global::Serde.SerdeInfoProvider.GetInfo<EmptyRecord>();
-                var typeDeserialize = deserializer.DeserializeType(_l_serdeInfo);
+                var typeDeserialize = deserializer.ReadType(_l_serdeInfo);
                 int _l_index_;
                 while ((_l_index_ = typeDeserialize.TryReadIndex(_l_serdeInfo, out var _l_errorName)) != IDeserializeType.EndOfType)
                 {

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.SerdeInfoTests.RgbProxy.IDeserialize.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.SerdeInfoTests.RgbProxy.IDeserialize.cs
@@ -18,20 +18,20 @@ namespace Serde.Test
                 var _l_serdeInfo = global::Serde.SerdeInfoProvider.GetInfo<RgbProxy>();
                 var typeDeserialize = deserializer.ReadType(_l_serdeInfo);
                 int _l_index_;
-                while ((_l_index_ = typeDeserialize.TryReadIndex(_l_serdeInfo, out var _l_errorName)) != IDeserializeType.EndOfType)
+                while ((_l_index_ = typeDeserialize.TryReadIndex(_l_serdeInfo, out _)) != IDeserializeType.EndOfType)
                 {
                     switch (_l_index_)
                     {
                         case 0:
-                            _l_r = typeDeserialize.ReadValue<byte, global::Serde.ByteWrap>(_l_index_);
+                            _l_r = typeDeserialize.ReadByte(_l_index_);
                             _r_assignedValid |= ((byte)1) << 0;
                             break;
                         case 1:
-                            _l_g = typeDeserialize.ReadValue<byte, global::Serde.ByteWrap>(_l_index_);
+                            _l_g = typeDeserialize.ReadByte(_l_index_);
                             _r_assignedValid |= ((byte)1) << 1;
                             break;
                         case 2:
-                            _l_b = typeDeserialize.ReadValue<byte, global::Serde.ByteWrap>(_l_index_);
+                            _l_b = typeDeserialize.ReadByte(_l_index_);
                             _r_assignedValid |= ((byte)1) << 2;
                             break;
                         case Serde.IDeserializeType.IndexNotFound:

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.SerdeInfoTests.RgbProxy.IDeserialize.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.SerdeInfoTests.RgbProxy.IDeserialize.cs
@@ -16,7 +16,7 @@ namespace Serde.Test
                 byte _l_b = default !;
                 byte _r_assignedValid = 0;
                 var _l_serdeInfo = global::Serde.SerdeInfoProvider.GetInfo<RgbProxy>();
-                var typeDeserialize = deserializer.DeserializeType(_l_serdeInfo);
+                var typeDeserialize = deserializer.ReadType(_l_serdeInfo);
                 int _l_index_;
                 while ((_l_index_ = typeDeserialize.TryReadIndex(_l_serdeInfo, out var _l_errorName)) != IDeserializeType.EndOfType)
                 {

--- a/test/Serde.Xml.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.AllInOne.ColorEnumWrap.IDeserialize.cs
+++ b/test/Serde.Xml.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.AllInOne.ColorEnumWrap.IDeserialize.cs
@@ -12,7 +12,7 @@ namespace Serde.Test
             static Serde.Test.AllInOne.ColorEnum IDeserialize<Serde.Test.AllInOne.ColorEnum>.Deserialize(IDeserializer deserializer)
             {
                 var serdeInfo = global::Serde.SerdeInfoProvider.GetInfo<Serde.Test.AllInOne.ColorEnumWrap>();
-                var de = deserializer.DeserializeType(serdeInfo);
+                var de = deserializer.ReadType(serdeInfo);
                 int index;
                 if ((index = de.TryReadIndex(serdeInfo, out var errorName)) == IDeserializeType.IndexNotFound)
                 {

--- a/test/Serde.Xml.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.AllInOne.IDeserialize.cs
+++ b/test/Serde.Xml.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.AllInOne.IDeserialize.cs
@@ -28,7 +28,7 @@ namespace Serde.Test
             Serde.Test.AllInOne.ColorEnum _l_color = default !;
             uint _r_assignedValid = 0;
             var _l_serdeInfo = global::Serde.SerdeInfoProvider.GetInfo<AllInOne>();
-            var typeDeserialize = deserializer.DeserializeType(_l_serdeInfo);
+            var typeDeserialize = deserializer.ReadType(_l_serdeInfo);
             int _l_index_;
             while ((_l_index_ = typeDeserialize.TryReadIndex(_l_serdeInfo, out var _l_errorName)) != IDeserializeType.EndOfType)
             {

--- a/test/Serde.Xml.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.AllInOne.IDeserialize.cs
+++ b/test/Serde.Xml.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.AllInOne.IDeserialize.cs
@@ -30,56 +30,56 @@ namespace Serde.Test
             var _l_serdeInfo = global::Serde.SerdeInfoProvider.GetInfo<AllInOne>();
             var typeDeserialize = deserializer.ReadType(_l_serdeInfo);
             int _l_index_;
-            while ((_l_index_ = typeDeserialize.TryReadIndex(_l_serdeInfo, out var _l_errorName)) != IDeserializeType.EndOfType)
+            while ((_l_index_ = typeDeserialize.TryReadIndex(_l_serdeInfo, out _)) != IDeserializeType.EndOfType)
             {
                 switch (_l_index_)
                 {
                     case 0:
-                        _l_boolfield = typeDeserialize.ReadValue<bool, global::Serde.BoolWrap>(_l_index_);
+                        _l_boolfield = typeDeserialize.ReadBool(_l_index_);
                         _r_assignedValid |= ((uint)1) << 0;
                         break;
                     case 1:
-                        _l_charfield = typeDeserialize.ReadValue<char, global::Serde.CharWrap>(_l_index_);
+                        _l_charfield = typeDeserialize.ReadChar(_l_index_);
                         _r_assignedValid |= ((uint)1) << 1;
                         break;
                     case 2:
-                        _l_bytefield = typeDeserialize.ReadValue<byte, global::Serde.ByteWrap>(_l_index_);
+                        _l_bytefield = typeDeserialize.ReadByte(_l_index_);
                         _r_assignedValid |= ((uint)1) << 2;
                         break;
                     case 3:
-                        _l_ushortfield = typeDeserialize.ReadValue<ushort, global::Serde.UInt16Wrap>(_l_index_);
+                        _l_ushortfield = typeDeserialize.ReadU16(_l_index_);
                         _r_assignedValid |= ((uint)1) << 3;
                         break;
                     case 4:
-                        _l_uintfield = typeDeserialize.ReadValue<uint, global::Serde.UInt32Wrap>(_l_index_);
+                        _l_uintfield = typeDeserialize.ReadU32(_l_index_);
                         _r_assignedValid |= ((uint)1) << 4;
                         break;
                     case 5:
-                        _l_ulongfield = typeDeserialize.ReadValue<ulong, global::Serde.UInt64Wrap>(_l_index_);
+                        _l_ulongfield = typeDeserialize.ReadU64(_l_index_);
                         _r_assignedValid |= ((uint)1) << 5;
                         break;
                     case 6:
-                        _l_sbytefield = typeDeserialize.ReadValue<sbyte, global::Serde.SByteWrap>(_l_index_);
+                        _l_sbytefield = typeDeserialize.ReadSByte(_l_index_);
                         _r_assignedValid |= ((uint)1) << 6;
                         break;
                     case 7:
-                        _l_shortfield = typeDeserialize.ReadValue<short, global::Serde.Int16Wrap>(_l_index_);
+                        _l_shortfield = typeDeserialize.ReadI16(_l_index_);
                         _r_assignedValid |= ((uint)1) << 7;
                         break;
                     case 8:
-                        _l_intfield = typeDeserialize.ReadValue<int, global::Serde.Int32Wrap>(_l_index_);
+                        _l_intfield = typeDeserialize.ReadI32(_l_index_);
                         _r_assignedValid |= ((uint)1) << 8;
                         break;
                     case 9:
-                        _l_longfield = typeDeserialize.ReadValue<long, global::Serde.Int64Wrap>(_l_index_);
+                        _l_longfield = typeDeserialize.ReadI64(_l_index_);
                         _r_assignedValid |= ((uint)1) << 9;
                         break;
                     case 10:
-                        _l_stringfield = typeDeserialize.ReadValue<string, global::Serde.StringWrap>(_l_index_);
+                        _l_stringfield = typeDeserialize.ReadString(_l_index_);
                         _r_assignedValid |= ((uint)1) << 10;
                         break;
                     case 11:
-                        _l_escapedstringfield = typeDeserialize.ReadValue<string, global::Serde.StringWrap>(_l_index_);
+                        _l_escapedstringfield = typeDeserialize.ReadString(_l_index_);
                         _r_assignedValid |= ((uint)1) << 11;
                         break;
                     case 12:


### PR DESCRIPTION
This heavily improves performance by avoiding generic virtual dispatch in the common case of deserializing primitive types inside a struct.

After these changes, the performance difference between Serde and S.T.J is almost entirely eliminated:

```
| Method      | Mean       | Error   | StdDev  | Gen0   | Gen1   | Allocated |
|------------ |-----------:|--------:|--------:|-------:|-------:|----------:|
| JsonNet     | 1,032.3 ns | 2.80 ns | 2.48 ns | 0.4063 | 0.0019 |    3400 B |
| SystemText  |   617.0 ns | 3.14 ns | 2.62 ns | 0.0534 |      - |     448 B |
| SerdeJson   |   633.4 ns | 1.44 ns | 1.21 ns | 0.0963 |      - |     808 B |
| SerdeManual |   632.7 ns | 4.01 ns | 3.13 ns | 0.0963 |      - |     808 B |
```