### PR TITLE
Remove a GVM for deserializing nullable values

### DIFF
--- a/src/serde/Proxies.cs
+++ b/src/serde/Proxies.cs
@@ -376,25 +376,18 @@ public static class NullableProxy
         where T : struct
         where TProxy : IDeserialize<T>
     {
-        private readonly Visitor _visitor = new(proxy);
+        private readonly BoxProxy _boxProxy = new(proxy);
 
         public T? Deserialize(IDeserializer deserializer)
         {
-            return deserializer.ReadNullableRef(_visitor);
+            return (T?)deserializer.ReadNullableRef<object, BoxProxy>(_boxProxy);
         }
 
-        private sealed class Visitor(TProxy proxy) : IDeserializeVisitor<T?>
+        private sealed class BoxProxy(TProxy underlyingProxy) : IDeserialize<object>
         {
-            public string ExpectedTypeName => typeof(T).ToString() + "?";
-
-            T? IDeserializeVisitor<T?>.VisitNull()
+            public object Deserialize(IDeserializer deserializer)
             {
-                return null;
-            }
-
-            T? IDeserializeVisitor<T?>.VisitNotNull(IDeserializer d)
-            {
-                return proxy.Deserialize(d);
+                return underlyingProxy.Deserialize(deserializer);
             }
         }
     }
@@ -446,26 +439,9 @@ public static class NullableRefProxy
         where T : class
         where TProxy : IDeserialize<T>
     {
-        private readonly Visitor _visitor = new(proxy);
-
         public T? Deserialize(IDeserializer deserializer)
         {
-            return deserializer.ReadNullableRef(_visitor);
-        }
-
-        private sealed class Visitor(TProxy proxy) : IDeserializeVisitor<T?>
-        {
-            public string ExpectedTypeName => typeof(T).ToString() + "?";
-
-            T? IDeserializeVisitor<T?>.VisitNull()
-            {
-                return null;
-            }
-
-            T? IDeserializeVisitor<T?>.VisitNotNull(IDeserializer d)
-            {
-                return proxy.Deserialize(d);
-            }
+            return deserializer.ReadNullableRef<T, TProxy>(proxy);
         }
     }
 }

--- a/src/serde/json/JsonDeserializer.ReadAny.cs
+++ b/src/serde/json/JsonDeserializer.ReadAny.cs
@@ -1,0 +1,236 @@
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+using Serde.IO;
+using static Serde.Json.ThrowHelpers;
+
+namespace Serde.Json;
+
+internal sealed partial class JsonDeserializer<TReader> : IDeserializer
+    where TReader : IByteReader
+{
+    public T ReadAny<T>(IDeserializeVisitor<T> v)
+        where T : class
+    {
+        var peek = Reader.SkipWhitespace();
+        T result;
+        switch (ThrowIfEos(peek))
+        {
+            case (byte)'[':
+                result = ReadEnumerable(v);
+                break;
+
+            case (byte)'-' or (>= (byte)'0' and <= (byte)'9'):
+                var d = ReadDouble();
+                result = v.VisitDouble(d);
+                break;
+
+            case (byte)'{':
+                result = DeserializeDictionary(v);
+                break;
+
+            case (byte)'"':
+                result = VisitString(v);
+                break;
+
+            case (byte)'n' when Reader.StartsWith("null"u8):
+                Reader.Advance(4);
+                result = v.VisitNull();
+                break;
+
+            case (byte)'t' when Reader.StartsWith("true"u8):
+                Reader.Advance(4);
+                result = v.VisitBool(true);
+                break;
+
+            case (byte)'f' when Reader.StartsWith("false"u8):
+                Reader.Advance(5);
+                result = v.VisitBool(false);
+                break;
+
+            default:
+                throw new JsonException($"Could not deserialize '{(char)peek}");
+        }
+        return result;
+    }
+
+    private T VisitString<T>(IDeserializeVisitor<T> v)
+    {
+        var span = ReadUtf8Span();
+        return v.VisitUtf8Span(span);
+    }
+
+    public T? ReadNullableRef<T, TProxy>(TProxy proxy)
+        where T : class
+        where TProxy : IDeserialize<T>
+    {
+        var peek = Reader.SkipWhitespace();
+        switch (ThrowIfEos(peek))
+        {
+            case (byte)'n' when Reader.StartsWith("null"u8):
+                Reader.Advance(4);
+                return null;
+            default:
+                return proxy.Deserialize(this);
+        }
+    }
+
+    public bool ReadBool()
+    {
+        return Reader.GetBoolean();
+    }
+
+    public T DeserializeDictionary<T>(IDeserializeVisitor<T> v)
+    {
+        var peek = Reader.SkipWhitespace();
+
+        if (peek != (short)'{')
+        {
+            throw new JsonException("Expected object start");
+        }
+
+        Reader.Advance();
+        var map = new DeDictionary(this);
+        return v.VisitDictionary(ref map);
+    }
+
+    /// <summary>
+    /// Expects to be one byte after '['
+    /// </summary>
+    private T ReadEnumerable<T>(IDeserializeVisitor<T> v)
+    {
+        var peek = Reader.Peek();
+        if (peek != (byte)'[')
+        {
+            throw new JsonException("Expected array start");
+        }
+        Reader.Advance();
+
+        var enumerable = new DeEnumerable(this);
+        return v.VisitEnumerable(ref enumerable);
+    }
+
+    private struct DeEnumerable : IDeserializeEnumerable
+    {
+        private JsonDeserializer<TReader> _deserializer;
+        private bool _first = true;
+        public DeEnumerable(JsonDeserializer<TReader> de)
+        {
+            _deserializer = de;
+        }
+        public int? SizeOpt => null;
+
+        public bool TryGetNext<T, TProxy>(TProxy proxy, [MaybeNullWhen(false)] out T next)
+            where TProxy : IDeserialize<T>
+        {
+            while (true)
+            {
+                var peek = _deserializer.Reader.SkipWhitespace();
+                if (peek == (short)',')
+                {
+                    if (_first)
+                    {
+                        throw new JsonException("Unexpected comma before first element");
+                    }
+                    _deserializer.Reader.Advance();
+                    peek = _deserializer.Reader.SkipWhitespace();
+                }
+
+                switch (peek)
+                {
+                    case IByteReader.EndOfStream:
+                        throw new JsonException("Unexpected end of stream");
+
+                    case (short)']':
+                        _deserializer.Reader.Advance();
+                        next = default;
+                        return false;
+
+                    default:
+                        _first = false;
+                        next = proxy.Deserialize(_deserializer);
+                        return true;
+                }
+            }
+        }
+    }
+
+    private struct DeDictionary : IDeserializeDictionary
+    {
+        private JsonDeserializer<TReader> _deserializer;
+        private bool _first = true;
+        public DeDictionary(JsonDeserializer<TReader> de)
+        {
+            _deserializer = de;
+        }
+
+        public int? SizeOpt => null;
+
+        public bool TryGetNextEntry<K, V, DK, DV>(DK dk, DV dv, [MaybeNullWhen(false)] out (K, V) next)
+            where DK : IDeserialize<K>
+            where DV : IDeserialize<V>
+        {
+            // Don't save state
+            if (!TryGetNextKey<K, DK>(dk, out K? nextKey))
+            {
+                next = default;
+                return false;
+            }
+            var nextValue = GetNextValue<V, DV>(dv);
+            next = (nextKey, nextValue);
+            return true;
+        }
+
+        public bool TryGetNextKey<K, D>(D d, [MaybeNullWhen(false)] out K next)
+            where D : IDeserialize<K>
+        {
+            while (true)
+            {
+                var peek = _deserializer.Reader.SkipWhitespace();
+
+                if (peek == (short)',')
+                {
+                    if (_first)
+                    {
+                        throw new JsonException("Unexpected comma before first element");
+                    }
+                    _deserializer.Reader.Advance();
+                    peek = _deserializer.Reader.SkipWhitespace();
+                }
+
+                switch (peek)
+                {
+                    case IByteReader.EndOfStream:
+                        throw new JsonException("Unexpected end of stream");
+
+                    case (short)'}':
+                        // Check if the next token is the end of the object, but don't advance the stream if not
+                        _deserializer.Reader.Advance();
+                        next = default;
+                        _first = false;
+                        return false;
+
+                    case (short)'"':
+                        next = d.Deserialize(_deserializer);
+                        _first = false;
+                        return true;
+
+                    default:
+                        throw new JsonException("Expected property name, found: " + (char)peek);
+                }
+            }
+        }
+
+        public V GetNextValue<V, D>(D d) where D : IDeserialize<V>
+        {
+            var peek = ThrowIfEos(_deserializer.Reader.SkipWhitespace());
+            if (peek != (byte)':')
+            {
+                throw new JsonException("Expected ':'");
+            }
+            _deserializer.Reader.Advance();
+            return d.Deserialize(_deserializer);
+        }
+    }
+
+}

--- a/src/serde/json/JsonDeserializer.cs
+++ b/src/serde/json/JsonDeserializer.cs
@@ -47,190 +47,6 @@ internal sealed partial class JsonDeserializer<TReader> : IDeserializer
         _scratch = new ScratchBuffer();
     }
 
-    public T ReadAny<T>(IDeserializeVisitor<T> v)
-    {
-        var peek = Reader.SkipWhitespace();
-        T result;
-        switch (ThrowIfEos(peek))
-        {
-            case (byte)'[':
-                result = ReadEnumerable(v);
-                break;
-
-            case (byte)'-' or (>= (byte)'0' and <= (byte)'9'):
-                var d = ReadDouble();
-                result = v.VisitDouble(d);
-                break;
-
-            case (byte)'{':
-                result = DeserializeDictionary(v);
-                break;
-
-            case (byte)'"':
-                result = VisitString(v);
-                break;
-
-            case (byte)'n' when Reader.StartsWith("null"u8):
-                Reader.Advance(4);
-                result = v.VisitNull();
-                break;
-
-            case (byte)'t' when Reader.StartsWith("true"u8):
-                Reader.Advance(4);
-                result = v.VisitBool(true);
-                break;
-
-            case (byte)'f' when Reader.StartsWith("false"u8):
-                Reader.Advance(5);
-                result = v.VisitBool(false);
-                break;
-
-            default:
-                throw new JsonException($"Could not deserialize '{(char)peek}");
-        }
-        return result;
-    }
-
-    private T VisitString<T>(IDeserializeVisitor<T> v)
-    {
-        var span = ReadUtf8Span();
-        return v.VisitUtf8Span(span);
-    }
-
-    public T ReadNullableRef<T>(IDeserializeVisitor<T> v)
-    {
-        var peek = Reader.SkipWhitespace();
-        switch (ThrowIfEos(peek))
-        {
-            case (byte)'n' when Reader.StartsWith("null"u8):
-                Reader.Advance(4);
-                return v.VisitNull();
-            default:
-                return v.VisitNotNull(this);
-        }
-    }
-
-
-    public bool ReadBool()
-    {
-        return Reader.GetBoolean();
-    }
-
-    public T DeserializeDictionary<T>(IDeserializeVisitor<T> v)
-    {
-        var peek = Reader.SkipWhitespace();
-
-        if (peek != (short)'{')
-        {
-            throw new JsonException("Expected object start");
-        }
-
-        Reader.Advance();
-        var map = new DeDictionary(this);
-        return v.VisitDictionary(ref map);
-    }
-
-    public IDeserializeCollection ReadCollection(ISerdeInfo typeInfo)
-    {
-        var kind = typeInfo.Kind;
-        if (kind is not (InfoKind.Enumerable or InfoKind.Dictionary))
-        {
-            throw new ArgumentException($"TypeKind is {typeInfo.Kind}, expected Enumerable or Dictionary");
-        }
-        switch ((ThrowIfEos(Reader.SkipWhitespace()), kind))
-        {
-            case ((byte)'[', InfoKind.Enumerable):
-            case ((byte)'{', InfoKind.Dictionary):
-                Reader.Advance();
-                break;
-            case (_, InfoKind.Enumerable):
-                throw new JsonException("Expected array start");
-            case (_, InfoKind.Dictionary):
-                throw new JsonException("Expected object start");
-        }
-
-        return new DeCollection(this);
-    }
-
-    private struct DeCollection : IDeserializeCollection
-    {
-        private JsonDeserializer<TReader> _deserializer;
-        private bool _first = true;
-        private bool _afterKey = false;
-
-        public DeCollection(JsonDeserializer<TReader> de)
-        {
-            _deserializer = de;
-        }
-
-        public int? SizeOpt => null;
-
-        public bool TryReadValue<T, TProxy>(ISerdeInfo typeInfo, TProxy d, [MaybeNullWhen(false)] out T next)
-            where TProxy : IDeserialize<T>
-        {
-            var peek = ThrowIfEos(_deserializer.Reader.SkipWhitespace());
-            if (peek == (short)',')
-            {
-                if (_first)
-                {
-                    throw new JsonException("Unexpected comma before first element");
-                }
-                if (_afterKey)
-                {
-                    throw new JsonException("Unexpected comma after key");
-                }
-                _deserializer.Reader.Advance();
-                peek = ThrowIfEos(_deserializer.Reader.SkipWhitespace());
-            }
-
-            if (_afterKey && peek != (short)':' && typeInfo.Kind == InfoKind.Dictionary)
-            {
-                throw new JsonException("Expected ':' after key");
-            }
-
-            if (peek == (short)':')
-            {
-                if (typeInfo.Kind == InfoKind.Enumerable)
-                {
-                    throw new JsonException("Unexpected ':' in array");
-                }
-                if (_first || !_afterKey)
-                {
-                    throw new JsonException("Unexpected ':' before key");
-                }
-                _deserializer.Reader.Advance();
-                peek = ThrowIfEos(_deserializer.Reader.SkipWhitespace());
-            }
-
-            switch (peek)
-            {
-                case (byte)']' when typeInfo.Kind == InfoKind.Enumerable:
-                    _deserializer.Reader.Advance();
-                    next = default;
-                    return false;
-
-                case (byte)'}':
-                    if (typeInfo.Kind != InfoKind.Dictionary)
-                    {
-                        throw new JsonException("Unexpected '}' in array");
-                    }
-                    if (_afterKey)
-                    {
-                        throw new JsonException("Expected object value, found '}'");
-                    }
-                    _deserializer.Reader.Advance();
-                    next = default;
-                    return false;
-
-                default:
-                    next = d.Deserialize(_deserializer);
-                    _first = false;
-                    _afterKey = typeInfo.Kind == InfoKind.Dictionary && !_afterKey;
-                    return true;
-            }
-        }
-    }
-
     public float ReadFloat() => Convert.ToSingle(ReadDouble());
 
     public double ReadDouble()
@@ -245,145 +61,6 @@ internal sealed partial class JsonDeserializer<TReader> : IDeserializer
         _ = ThrowIfEos(Reader.SkipWhitespace());
         _scratch.Clear();
         return Reader.GetDecimal(_scratch);
-    }
-
-    /// <summary>
-    /// Expects to be one byte after '['
-    /// </summary>
-    private T ReadEnumerable<T>(IDeserializeVisitor<T> v)
-    {
-        var peek = Reader.Peek();
-        if (peek != (byte)'[')
-        {
-            throw new JsonException("Expected array start");
-        }
-        Reader.Advance();
-
-        var enumerable = new DeEnumerable(this);
-        return v.VisitEnumerable(ref enumerable);
-    }
-
-    private struct DeEnumerable : IDeserializeEnumerable
-    {
-        private JsonDeserializer<TReader> _deserializer;
-        private bool _first = true;
-        public DeEnumerable(JsonDeserializer<TReader> de)
-        {
-            _deserializer = de;
-        }
-        public int? SizeOpt => null;
-
-        public bool TryGetNext<T, TProxy>(TProxy proxy, [MaybeNullWhen(false)] out T next)
-            where TProxy : IDeserialize<T>
-        {
-            while (true)
-            {
-                var peek = _deserializer.Reader.SkipWhitespace();
-                if (peek == (short)',')
-                {
-                    if (_first)
-                    {
-                        throw new JsonException("Unexpected comma before first element");
-                    }
-                    _deserializer.Reader.Advance();
-                    peek = _deserializer.Reader.SkipWhitespace();
-                }
-
-                switch (peek)
-                {
-                    case IByteReader.EndOfStream:
-                        throw new JsonException("Unexpected end of stream");
-
-                    case (short)']':
-                        _deserializer.Reader.Advance();
-                        next = default;
-                        return false;
-
-                    default:
-                        _first = false;
-                        next = proxy.Deserialize(_deserializer);
-                        return true;
-                }
-            }
-        }
-    }
-
-    private struct DeDictionary : IDeserializeDictionary
-    {
-        private JsonDeserializer<TReader> _deserializer;
-        private bool _first = true;
-        public DeDictionary(JsonDeserializer<TReader> de)
-        {
-            _deserializer = de;
-        }
-
-        public int? SizeOpt => null;
-
-        public bool TryGetNextEntry<K, V, DK, DV>(DK dk, DV dv, [MaybeNullWhen(false)] out (K, V) next)
-            where DK : IDeserialize<K>
-            where DV : IDeserialize<V>
-        {
-            // Don't save state
-            if (!TryGetNextKey<K, DK>(dk, out K? nextKey))
-            {
-                next = default;
-                return false;
-            }
-            var nextValue = GetNextValue<V, DV>(dv);
-            next = (nextKey, nextValue);
-            return true;
-        }
-
-        public bool TryGetNextKey<K, D>(D d, [MaybeNullWhen(false)] out K next)
-            where D : IDeserialize<K>
-        {
-            while (true)
-            {
-                var peek = _deserializer.Reader.SkipWhitespace();
-
-                if (peek == (short)',')
-                {
-                    if (_first)
-                    {
-                        throw new JsonException("Unexpected comma before first element");
-                    }
-                    _deserializer.Reader.Advance();
-                    peek = _deserializer.Reader.SkipWhitespace();
-                }
-
-                switch (peek)
-                {
-                    case IByteReader.EndOfStream:
-                        throw new JsonException("Unexpected end of stream");
-
-                    case (short)'}':
-                        // Check if the next token is the end of the object, but don't advance the stream if not
-                        _deserializer.Reader.Advance();
-                        next = default;
-                        _first = false;
-                        return false;
-
-                    case (short)'"':
-                        next = d.Deserialize(_deserializer);
-                        _first = false;
-                        return true;
-
-                    default:
-                        throw new JsonException("Expected property name, found: " + (char)peek);
-                }
-            }
-        }
-
-        public V GetNextValue<V, D>(D d) where D : IDeserialize<V>
-        {
-            var peek = ThrowIfEos(_deserializer.Reader.SkipWhitespace());
-            if (peek != (byte)':')
-            {
-                throw new JsonException("Expected ':'");
-            }
-            _deserializer.Reader.Advance();
-            return d.Deserialize(_deserializer);
-        }
     }
 
     public sbyte ReadSByte() => Convert.ToSByte(ReadI64());
@@ -561,6 +238,107 @@ partial class JsonDeserializer<TReader> : IDeserializeType
     {
         ReadColon();
         Reader.Skip();
+    }
+
+    public IDeserializeCollection ReadCollection(ISerdeInfo typeInfo)
+    {
+        var kind = typeInfo.Kind;
+        if (kind is not (InfoKind.Enumerable or InfoKind.Dictionary))
+        {
+            throw new ArgumentException($"TypeKind is {typeInfo.Kind}, expected Enumerable or Dictionary");
+        }
+        switch ((ThrowIfEos(Reader.SkipWhitespace()), kind))
+        {
+            case ((byte)'[', InfoKind.Enumerable):
+            case ((byte)'{', InfoKind.Dictionary):
+                Reader.Advance();
+                break;
+            case (_, InfoKind.Enumerable):
+                throw new JsonException("Expected array start");
+            case (_, InfoKind.Dictionary):
+                throw new JsonException("Expected object start");
+        }
+
+        return new DeCollection(this);
+    }
+
+    private struct DeCollection : IDeserializeCollection
+    {
+        private JsonDeserializer<TReader> _deserializer;
+        private bool _first = true;
+        private bool _afterKey = false;
+
+        public DeCollection(JsonDeserializer<TReader> de)
+        {
+            _deserializer = de;
+        }
+
+        public int? SizeOpt => null;
+
+        public bool TryReadValue<T, TProxy>(ISerdeInfo typeInfo, TProxy d, [MaybeNullWhen(false)] out T next)
+            where TProxy : IDeserialize<T>
+        {
+            var peek = ThrowIfEos(_deserializer.Reader.SkipWhitespace());
+            if (peek == (short)',')
+            {
+                if (_first)
+                {
+                    throw new JsonException("Unexpected comma before first element");
+                }
+                if (_afterKey)
+                {
+                    throw new JsonException("Unexpected comma after key");
+                }
+                _deserializer.Reader.Advance();
+                peek = ThrowIfEos(_deserializer.Reader.SkipWhitespace());
+            }
+
+            if (_afterKey && peek != (short)':' && typeInfo.Kind == InfoKind.Dictionary)
+            {
+                throw new JsonException("Expected ':' after key");
+            }
+
+            if (peek == (short)':')
+            {
+                if (typeInfo.Kind == InfoKind.Enumerable)
+                {
+                    throw new JsonException("Unexpected ':' in array");
+                }
+                if (_first || !_afterKey)
+                {
+                    throw new JsonException("Unexpected ':' before key");
+                }
+                _deserializer.Reader.Advance();
+                peek = ThrowIfEos(_deserializer.Reader.SkipWhitespace());
+            }
+
+            switch (peek)
+            {
+                case (byte)']' when typeInfo.Kind == InfoKind.Enumerable:
+                    _deserializer.Reader.Advance();
+                    next = default;
+                    return false;
+
+                case (byte)'}':
+                    if (typeInfo.Kind != InfoKind.Dictionary)
+                    {
+                        throw new JsonException("Unexpected '}' in array");
+                    }
+                    if (_afterKey)
+                    {
+                        throw new JsonException("Expected object value, found '}'");
+                    }
+                    _deserializer.Reader.Advance();
+                    next = default;
+                    return false;
+
+                default:
+                    next = d.Deserialize(_deserializer);
+                    _first = false;
+                    _afterKey = typeInfo.Kind == InfoKind.Dictionary && !_afterKey;
+                    return true;
+            }
+        }
     }
 
     int IDeserializeType.TryReadIndex(ISerdeInfo serdeInfo, out string? errorName)


### PR DESCRIPTION
GVMs (Generic Virtual Methods) can cause large code size increases in AOT. Because all reference types share a single code implementation, generics constrained to class don't have this downside. This change removes a GVM for deserializing nullable types, which includes nullable structs. Instead, deserializing nullable structs will box.