### PR TITLE
Add support for primary constructors

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,6 +5,6 @@
     <Deterministic>true</Deterministic>
     <TestTfm>net8.0</TestTfm>
     <SerdeAssemblyVersion>0.8.0</SerdeAssemblyVersion>
-    <SerdePkgVersion>0.8.0-preview1</SerdePkgVersion>
+    <SerdePkgVersion>0.8.0-preview2</SerdePkgVersion>
   </PropertyGroup>
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -10,8 +10,8 @@
     <PackageVersion Include="FsCheck.Xunit" Version="2.16.6" />
     <PackageVersion Include="NuGetizer" Version="1.2.3" />
     <PackageVersion Include="StaticCs" Version="0.2.0" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.6.0-1.final" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.6.0-1.final" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.6.0" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.6.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Analyzer.Testing" Version="1.1.2" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.SourceGenerators.Testing" Version="1.1.2" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="16.8.0" />

--- a/src/generator/ConfigOptions.cs
+++ b/src/generator/ConfigOptions.cs
@@ -8,7 +8,6 @@ internal record TypeOptions
 {
     public bool DenyUnknownMembers { get; init; } = false;
     public MemberFormat MemberFormat { get; init; } = MemberFormat.CamelCase;
-    public ITypeSymbol? ConstructorSignature { get; init; } = null;
     public bool SerializeNull { get; init; } = false;
 }
 

--- a/src/generator/Diagnostics.cs
+++ b/src/generator/Diagnostics.cs
@@ -14,7 +14,7 @@ namespace Serde
         ERR_DoesntImplementInterface = 1,
         ERR_TypeNotPartial = 2,
         ERR_CantWrapSpecialType = 3,
-        ERR_CantFindConstructorSignature = 4,
+        ERR_MissingPrimaryCtor = 4,
         ERR_CantFindNestedWrapper = 5,
         ERR_WrapperDoesntImplementInterface = 6,
     }
@@ -26,7 +26,7 @@ namespace Serde
             ERR_DoesntImplementInterface => nameof(ERR_DoesntImplementInterface),
             ERR_TypeNotPartial => nameof(ERR_TypeNotPartial),
             ERR_CantWrapSpecialType => nameof(ERR_CantWrapSpecialType),
-            ERR_CantFindConstructorSignature => nameof(ERR_CantFindConstructorSignature),
+            ERR_MissingPrimaryCtor => nameof(ERR_MissingPrimaryCtor),
             ERR_CantFindNestedWrapper => nameof(ERR_CantFindNestedWrapper),
             ERR_WrapperDoesntImplementInterface => nameof(ERR_WrapperDoesntImplementInterface),
         };

--- a/src/generator/Generator.Deserialize.cs
+++ b/src/generator/Generator.Deserialize.cs
@@ -333,7 +333,7 @@ namespace Serde
             if (parameterlessCtor is null && primaryCtor is null)
             {
                 context.ReportDiagnostic(CreateDiagnostic(DiagId.ERR_MissingPrimaryCtor, type.Locations[0]));
-                return "";
+                return $"var newType = new {typeName}();";
             }
 
             var assignmentMembers = new List<DataMemberSymbol>(members);

--- a/src/generator/Generator.Deserialize.cs
+++ b/src/generator/Generator.Deserialize.cs
@@ -299,8 +299,7 @@ namespace Serde
         /// <summary>
         /// If the type has a parameterless constructor then we will use that and just set
         /// each member in the initializer. If there is no parameterlss constructor, there
-        /// must be a constructor signature as specified by the ConstructorSignature property
-        /// in the SerdeTypeOptions.
+        /// must be a primary constructor.
         /// </summary>
         private static string GenerateTypeCreation(
             GeneratorExecutionContext context,
@@ -309,56 +308,40 @@ namespace Serde
             List<DataMemberSymbol> members,
             string assignedMask)
         {
-            var targetSignature = SymbolUtilities.GetTypeOptions(type).ConstructorSignature;
-            var targetTuple = targetSignature as INamedTypeSymbol;
-            var ctors = type.GetMembers(".ctor");
-            IMethodSymbol? targetCtor = null;
-            IMethodSymbol? parameterLessCtor = null;
-            foreach (var ctorSymbol in ctors)
+            IMethodSymbol? primaryCtor = null;
+            IMethodSymbol? parameterlessCtor = null;
+            if (type is INamedTypeSymbol named)
             {
-                if (ctorSymbol is IMethodSymbol ctorMethod)
+                foreach (var ctor in named.InstanceConstructors)
                 {
-                    if (targetTuple is not null && ctorMethod.Parameters.Length == targetTuple.TupleElements.Length)
+                    foreach (var syntaxRef in ctor.DeclaringSyntaxReferences)
                     {
-                        bool mismatch = false;
-                        for(int i = 0; i < targetTuple.TupleElements.Length; i++)
+                        var syntax = syntaxRef.GetSyntax();
+                        if (syntax is TypeDeclarationSyntax)
                         {
-                            var elem = targetTuple.TupleElements[i];
-                            var param = ctorMethod.Parameters[i];
-                            if (!elem.Type.Equals(param.Type, SymbolEqualityComparer.Default))
-                            {
-                                mismatch = true;
-                                break;
-                            }
-                        }
-                        if (!mismatch)
-                        {
-                            targetCtor = ctorMethod;
-                            break;
+                            primaryCtor = ctor;
                         }
                     }
-                    if (ctorMethod is { Parameters.Length: 0 })
+                    if (ctor.Parameters.Length == 0)
                     {
-                        parameterLessCtor = ctorMethod;
-                        if (targetSignature is null)
-                        {
-                            break;
-                        }
+                        parameterlessCtor = ctor;
+                        break;
                     }
                 }
             }
-            if (targetSignature is not null && targetCtor is null)
+
+            if (parameterlessCtor is null && primaryCtor is null)
             {
-                context.ReportDiagnostic(CreateDiagnostic(DiagId.ERR_CantFindConstructorSignature, type.Locations[0]));
+                context.ReportDiagnostic(CreateDiagnostic(DiagId.ERR_MissingPrimaryCtor, type.Locations[0]));
                 return "";
             }
 
             var assignmentMembers = new List<DataMemberSymbol>(members);
             var assignments = new StringBuilder();
             var parameters = new StringBuilder();
-            if (targetCtor is not null)
+            if (primaryCtor is not null)
             {
-                foreach (var p in targetCtor.Parameters)
+                foreach (var p in primaryCtor.Parameters)
                 {
                     var index = assignmentMembers.FindIndex(m => m.Name == p.Name);
                     if (parameters.Length != 0)

--- a/src/generator/HelpersAndUtilities/SymbolUtilities.cs
+++ b/src/generator/HelpersAndUtilities/SymbolUtilities.cs
@@ -155,11 +155,6 @@ namespace Serde
                                     Type.SpecialType: SpecialType.System_Boolean
                                 }
                             ) => options with { DenyUnknownMembers = (bool)value },
-                            ( nameof(TypeOptions.ConstructorSignature),
-                                {
-                                    Kind: TypedConstantKind.Type,
-                                }
-                            ) => options with { ConstructorSignature = (ITypeSymbol)value },
                             _ => options
                         };
                     }

--- a/src/generator/Resources.resx
+++ b/src/generator/Resources.resx
@@ -126,8 +126,8 @@
   <data name="ERR_CantWrapSpecialType" xml:space="preserve">
     <value>The type '{0}' can't be automatically wrapped because it is a built-in type.</value>
   </data>
-  <data name="ERR_CantFindConstructorSignature" xml:space="preserve">
-    <value>Could not find a constructor with the target signature listed by the ConstructorSignature parameter.</value>
+  <data name="ERR_MissingPrimaryCtor" xml:space="preserve">
+    <value>Type must have either a primary constructor or a parameterless constructor.</value>
   </data>
   <data name="ERR_CantFindNestedWrapper" xml:space="preserve">
     <value>Could not find nested type named '{0}' inside type '{1}'. The proxied type '{2}' is generic, so the expected proxy is a parent type with Serialize and Deserialize nested proxies.</value>

--- a/src/serde/Attributes.cs
+++ b/src/serde/Attributes.cs
@@ -92,12 +92,6 @@ sealed class SerdeTypeOptions : Attribute
     public MemberFormat MemberFormat { get; init; } = MemberFormat.CamelCase;
 
     /// <summary>
-    /// Pick the constructor used for deserialization. Expects a tuple with the same types as
-    /// the desired parameter list of the desired constructor.
-    /// </summary>
-    public Type? ConstructorSignature { get; init; }
-
-    /// <summary>
     /// The default behavior for null is to skip serialization. Set this to true to force
     /// serialization.
     /// </summary>

--- a/test/Serde.Generation.Test/DeserializeTests.cs
+++ b/test/Serde.Generation.Test/DeserializeTests.cs
@@ -201,6 +201,21 @@ partial class A
             return VerifyDeserialize(src);
         }
 
+        [Fact]
+        public Task NoParameterlessOrPrimaryCtor()
+        {
+            var src = """
+using Serde;
+[GenerateDeserialize]
+partial class C
+{
+    public int A;
+    public C(int A) { A = this.A; }
+}
+""";
+            return VerifyDeserialize(src);
+        }
+
         private static Task VerifyDeserialize(
             string src,
             [CallerMemberName] string caller = "")

--- a/test/Serde.Generation.Test/WrapperTests.cs
+++ b/test/Serde.Generation.Test/WrapperTests.cs
@@ -253,7 +253,6 @@ partial class C
 using Serde;
 
 [GenerateDeserialize]
-[SerdeTypeOptions(ConstructorSignature = typeof((int, string)))]
 partial record R(int A, string B);
 """;
             return VerifyGeneratedCode(src, "R.IDeserialize", """

--- a/test/Serde.Generation.Test/test_output/DeserializeTests/NoParameterlessOrPrimaryCtor#C.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/DeserializeTests/NoParameterlessOrPrimaryCtor#C.IDeserialize.verified.cs
@@ -1,0 +1,45 @@
+﻿//HintName: C.IDeserialize.cs
+
+#nullable enable
+using System;
+using Serde;
+
+partial class C : Serde.IDeserializeProvider<C>
+{
+    static IDeserialize<C> IDeserializeProvider<C>.DeserializeInstance => CDeserializeProxy.Instance;
+
+    sealed class CDeserializeProxy : Serde.IDeserialize<C>
+    {
+        C Serde.IDeserialize<C>.Deserialize(IDeserializer deserializer)
+        {
+            int _l_a = default !;
+            byte _r_assignedValid = 0;
+            var _l_serdeInfo = global::Serde.SerdeInfoProvider.GetInfo<C>();
+            var typeDeserialize = deserializer.ReadType(_l_serdeInfo);
+            int _l_index_;
+            while ((_l_index_ = typeDeserialize.TryReadIndex(_l_serdeInfo, out _)) != IDeserializeType.EndOfType)
+            {
+                switch (_l_index_)
+                {
+                    case 0:
+                        _l_a = typeDeserialize.ReadI32(_l_index_);
+                        _r_assignedValid |= ((byte)1) << 0;
+                        break;
+                    case Serde.IDeserializeType.IndexNotFound:
+                        typeDeserialize.SkipValue();
+                        break;
+                    default:
+                        throw new InvalidOperationException("Unexpected index: " + _l_index_);
+                }
+            }
+
+            var newType = new C();
+            return newType;
+        }
+
+        public static readonly CDeserializeProxy Instance = new();
+        private CDeserializeProxy()
+        {
+        }
+    }
+}

--- a/test/Serde.Generation.Test/test_output/DeserializeTests/NoParameterlessOrPrimaryCtor#C.ISerdeInfoProvider.verified.cs
+++ b/test/Serde.Generation.Test/test_output/DeserializeTests/NoParameterlessOrPrimaryCtor#C.ISerdeInfoProvider.verified.cs
@@ -1,0 +1,12 @@
+﻿//HintName: C.ISerdeInfoProvider.cs
+
+#nullable enable
+partial class C : Serde.ISerdeInfoProvider
+{
+    static global::Serde.ISerdeInfo global::Serde.ISerdeInfoProvider.SerdeInfo { get; } = Serde.SerdeInfo.MakeCustom(
+        "C",
+        typeof(C).GetCustomAttributesData(),
+        new (string, global::Serde.ISerdeInfo, System.Reflection.MemberInfo)[] {
+("a", global::Serde.SerdeInfoProvider.GetInfo<global::Serde.Int32Proxy>(), typeof(C).GetField("A")!)
+    });
+}

--- a/test/Serde.Generation.Test/test_output/DeserializeTests/NoParameterlessOrPrimaryCtor#FinalDiagnostics.verified.txt
+++ b/test/Serde.Generation.Test/test_output/DeserializeTests/NoParameterlessOrPrimaryCtor#FinalDiagnostics.verified.txt
@@ -1,0 +1,13 @@
+﻿[
+  {
+    "Id": "CS7036",
+    "Title": "",
+    "Severity": "Error",
+    "WarningLevel": "0",
+    "Location": "SerdeGenerator/Serde.SerdeImplRoslynGenerator/C.IDeserialize.cs: (34,30)-(34,31)",
+    "HelpLink": "https://msdn.microsoft.com/query/roslyn.query?appId=roslyn&k=k(CS7036)",
+    "MessageFormat": "There is no argument given that corresponds to the required parameter '{0}' of '{1}'",
+    "Message": "There is no argument given that corresponds to the required parameter 'A' of 'C.C(int)'",
+    "Category": "Compiler"
+  }
+]

--- a/test/Serde.Generation.Test/test_output/DeserializeTests/NoParameterlessOrPrimaryCtor.verified.txt
+++ b/test/Serde.Generation.Test/test_output/DeserializeTests/NoParameterlessOrPrimaryCtor.verified.txt
@@ -1,0 +1,14 @@
+﻿{
+  Diagnostics: [
+    {
+      Id: ERR_MissingPrimaryCtor,
+      Title: ,
+      Severity: Error,
+      WarningLevel: 0,
+      Location: : (2,14)-(2,15),
+      MessageFormat: Type must have either a primary constructor or a parameterless constructor.,
+      Message: Type must have either a primary constructor or a parameterless constructor.,
+      Category: Serde
+    }
+  ]
+}


### PR DESCRIPTION
Currently only parameterless constructors are supported for deserialization. This PR adds support for primary constructors as well.