### PR TITLE
azsdhTreat cases like fields in union

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -9,7 +9,7 @@
     <PackageVersion Include="FsCheck" Version="2.16.6" />
     <PackageVersion Include="FsCheck.Xunit" Version="2.16.6" />
     <PackageVersion Include="NuGetizer" Version="1.2.3" />
-    <PackageVersion Include="StaticCs" Version="0.2.0" />
+    <PackageVersion Include="StaticCs" Version="0.3.1" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.6.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.6.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Analyzer.Testing" Version="1.1.2" />

--- a/src/serde/ISerdeInfo.cs
+++ b/src/serde/ISerdeInfo.cs
@@ -128,6 +128,10 @@ public static class SerdeInfo
         string typeName)
         => new CollectionInfo(typeName, InfoKind.Dictionary);
 
+    /// <summary>
+    /// Make an ISerdeInfo that represents a union. Each case is represented as a field, meaning
+    /// that each index corresponds to a case.
+    /// </summary>
     public static IUnionSerdeInfo MakeUnion(
         string typeName,
         IList<CustomAttributeData> typeAttributes,
@@ -348,14 +352,9 @@ file sealed class UnionSerdeInfo(
     public int FieldCount => caseInfos.Length;
 
     public IList<CustomAttributeData> GetFieldAttributes(int index)
-    {
-        throw new NotImplementedException();
-    }
+        => caseInfos[index].Attributes;
 
-    public ISerdeInfo GetFieldInfo(int index)
-    {
-        throw new NotImplementedException();
-    }
+    public ISerdeInfo GetFieldInfo(int index) => caseInfos[index];
 
     /// <summary>
     /// The field name for a union is the name of the case.

--- a/test/Serde.Test/Serde.Test.csproj
+++ b/test/Serde.Test/Serde.Test.csproj
@@ -20,6 +20,10 @@
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzer.Testing" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.SourceGenerators.Testing" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="StaticCS">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
     <PackageReference Include="xunit" />
     <PackageReference Include="xunit.runner.visualstudio">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.SerdeInfoTests.UnionBase.IDeserialize.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.SerdeInfoTests.UnionBase.IDeserialize.cs
@@ -1,0 +1,43 @@
+
+#nullable enable
+
+using System;
+using Serde;
+
+namespace Serde.Test;
+
+partial class SerdeInfoTests
+{
+    partial record UnionBase : Serde.IDeserializeProvider<Serde.Test.SerdeInfoTests.UnionBase>
+    {
+        static IDeserialize<Serde.Test.SerdeInfoTests.UnionBase> IDeserializeProvider<Serde.Test.SerdeInfoTests.UnionBase>.DeserializeInstance
+            => UnionBaseDeserializeProxy.Instance;
+
+        sealed partial class UnionBaseDeserializeProxy : global::Serde.IDeserialize<Serde.Test.SerdeInfoTests.UnionBase>
+        {
+            Serde.Test.SerdeInfoTests.UnionBase IDeserialize<Serde.Test.SerdeInfoTests.UnionBase>.Deserialize(IDeserializer deserializer)
+            {
+                var serdeInfo = global::Serde.SerdeInfoProvider.GetInfo<Serde.Test.SerdeInfoTests.UnionBase>();
+                var de = deserializer.ReadType(serdeInfo);
+                int index;
+                if ((index = de.TryReadIndex(serdeInfo, out var errorName)) == IDeserializeType.IndexNotFound)
+                {
+                    throw Serde.DeserializeException.UnknownMember(errorName!, serdeInfo);
+                }
+                Serde.Test.SerdeInfoTests.UnionBase _l_result = index switch {
+                    0 => de.ReadValue<Serde.Test.SerdeInfoTests.UnionBase.A, _m_AProxy>(0),
+                    1 => de.ReadValue<Serde.Test.SerdeInfoTests.UnionBase.B, _m_BProxy>(1),
+
+                    _ => throw new InvalidOperationException($"Unexpected index: {index}")
+                };
+                if ((index = de.TryReadIndex(serdeInfo, out _)) != IDeserializeType.EndOfType)
+                {
+                    throw Serde.DeserializeException.ExpectedEndOfType(index);
+                }
+                return _l_result;
+            }public static readonly UnionBaseDeserializeProxy Instance = new();
+            private UnionBaseDeserializeProxy() { }
+
+        }
+    }
+}

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.SerdeInfoTests.UnionBase.ISerdeInfoProvider.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.SerdeInfoTests.UnionBase.ISerdeInfoProvider.cs
@@ -1,0 +1,25 @@
+
+#nullable enable
+
+namespace Serde.Test;
+
+partial class SerdeInfoTests
+{
+    partial record UnionBase : Serde.ISerdeInfoProvider
+    {
+        static global::Serde.ISerdeInfo global::Serde.ISerdeInfoProvider.SerdeInfo { get; } = Serde.SerdeInfo.MakeUnion(
+            "UnionBase",
+            typeof(Serde.Test.SerdeInfoTests.UnionBase).GetCustomAttributesData(),
+            System.Collections.Immutable.ImmutableArray.Create<global::Serde.ISerdeInfo>(
+                        global::Serde.SerdeInfoProvider.GetInfo<_m_AProxy>(),
+                        global::Serde.SerdeInfoProvider.GetInfo<_m_BProxy>()
+            )
+        );
+
+        [global::Serde.GenerateDeserialize]
+        private sealed partial class _m_AProxy {}
+        [global::Serde.GenerateDeserialize]
+        private sealed partial class _m_BProxy {}
+
+    }
+}

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.SerdeInfoTests.UnionBase._m_AProxy.IDeserialize.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.SerdeInfoTests.UnionBase._m_AProxy.IDeserialize.cs
@@ -1,0 +1,54 @@
+
+#nullable enable
+
+using System;
+using Serde;
+
+namespace Serde.Test;
+
+partial class SerdeInfoTests
+{
+    partial record UnionBase
+    {
+        partial class _m_AProxy : Serde.IDeserializeProvider<Serde.Test.SerdeInfoTests.UnionBase.A>
+        {
+            static IDeserialize<Serde.Test.SerdeInfoTests.UnionBase.A> IDeserializeProvider<Serde.Test.SerdeInfoTests.UnionBase.A>.DeserializeInstance
+                => _m_AProxyDeserializeProxy.Instance;
+
+            sealed partial class _m_AProxyDeserializeProxy :Serde.IDeserialize<Serde.Test.SerdeInfoTests.UnionBase.A>
+            {
+                Serde.Test.SerdeInfoTests.UnionBase.A Serde.IDeserialize<Serde.Test.SerdeInfoTests.UnionBase.A>.Deserialize(IDeserializer deserializer)
+                {
+
+                    byte _r_assignedValid = 0;
+
+                    var _l_serdeInfo = global::Serde.SerdeInfoProvider.GetInfo<_m_AProxy>();
+                    var typeDeserialize = deserializer.ReadType(_l_serdeInfo);
+                    int _l_index_;
+                    while ((_l_index_ = typeDeserialize.TryReadIndex(_l_serdeInfo, out _)) != IDeserializeType.EndOfType)
+                    {
+                        switch (_l_index_)
+                        {
+                            case Serde.IDeserializeType.IndexNotFound:
+                                typeDeserialize.SkipValue();
+                                break;
+                            default:
+                                throw new InvalidOperationException("Unexpected index: " + _l_index_);
+                        }
+                    }
+                    if ((_r_assignedValid & 0b0) != 0b0)
+                    {
+                        throw Serde.DeserializeException.UnassignedMember();
+                    }
+                    var newType = new Serde.Test.SerdeInfoTests.UnionBase.A() {
+                    };
+
+                    return newType;
+                }
+                public static readonly _m_AProxyDeserializeProxy Instance = new();
+                private _m_AProxyDeserializeProxy() { }
+
+            }
+        }
+    }
+}

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.SerdeInfoTests.UnionBase._m_AProxy.ISerdeInfoProvider.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.SerdeInfoTests.UnionBase._m_AProxy.ISerdeInfoProvider.cs
@@ -1,0 +1,21 @@
+
+#nullable enable
+
+namespace Serde.Test;
+
+partial class SerdeInfoTests
+{
+    partial record UnionBase
+    {
+        partial class _m_AProxy : Serde.ISerdeInfoProvider
+        {
+            static global::Serde.ISerdeInfo global::Serde.ISerdeInfoProvider.SerdeInfo { get; } = Serde.SerdeInfo.MakeCustom(
+                "A",
+                typeof(Serde.Test.SerdeInfoTests.UnionBase.A).GetCustomAttributesData(),
+                new (string, global::Serde.ISerdeInfo, System.Reflection.MemberInfo)[] {
+
+                }
+            );
+        }
+    }
+}

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.SerdeInfoTests.UnionBase._m_BProxy.IDeserialize.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.SerdeInfoTests.UnionBase._m_BProxy.IDeserialize.cs
@@ -1,0 +1,54 @@
+
+#nullable enable
+
+using System;
+using Serde;
+
+namespace Serde.Test;
+
+partial class SerdeInfoTests
+{
+    partial record UnionBase
+    {
+        partial class _m_BProxy : Serde.IDeserializeProvider<Serde.Test.SerdeInfoTests.UnionBase.B>
+        {
+            static IDeserialize<Serde.Test.SerdeInfoTests.UnionBase.B> IDeserializeProvider<Serde.Test.SerdeInfoTests.UnionBase.B>.DeserializeInstance
+                => _m_BProxyDeserializeProxy.Instance;
+
+            sealed partial class _m_BProxyDeserializeProxy :Serde.IDeserialize<Serde.Test.SerdeInfoTests.UnionBase.B>
+            {
+                Serde.Test.SerdeInfoTests.UnionBase.B Serde.IDeserialize<Serde.Test.SerdeInfoTests.UnionBase.B>.Deserialize(IDeserializer deserializer)
+                {
+
+                    byte _r_assignedValid = 0;
+
+                    var _l_serdeInfo = global::Serde.SerdeInfoProvider.GetInfo<_m_BProxy>();
+                    var typeDeserialize = deserializer.ReadType(_l_serdeInfo);
+                    int _l_index_;
+                    while ((_l_index_ = typeDeserialize.TryReadIndex(_l_serdeInfo, out _)) != IDeserializeType.EndOfType)
+                    {
+                        switch (_l_index_)
+                        {
+                            case Serde.IDeserializeType.IndexNotFound:
+                                typeDeserialize.SkipValue();
+                                break;
+                            default:
+                                throw new InvalidOperationException("Unexpected index: " + _l_index_);
+                        }
+                    }
+                    if ((_r_assignedValid & 0b0) != 0b0)
+                    {
+                        throw Serde.DeserializeException.UnassignedMember();
+                    }
+                    var newType = new Serde.Test.SerdeInfoTests.UnionBase.B() {
+                    };
+
+                    return newType;
+                }
+                public static readonly _m_BProxyDeserializeProxy Instance = new();
+                private _m_BProxyDeserializeProxy() { }
+
+            }
+        }
+    }
+}

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.SerdeInfoTests.UnionBase._m_BProxy.ISerdeInfoProvider.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.SerdeInfoTests.UnionBase._m_BProxy.ISerdeInfoProvider.cs
@@ -1,0 +1,21 @@
+
+#nullable enable
+
+namespace Serde.Test;
+
+partial class SerdeInfoTests
+{
+    partial record UnionBase
+    {
+        partial class _m_BProxy : Serde.ISerdeInfoProvider
+        {
+            static global::Serde.ISerdeInfo global::Serde.ISerdeInfoProvider.SerdeInfo { get; } = Serde.SerdeInfo.MakeCustom(
+                "B",
+                typeof(Serde.Test.SerdeInfoTests.UnionBase.B).GetCustomAttributesData(),
+                new (string, global::Serde.ISerdeInfo, System.Reflection.MemberInfo)[] {
+
+                }
+            );
+        }
+    }
+}


### PR DESCRIPTION
This actually aligns with enums. Each case is a field, but only one case is 'live' at a time. It also makes code using the union simpler as it can effectively recur into
it by treating like any other composite type.