### PR TITLE
Add support for inlining single members

### DIFF
--- a/src/generator/ConfigOptions.cs
+++ b/src/generator/ConfigOptions.cs
@@ -34,4 +34,9 @@ internal readonly record struct MemberOptions()
 
     /// <see cref="SerdeMemberOptions.SkipDeserialize" />
     public bool SkipDeserialize { get; init; } = false;
+
+    /// <summary>
+    /// <see cref="SerdeMemberOptions.Inline"/>
+    /// </summary>
+    public bool Inline { get; init; } = false;
 }

--- a/src/generator/DataMemberSymbol.cs
+++ b/src/generator/DataMemberSymbol.cs
@@ -103,6 +103,8 @@ namespace Serde
 
         public ImmutableArray<AttributeData> Attributes => Symbol.GetAttributes();
 
+        public bool Inline => _memberOptions.Inline;
+
         /// <summary>
         /// Retrieves the name of the member after formatting options are applied.
         /// </summary>

--- a/src/generator/Diagnostics.cs
+++ b/src/generator/Diagnostics.cs
@@ -18,6 +18,8 @@ namespace Serde
         ERR_CantFindNestedWrapper = 5,
         ERR_WrapperDoesntImplementInterface = 6,
         ERR_CantImplementAbstract = 7,
+        ERR_MultipleInline = 8,
+        ERR_InlineWithOtherMembers = 9,
     }
 
     internal static class Diagnostics
@@ -31,6 +33,8 @@ namespace Serde
             ERR_CantFindNestedWrapper => nameof(ERR_CantFindNestedWrapper),
             ERR_WrapperDoesntImplementInterface => nameof(ERR_WrapperDoesntImplementInterface),
             ERR_CantImplementAbstract => nameof(ERR_CantImplementAbstract),
+            ERR_MultipleInline => nameof(ERR_MultipleInline),
+            ERR_InlineWithOtherMembers => nameof(ERR_InlineWithOtherMembers),
         };
 
         public static Diagnostic CreateDiagnostic(DiagId id, Location location, params object[] args)

--- a/src/generator/HelpersAndUtilities/SymbolUtilities.cs
+++ b/src/generator/HelpersAndUtilities/SymbolUtilities.cs
@@ -136,6 +136,14 @@ namespace Serde
                                 }
                             } => options with { SkipDeserialize = (bool)value },
 
+                            {
+                                Key: nameof(MemberOptions.Inline),
+                                Value: {
+                                    Kind: TypedConstantKind.Primitive,
+                                    Type.SpecialType: SpecialType.System_Boolean
+                                }
+                            } => options with { Inline = (bool)value },
+
                             _ => options
                         };
                     }

--- a/src/generator/Resources.resx
+++ b/src/generator/Resources.resx
@@ -142,4 +142,10 @@
 - With only private constructors
 - With one or more nested records that inherit from the parent record</value>
   </data>
+  <data name="ERR_MultipleInline" xml:space="preserve">
+    <value>SerdeMemberOptions.Inline can only be appled to one member.</value>
+  </data>
+  <data name="ERR_InlineWithOtherMembers" xml:space="preserve">
+    <value>SerdeMemberOptions.Inline cannot be used when the type has multiple members.</value>
+  </data>
 </root>

--- a/src/serde/Attributes.cs
+++ b/src/serde/Attributes.cs
@@ -167,6 +167,12 @@ sealed class SerdeMemberOptions : Attribute
     /// Proxy type for the IDeserialize implementation.
     /// </summary>
     public Type? DeserializeProxy { get; init; } = null;
+
+    /// <summary>
+    /// Inline the given member into the parent type. Currently only valid when
+    /// the type contains a single member.
+    /// </summary>
+    public bool Inline { get; init; } = false;
 }
 
 /// <summary>

--- a/src/serde/Proxies.cs
+++ b/src/serde/Proxies.cs
@@ -1,24 +1,20 @@
 // Contains implementations of data interfaces for core types
 
+using System.Diagnostics;
+
 namespace Serde;
 
 internal interface ISerdePrimitive<TSelf, T>
     : ISerde<T>, ISerdeProvider<TSelf, T>, ITypeSerialize<T>, ITypeDeserialize<T>
     where TSelf : ISerdePrimitive<TSelf, T>
-{
-    /// <summary>
-    /// Abstract static to force all primitives to provide a convenient static accessor.
-    /// </summary>
-    public new abstract static ISerdeInfo SerdeInfo { get; }
-}
+{ }
 
 public sealed class BoolProxy : ISerdePrimitive<BoolProxy, bool>
 {
     public static BoolProxy Instance { get; } = new();
     private BoolProxy() { }
 
-    public static ISerdeInfo SerdeInfo { get; } = Serde.SerdeInfo.MakePrimitive(s_typeName);
-    ISerdeInfo ISerdeInfoProvider.SerdeInfo => SerdeInfo;
+    public ISerdeInfo SerdeInfo { get; } = Serde.SerdeInfo.MakePrimitive(s_typeName);
 
     private const string s_typeName = "bool";
     void ISerialize<bool>.Serialize(bool value, ISerializer serializer)
@@ -36,8 +32,7 @@ public sealed class CharProxy : ISerdePrimitive<CharProxy, char>
     public static CharProxy Instance { get; } = new();
     private CharProxy() { }
 
-    public static ISerdeInfo SerdeInfo { get; } = Serde.SerdeInfo.MakePrimitive(s_typeName);
-    ISerdeInfo ISerdeInfoProvider.SerdeInfo => SerdeInfo;
+    public ISerdeInfo SerdeInfo { get; } = Serde.SerdeInfo.MakePrimitive(s_typeName);
 
     private const string s_typeName = "char";
     void ISerialize<char>.Serialize(char value, ISerializer serializer)
@@ -57,8 +52,7 @@ public sealed class U8Proxy : ISerdePrimitive<U8Proxy, byte>
     public static U8Proxy Instance { get; } = new();
     private U8Proxy() { }
 
-    public static ISerdeInfo SerdeInfo { get; } = Serde.SerdeInfo.MakePrimitive(s_typeName);
-    ISerdeInfo ISerdeInfoProvider.SerdeInfo => SerdeInfo;
+    public ISerdeInfo SerdeInfo { get; } = Serde.SerdeInfo.MakePrimitive(s_typeName);
 
     private const string s_typeName = "byte";
     public void Serialize(byte value, ISerializer serializer)
@@ -78,8 +72,7 @@ public sealed class U16Proxy : ISerdePrimitive<U16Proxy, ushort>
     public static U16Proxy Instance { get; } = new();
     private U16Proxy() { }
 
-    public static ISerdeInfo SerdeInfo { get; } = Serde.SerdeInfo.MakePrimitive(s_typeName);
-    ISerdeInfo ISerdeInfoProvider.SerdeInfo => SerdeInfo;
+    public ISerdeInfo SerdeInfo { get; } = Serde.SerdeInfo.MakePrimitive(s_typeName);
 
     private const string s_typeName = "ushort";
     void ISerialize<ushort>.Serialize(ushort value, ISerializer serializer)
@@ -99,8 +92,7 @@ public sealed class U32Proxy : ISerdePrimitive<U32Proxy, uint>
     public static U32Proxy Instance { get; } = new();
     private U32Proxy() { }
 
-    public static ISerdeInfo SerdeInfo { get; } = Serde.SerdeInfo.MakePrimitive(s_typeName);
-    ISerdeInfo ISerdeInfoProvider.SerdeInfo => SerdeInfo;
+    public ISerdeInfo SerdeInfo { get; } = Serde.SerdeInfo.MakePrimitive(s_typeName);
 
     private const string s_typeName = "uint";
     void ISerialize<uint>.Serialize(uint value, ISerializer serializer)
@@ -120,8 +112,7 @@ public sealed class U64Proxy : ISerdePrimitive<U64Proxy, ulong>
     public static U64Proxy Instance { get; } = new();
     private U64Proxy() { }
 
-    public static ISerdeInfo SerdeInfo { get; } = Serde.SerdeInfo.MakePrimitive(s_typeName);
-    ISerdeInfo ISerdeInfoProvider.SerdeInfo => SerdeInfo;
+    public ISerdeInfo SerdeInfo { get; } = Serde.SerdeInfo.MakePrimitive(s_typeName);
 
     private const string s_typeName = "ulong";
     void ISerialize<ulong>.Serialize(ulong value, ISerializer serializer)
@@ -141,8 +132,7 @@ public sealed class I8Proxy : ISerdePrimitive<I8Proxy, sbyte>
     public static I8Proxy Instance { get; } = new();
     private I8Proxy() { }
 
-    public static ISerdeInfo SerdeInfo { get; } = Serde.SerdeInfo.MakePrimitive(s_typeName);
-    ISerdeInfo ISerdeInfoProvider.SerdeInfo => SerdeInfo;
+    public ISerdeInfo SerdeInfo { get; } = Serde.SerdeInfo.MakePrimitive(s_typeName);
 
     private const string s_typeName = "sbyte";
     void ISerialize<sbyte>.Serialize(sbyte value, ISerializer serializer)
@@ -162,8 +152,7 @@ public sealed class I16Proxy : ISerdePrimitive<I16Proxy, short>
     public static I16Proxy Instance { get; } = new();
     private I16Proxy() { }
 
-    public static ISerdeInfo SerdeInfo { get; } = Serde.SerdeInfo.MakePrimitive(s_typeName);
-    ISerdeInfo ISerdeInfoProvider.SerdeInfo => SerdeInfo;
+    public ISerdeInfo SerdeInfo { get; } = Serde.SerdeInfo.MakePrimitive(s_typeName);
 
     private const string s_typeName = "short";
     void ISerialize<short>.Serialize(short value, ISerializer serializer)
@@ -204,8 +193,7 @@ public sealed class I64Proxy : ISerdePrimitive<I64Proxy, long>
     public static I64Proxy Instance { get; } = new();
     private I64Proxy() { }
 
-    public static ISerdeInfo SerdeInfo { get; } = Serde.SerdeInfo.MakePrimitive(s_typeName);
-    ISerdeInfo ISerdeInfoProvider.SerdeInfo => SerdeInfo;
+    public ISerdeInfo SerdeInfo { get; } = Serde.SerdeInfo.MakePrimitive(s_typeName);
 
     private const string s_typeName = "long";
     void ISerialize<long>.Serialize(long value, ISerializer serializer)
@@ -225,8 +213,7 @@ public sealed class F32Proxy : ISerdePrimitive<F32Proxy, float>
     public static F32Proxy Instance { get; } = new();
     private F32Proxy() { }
 
-    public static ISerdeInfo SerdeInfo { get; } = Serde.SerdeInfo.MakePrimitive("float");
-    ISerdeInfo ISerdeInfoProvider.SerdeInfo => SerdeInfo;
+    public ISerdeInfo SerdeInfo { get; } = Serde.SerdeInfo.MakePrimitive("float");
 
     public void Serialize(float value, ISerializer serializer)
         => serializer.WriteF32(value);
@@ -245,8 +232,7 @@ public sealed class F64Proxy : ISerdePrimitive<F64Proxy, double>
     public static F64Proxy Instance { get; } = new();
     private F64Proxy() { }
 
-    public static ISerdeInfo SerdeInfo { get; } = Serde.SerdeInfo.MakePrimitive("double");
-    ISerdeInfo ISerdeInfoProvider.SerdeInfo => SerdeInfo;
+    public ISerdeInfo SerdeInfo { get; } = Serde.SerdeInfo.MakePrimitive("double");
 
     void ISerialize<double>.Serialize(double value, ISerializer serializer)
         => serializer.WriteF64(value);
@@ -265,8 +251,7 @@ public sealed class DecimalProxy : ISerdePrimitive<DecimalProxy, decimal>
     public static DecimalProxy Instance { get; } = new();
     private DecimalProxy() { }
 
-    public static ISerdeInfo SerdeInfo { get; } = Serde.SerdeInfo.MakePrimitive("decimal");
-    ISerdeInfo ISerdeInfoProvider.SerdeInfo => SerdeInfo;
+    public ISerdeInfo SerdeInfo { get; } = Serde.SerdeInfo.MakePrimitive("decimal");
 
     void ISerialize<decimal>.Serialize(decimal value, ISerializer serializer)
         => serializer.WriteDecimal(value);
@@ -301,7 +286,7 @@ public sealed class StringProxy : ISerdePrimitive<StringProxy, string>
         => serializer.WriteString(info, index, value);
 }
 
-public static class BoxProxy
+internal static class BoxProxy
 {
     public sealed class Ser<T, TProvider> : ISerialize<object?>, ITypeSerialize<T>
         where TProvider : ISerializeProvider<T>
@@ -408,7 +393,7 @@ public static class NullableRefProxy
     }
 
     public sealed class De<T, TProvider> : IDeserialize<T?>, IDeserializeProvider<T?>
-        where T : class
+        where T : class?
         where TProvider : IDeserializeProvider<T>
     {
         public static De<T, TProvider> Instance { get; } = new();

--- a/test/Serde.Generation.Test/DeserializeTests.cs
+++ b/test/Serde.Generation.Test/DeserializeTests.cs
@@ -1,4 +1,3 @@
-
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using Xunit;
@@ -8,6 +7,53 @@ namespace Serde.Test
 {
     public class DeserializeTests
     {
+        [Fact]
+        public Task InlineMember()
+        {
+            var src = """
+using Serde;
+
+[GenerateDeserialize]
+public partial record StringWrap(
+    [property: SerdeMemberOptions(Inline = true)]
+    string Value
+);
+""";
+            return VerifyDeserialize(src);
+        }
+
+        [Fact]
+        public Task MultipleInlineMember()
+        {
+            var src = """
+using Serde;
+[GenerateDeserialize]
+partial record StringWrap(
+    [property: SerdeMemberOptions(Inline = true)]
+    string Value,
+    [property: SerdeMemberOptions(Inline = true)]
+    string Value2
+);
+""";
+            return VerifyDeserialize(src);
+        }
+
+        [Fact]
+        public Task SingleInlineMemberWithOthers()
+        {
+            var src = """
+using Serde;
+
+[GenerateDeserialize]
+public partial record StringWrap(
+    [property: SerdeMemberOptions(Inline = true)]
+    string InlineValue,
+    string RegularValue
+);
+""";
+            return VerifyDeserialize(src);
+        }
+
         [Fact]
         public Task NestedExplicitDeserializeWrapper()
         {

--- a/test/Serde.Generation.Test/SerializeTests.cs
+++ b/test/Serde.Generation.Test/SerializeTests.cs
@@ -1,4 +1,3 @@
-
 using System;
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
@@ -9,6 +8,21 @@ namespace Serde.Test
 {
     public class SerializeTests
     {
+        [Fact]
+        public Task InlineMember()
+        {
+            var src = """
+using Serde;
+
+[GenerateSerialize]
+public partial record StringWrap(
+    [property: SerdeMemberOptions(Inline = true)]
+    string Value
+);
+""";
+            return VerifySerialize(src);
+        }
+
         [Fact]
         public Task NestedExplicitSerializeWrapper()
         {
@@ -566,6 +580,39 @@ abstract partial record Base
 }
 """;
             return VerifyMultiFile(src);
+        }
+
+        [Fact]
+        public Task MultipleInlineMember()
+        {
+            var src = """
+using Serde;
+
+[GenerateSerialize]
+public partial record StringWrap(
+    [property: SerdeMemberOptions(Inline = true)]
+    string Value,
+    [property: SerdeMemberOptions(Inline = true)]
+    string Value2
+);
+""";
+            return VerifySerialize(src);
+        }
+
+        [Fact]
+        public Task SingleInlineMemberWithOthers()
+        {
+            var src = """
+using Serde;
+
+[GenerateSerialize]
+public partial record StringWrap(
+    [property: SerdeMemberOptions(Inline = true)]
+    string InlineValue,
+    string RegularValue
+);
+""";
+            return VerifySerialize(src);
         }
 
         private static Task VerifySerialize(

--- a/test/Serde.Generation.Test/test_output/AllInOneTest.GeneratorTest/Serde.Test.AllInOne.ISerdeInfoProvider.verified.cs
+++ b/test/Serde.Generation.Test/test_output/AllInOneTest.GeneratorTest/Serde.Test.AllInOne.ISerdeInfoProvider.verified.cs
@@ -6,7 +6,7 @@ namespace Serde.Test;
 
 partial record AllInOne
 {
-    private static global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
+    private static readonly global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
         "AllInOne",
     typeof(Serde.Test.AllInOne).GetCustomAttributesData(),
     new (string, global::Serde.ISerdeInfo, System.Reflection.MemberInfo?)[] {

--- a/test/Serde.Generation.Test/test_output/DeserializeTests.BasicDU/Some.Nested.Namespace.Base._m_AProxy.ISerdeInfoProvider.verified.cs
+++ b/test/Serde.Generation.Test/test_output/DeserializeTests.BasicDU/Some.Nested.Namespace.Base._m_AProxy.ISerdeInfoProvider.verified.cs
@@ -8,7 +8,7 @@ partial record Base
 {
     partial class _m_AProxy
     {
-        private static global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
+        private static readonly global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
             "A",
         typeof(Some.Nested.Namespace.Base.A).GetCustomAttributesData(),
         new (string, global::Serde.ISerdeInfo, System.Reflection.MemberInfo?)[] {

--- a/test/Serde.Generation.Test/test_output/DeserializeTests.BasicDU/Some.Nested.Namespace.Base._m_BProxy.ISerdeInfoProvider.verified.cs
+++ b/test/Serde.Generation.Test/test_output/DeserializeTests.BasicDU/Some.Nested.Namespace.Base._m_BProxy.ISerdeInfoProvider.verified.cs
@@ -8,7 +8,7 @@ partial record Base
 {
     partial class _m_BProxy
     {
-        private static global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
+        private static readonly global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
             "B",
         typeof(Some.Nested.Namespace.Base.B).GetCustomAttributesData(),
         new (string, global::Serde.ISerdeInfo, System.Reflection.MemberInfo?)[] {

--- a/test/Serde.Generation.Test/test_output/DeserializeTests.BasicDUGenerateSerde/Some.Nested.Namespace.Base._m_AProxy.ISerdeInfoProvider.verified.cs
+++ b/test/Serde.Generation.Test/test_output/DeserializeTests.BasicDUGenerateSerde/Some.Nested.Namespace.Base._m_AProxy.ISerdeInfoProvider.verified.cs
@@ -8,7 +8,7 @@ partial record Base
 {
     partial class _m_AProxy
     {
-        private static global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
+        private static readonly global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
             "A",
         typeof(Some.Nested.Namespace.Base.A).GetCustomAttributesData(),
         new (string, global::Serde.ISerdeInfo, System.Reflection.MemberInfo?)[] {

--- a/test/Serde.Generation.Test/test_output/DeserializeTests.BasicDUGenerateSerde/Some.Nested.Namespace.Base._m_BProxy.ISerdeInfoProvider.verified.cs
+++ b/test/Serde.Generation.Test/test_output/DeserializeTests.BasicDUGenerateSerde/Some.Nested.Namespace.Base._m_BProxy.ISerdeInfoProvider.verified.cs
@@ -8,7 +8,7 @@ partial record Base
 {
     partial class _m_BProxy
     {
-        private static global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
+        private static readonly global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
             "B",
         typeof(Some.Nested.Namespace.Base.B).GetCustomAttributesData(),
         new (string, global::Serde.ISerdeInfo, System.Reflection.MemberInfo?)[] {

--- a/test/Serde.Generation.Test/test_output/DeserializeTests.BasicDUGenerateSerializeAndDeserialize/Some.Nested.Namespace.Base._m_AProxy.ISerdeInfoProvider.verified.cs
+++ b/test/Serde.Generation.Test/test_output/DeserializeTests.BasicDUGenerateSerializeAndDeserialize/Some.Nested.Namespace.Base._m_AProxy.ISerdeInfoProvider.verified.cs
@@ -8,7 +8,7 @@ partial record Base
 {
     partial class _m_AProxy
     {
-        private static global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
+        private static readonly global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
             "A",
         typeof(Some.Nested.Namespace.Base.A).GetCustomAttributesData(),
         new (string, global::Serde.ISerdeInfo, System.Reflection.MemberInfo?)[] {

--- a/test/Serde.Generation.Test/test_output/DeserializeTests.BasicDUGenerateSerializeAndDeserialize/Some.Nested.Namespace.Base._m_BProxy.ISerdeInfoProvider.verified.cs
+++ b/test/Serde.Generation.Test/test_output/DeserializeTests.BasicDUGenerateSerializeAndDeserialize/Some.Nested.Namespace.Base._m_BProxy.ISerdeInfoProvider.verified.cs
@@ -8,7 +8,7 @@ partial record Base
 {
     partial class _m_BProxy
     {
-        private static global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
+        private static readonly global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
             "B",
         typeof(Some.Nested.Namespace.Base.B).GetCustomAttributesData(),
         new (string, global::Serde.ISerdeInfo, System.Reflection.MemberInfo?)[] {

--- a/test/Serde.Generation.Test/test_output/DeserializeTests.EnumMember/C.ISerdeInfoProvider.verified.cs
+++ b/test/Serde.Generation.Test/test_output/DeserializeTests.EnumMember/C.ISerdeInfoProvider.verified.cs
@@ -3,7 +3,7 @@
 #nullable enable
 partial class C
 {
-    private static global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
+    private static readonly global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
         "C",
     typeof(C).GetCustomAttributesData(),
     new (string, global::Serde.ISerdeInfo, System.Reflection.MemberInfo?)[] {

--- a/test/Serde.Generation.Test/test_output/DeserializeTests.NestedExplicitDeserializeWrapper/OptsWrap.ISerdeInfoProvider.verified.cs
+++ b/test/Serde.Generation.Test/test_output/DeserializeTests.NestedExplicitDeserializeWrapper/OptsWrap.ISerdeInfoProvider.verified.cs
@@ -3,7 +3,7 @@
 #nullable enable
 partial record struct OptsWrap
 {
-    private static global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
+    private static readonly global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
         "BIND_OPTS",
     typeof(System.Runtime.InteropServices.ComTypes.BIND_OPTS).GetCustomAttributesData(),
     new (string, global::Serde.ISerdeInfo, System.Reflection.MemberInfo?)[] {

--- a/test/Serde.Generation.Test/test_output/DeserializeTests.NestedExplicitDeserializeWrapper/S.ISerdeInfoProvider.verified.cs
+++ b/test/Serde.Generation.Test/test_output/DeserializeTests.NestedExplicitDeserializeWrapper/S.ISerdeInfoProvider.verified.cs
@@ -3,7 +3,7 @@
 #nullable enable
 partial struct S
 {
-    private static global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
+    private static readonly global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
         "S",
     typeof(S).GetCustomAttributesData(),
     new (string, global::Serde.ISerdeInfo, System.Reflection.MemberInfo?)[] {

--- a/test/Serde.Generation.Test/test_output/DeserializeTests/Array#ArrayField.ISerdeInfoProvider.verified.cs
+++ b/test/Serde.Generation.Test/test_output/DeserializeTests/Array#ArrayField.ISerdeInfoProvider.verified.cs
@@ -3,7 +3,7 @@
 #nullable enable
 partial class ArrayField
 {
-    private static global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
+    private static readonly global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
         "ArrayField",
     typeof(ArrayField).GetCustomAttributesData(),
     new (string, global::Serde.ISerdeInfo, System.Reflection.MemberInfo?)[] {

--- a/test/Serde.Generation.Test/test_output/DeserializeTests/DeserializeMissing#SetToNull.ISerdeInfoProvider.verified.cs
+++ b/test/Serde.Generation.Test/test_output/DeserializeTests/DeserializeMissing#SetToNull.ISerdeInfoProvider.verified.cs
@@ -3,7 +3,7 @@
 #nullable enable
 partial record struct SetToNull
 {
-    private static global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
+    private static readonly global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
         "SetToNull",
     typeof(SetToNull).GetCustomAttributesData(),
     new (string, global::Serde.ISerdeInfo, System.Reflection.MemberInfo?)[] {

--- a/test/Serde.Generation.Test/test_output/DeserializeTests/DeserializeOnlyWrap#Wrap.ISerdeInfoProvider.verified.cs
+++ b/test/Serde.Generation.Test/test_output/DeserializeTests/DeserializeOnlyWrap#Wrap.ISerdeInfoProvider.verified.cs
@@ -3,7 +3,7 @@
 #nullable enable
 partial record struct Wrap
 {
-    private static global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
+    private static readonly global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
         "BIND_OPTS",
     typeof(System.Runtime.InteropServices.ComTypes.BIND_OPTS).GetCustomAttributesData(),
     new (string, global::Serde.ISerdeInfo, System.Reflection.MemberInfo?)[] {

--- a/test/Serde.Generation.Test/test_output/DeserializeTests/InlineMember#StringWrap.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/DeserializeTests/InlineMember#StringWrap.IDeserialize.verified.cs
@@ -1,0 +1,25 @@
+﻿//HintName: StringWrap.IDeserialize.cs
+
+#nullable enable
+
+using System;
+using Serde;
+partial record StringWrap : Serde.IDeserializeProvider<StringWrap>
+{
+    static IDeserialize<StringWrap> IDeserializeProvider<StringWrap>.Instance
+        => _DeObj.Instance;
+
+    sealed partial class _DeObj  : global::Serde.IDeserialize<StringWrap>
+    {
+        global::Serde.ISerdeInfo global::Serde.ISerdeInfoProvider.SerdeInfo => StringWrap.s_serdeInfo;
+
+        StringWrap global::Serde.IDeserialize<StringWrap>.Deserialize(global::Serde.IDeserializer deserializer)
+        {
+            var deObj = global::Serde.DeserializeProvider.GetDeserialize<string, global::Serde.StringProxy>();
+            return new(deObj.Deserialize(deserializer));
+        }
+        public static readonly _DeObj Instance = new();
+        private _DeObj() { }
+
+    }
+}

--- a/test/Serde.Generation.Test/test_output/DeserializeTests/InlineMember#StringWrap.ISerdeInfoProvider.verified.cs
+++ b/test/Serde.Generation.Test/test_output/DeserializeTests/InlineMember#StringWrap.ISerdeInfoProvider.verified.cs
@@ -1,0 +1,8 @@
+﻿//HintName: StringWrap.ISerdeInfoProvider.cs
+
+#nullable enable
+partial record StringWrap
+{
+    private static readonly global::Serde.ISerdeInfo s_serdeInfo
+        = global::Serde.SerdeInfoProvider.GetDeserializeInfo<string, global::Serde.StringProxy>();
+}

--- a/test/Serde.Generation.Test/test_output/DeserializeTests/MemberSkip#Rgb.ISerdeInfoProvider.verified.cs
+++ b/test/Serde.Generation.Test/test_output/DeserializeTests/MemberSkip#Rgb.ISerdeInfoProvider.verified.cs
@@ -3,7 +3,7 @@
 #nullable enable
 partial struct Rgb
 {
-    private static global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
+    private static readonly global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
         "Rgb",
     typeof(Rgb).GetCustomAttributesData(),
     new (string, global::Serde.ISerdeInfo, System.Reflection.MemberInfo?)[] {

--- a/test/Serde.Generation.Test/test_output/DeserializeTests/MemberSkipDeserialize#Rgb.ISerdeInfoProvider.verified.cs
+++ b/test/Serde.Generation.Test/test_output/DeserializeTests/MemberSkipDeserialize#Rgb.ISerdeInfoProvider.verified.cs
@@ -3,7 +3,7 @@
 #nullable enable
 partial struct Rgb
 {
-    private static global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
+    private static readonly global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
         "Rgb",
     typeof(Rgb).GetCustomAttributesData(),
     new (string, global::Serde.ISerdeInfo, System.Reflection.MemberInfo?)[] {

--- a/test/Serde.Generation.Test/test_output/DeserializeTests/MemberSkipSerialize#Rgb.ISerdeInfoProvider.verified.cs
+++ b/test/Serde.Generation.Test/test_output/DeserializeTests/MemberSkipSerialize#Rgb.ISerdeInfoProvider.verified.cs
@@ -3,7 +3,7 @@
 #nullable enable
 partial struct Rgb
 {
-    private static global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
+    private static readonly global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
         "Rgb",
     typeof(Rgb).GetCustomAttributesData(),
     new (string, global::Serde.ISerdeInfo, System.Reflection.MemberInfo?)[] {

--- a/test/Serde.Generation.Test/test_output/DeserializeTests/MultipleInlineMember#FinalDiagnostics.verified.txt
+++ b/test/Serde.Generation.Test/test_output/DeserializeTests/MultipleInlineMember#FinalDiagnostics.verified.txt
@@ -1,0 +1,24 @@
+﻿[
+  {
+    "Id": "CS0535",
+    "Title": "",
+    "Severity": "Error",
+    "WarningLevel": "0",
+    "Location": "SerdeGenerator/Serde.SerdeImplRoslynGenerator/StringWrap.IDeserialize.cs: (10,34)-(10,72)",
+    "HelpLink": "https://msdn.microsoft.com/query/roslyn.query?appId=roslyn&k=k(CS0535)",
+    "MessageFormat": "'{0}' does not implement interface member '{1}'",
+    "Message": "'StringWrap._DeObj' does not implement interface member 'IDeserialize<StringWrap>.Deserialize(IDeserializer)'",
+    "Category": "Compiler"
+  },
+  {
+    "Id": "CS0117",
+    "Title": "",
+    "Severity": "Error",
+    "WarningLevel": "0",
+    "Location": "SerdeGenerator/Serde.SerdeImplRoslynGenerator/StringWrap.IDeserialize.cs: (12,90)-(12,101)",
+    "HelpLink": "https://msdn.microsoft.com/query/roslyn.query?appId=roslyn&k=k(CS0117)",
+    "MessageFormat": "'{0}' does not contain a definition for '{1}'",
+    "Message": "'StringWrap' does not contain a definition for 's_serdeInfo'",
+    "Category": "Compiler"
+  }
+]

--- a/test/Serde.Generation.Test/test_output/DeserializeTests/MultipleInlineMember#StringWrap.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/DeserializeTests/MultipleInlineMember#StringWrap.IDeserialize.verified.cs
@@ -1,0 +1,20 @@
+﻿//HintName: StringWrap.IDeserialize.cs
+
+#nullable enable
+
+using System;
+using Serde;
+partial record StringWrap : Serde.IDeserializeProvider<StringWrap>
+{
+    static IDeserialize<StringWrap> IDeserializeProvider<StringWrap>.Instance
+        => _DeObj.Instance;
+
+    sealed partial class _DeObj : global::Serde.IDeserialize<StringWrap>
+    {
+        global::Serde.ISerdeInfo global::Serde.ISerdeInfoProvider.SerdeInfo => StringWrap.s_serdeInfo;
+
+        public static readonly _DeObj Instance = new();
+        private _DeObj() { }
+
+    }
+}

--- a/test/Serde.Generation.Test/test_output/DeserializeTests/MultipleInlineMember.verified.txt
+++ b/test/Serde.Generation.Test/test_output/DeserializeTests/MultipleInlineMember.verified.txt
@@ -1,0 +1,14 @@
+﻿{
+  Diagnostics: [
+    {
+      Id: ERR_MultipleInline,
+      Title: ,
+      Severity: Error,
+      WarningLevel: 0,
+      Location: : (1,0)-(7,2),
+      MessageFormat: SerdeMemberOptions.Inline can only be appled to one member.,
+      Message: SerdeMemberOptions.Inline can only be appled to one member.,
+      Category: Serde
+    }
+  ]
+}

--- a/test/Serde.Generation.Test/test_output/DeserializeTests/NestedPartialClasses#A.B.C.D.ISerdeInfoProvider.verified.cs
+++ b/test/Serde.Generation.Test/test_output/DeserializeTests/NestedPartialClasses#A.B.C.D.ISerdeInfoProvider.verified.cs
@@ -9,7 +9,7 @@ partial class A
         {
             partial class D
             {
-                private static global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
+                private static readonly global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
                     "D",
                 typeof(A.B.C.D).GetCustomAttributesData(),
                 new (string, global::Serde.ISerdeInfo, System.Reflection.MemberInfo?)[] {

--- a/test/Serde.Generation.Test/test_output/DeserializeTests/NoParameterlessOrPrimaryCtor#C.ISerdeInfoProvider.verified.cs
+++ b/test/Serde.Generation.Test/test_output/DeserializeTests/NoParameterlessOrPrimaryCtor#C.ISerdeInfoProvider.verified.cs
@@ -3,7 +3,7 @@
 #nullable enable
 partial class C
 {
-    private static global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
+    private static readonly global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
         "C",
     typeof(C).GetCustomAttributesData(),
     new (string, global::Serde.ISerdeInfo, System.Reflection.MemberInfo?)[] {

--- a/test/Serde.Generation.Test/test_output/DeserializeTests/NullableRefField#S.ISerdeInfoProvider.verified.cs
+++ b/test/Serde.Generation.Test/test_output/DeserializeTests/NullableRefField#S.ISerdeInfoProvider.verified.cs
@@ -3,7 +3,7 @@
 #nullable enable
 partial struct S
 {
-    private static global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
+    private static readonly global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
         "S",
     typeof(S).GetCustomAttributesData(),
     new (string, global::Serde.ISerdeInfo, System.Reflection.MemberInfo?)[] {

--- a/test/Serde.Generation.Test/test_output/DeserializeTests/Rgb#Rgb.ISerdeInfoProvider.verified.cs
+++ b/test/Serde.Generation.Test/test_output/DeserializeTests/Rgb#Rgb.ISerdeInfoProvider.verified.cs
@@ -3,7 +3,7 @@
 #nullable enable
 partial struct Rgb
 {
-    private static global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
+    private static readonly global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
         "Rgb",
     typeof(Rgb).GetCustomAttributesData(),
     new (string, global::Serde.ISerdeInfo, System.Reflection.MemberInfo?)[] {

--- a/test/Serde.Generation.Test/test_output/DeserializeTests/SingleInlineMemberWithOthers#FinalDiagnostics.verified.txt
+++ b/test/Serde.Generation.Test/test_output/DeserializeTests/SingleInlineMemberWithOthers#FinalDiagnostics.verified.txt
@@ -1,0 +1,13 @@
+﻿[
+  {
+    "Id": "CS0535",
+    "Title": "",
+    "Severity": "Error",
+    "WarningLevel": "0",
+    "Location": "SerdeGenerator/Serde.SerdeImplRoslynGenerator/StringWrap.IDeserialize.cs: (10,35)-(10,65)",
+    "HelpLink": "https://msdn.microsoft.com/query/roslyn.query?appId=roslyn&k=k(CS0535)",
+    "MessageFormat": "'{0}' does not implement interface member '{1}'",
+    "Message": "'StringWrap._DeObj' does not implement interface member 'IDeserialize<StringWrap>.Deserialize(IDeserializer)'",
+    "Category": "Compiler"
+  }
+]

--- a/test/Serde.Generation.Test/test_output/DeserializeTests/SingleInlineMemberWithOthers#StringWrap.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/DeserializeTests/SingleInlineMemberWithOthers#StringWrap.IDeserialize.verified.cs
@@ -1,0 +1,20 @@
+﻿//HintName: StringWrap.IDeserialize.cs
+
+#nullable enable
+
+using System;
+using Serde;
+partial record StringWrap : Serde.IDeserializeProvider<StringWrap>
+{
+    static IDeserialize<StringWrap> IDeserializeProvider<StringWrap>.Instance
+        => _DeObj.Instance;
+
+    sealed partial class _DeObj  : Serde.IDeserialize<StringWrap>
+    {
+        global::Serde.ISerdeInfo global::Serde.ISerdeInfoProvider.SerdeInfo => StringWrap.s_serdeInfo;
+
+        public static readonly _DeObj Instance = new();
+        private _DeObj() { }
+
+    }
+}

--- a/test/Serde.Generation.Test/test_output/DeserializeTests/SingleInlineMemberWithOthers#StringWrap.ISerdeInfoProvider.verified.cs
+++ b/test/Serde.Generation.Test/test_output/DeserializeTests/SingleInlineMemberWithOthers#StringWrap.ISerdeInfoProvider.verified.cs
@@ -1,0 +1,8 @@
+﻿//HintName: StringWrap.ISerdeInfoProvider.cs
+
+#nullable enable
+partial record StringWrap
+{
+    private static readonly global::Serde.ISerdeInfo s_serdeInfo
+        = global::Serde.SerdeInfoProvider.GetDeserializeInfo<string, global::Serde.StringProxy>();
+}

--- a/test/Serde.Generation.Test/test_output/DeserializeTests/SingleInlineMemberWithOthers.verified.txt
+++ b/test/Serde.Generation.Test/test_output/DeserializeTests/SingleInlineMemberWithOthers.verified.txt
@@ -1,0 +1,14 @@
+﻿{
+  Diagnostics: [
+    {
+      Id: ERR_InlineWithOtherMembers,
+      Title: ,
+      Severity: Error,
+      WarningLevel: 0,
+      Location: : (2,0)-(7,2),
+      MessageFormat: SerdeMemberOptions.Inline cannot be used when the type has multiple members.,
+      Message: SerdeMemberOptions.Inline cannot be used when the type has multiple members.,
+      Category: Serde
+    }
+  ]
+}

--- a/test/Serde.Generation.Test/test_output/MemberFormatTests.CamelCase/S.ISerdeInfoProvider.verified.cs
+++ b/test/Serde.Generation.Test/test_output/MemberFormatTests.CamelCase/S.ISerdeInfoProvider.verified.cs
@@ -3,7 +3,7 @@
 #nullable enable
 partial struct S
 {
-    private static global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
+    private static readonly global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
         "S",
     typeof(S).GetCustomAttributesData(),
     new (string, global::Serde.ISerdeInfo, System.Reflection.MemberInfo?)[] {

--- a/test/Serde.Generation.Test/test_output/MemberFormatTests.Default/S.ISerdeInfoProvider.verified.cs
+++ b/test/Serde.Generation.Test/test_output/MemberFormatTests.Default/S.ISerdeInfoProvider.verified.cs
@@ -3,7 +3,7 @@
 #nullable enable
 partial struct S
 {
-    private static global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
+    private static readonly global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
         "S",
     typeof(S).GetCustomAttributesData(),
     new (string, global::Serde.ISerdeInfo, System.Reflection.MemberInfo?)[] {

--- a/test/Serde.Generation.Test/test_output/MemberFormatTests.EnumValues/S.ISerdeInfoProvider.verified.cs
+++ b/test/Serde.Generation.Test/test_output/MemberFormatTests.EnumValues/S.ISerdeInfoProvider.verified.cs
@@ -3,7 +3,7 @@
 #nullable enable
 partial struct S
 {
-    private static global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
+    private static readonly global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
         "S",
     typeof(S).GetCustomAttributesData(),
     new (string, global::Serde.ISerdeInfo, System.Reflection.MemberInfo?)[] {

--- a/test/Serde.Generation.Test/test_output/MemberFormatTests.EnumValues/S2.ISerdeInfoProvider.verified.cs
+++ b/test/Serde.Generation.Test/test_output/MemberFormatTests.EnumValues/S2.ISerdeInfoProvider.verified.cs
@@ -3,7 +3,7 @@
 #nullable enable
 partial struct S2
 {
-    private static global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
+    private static readonly global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
         "S2",
     typeof(S2).GetCustomAttributesData(),
     new (string, global::Serde.ISerdeInfo, System.Reflection.MemberInfo?)[] {

--- a/test/Serde.Generation.Test/test_output/MemberFormatTests.KebabCase/S.ISerdeInfoProvider.verified.cs
+++ b/test/Serde.Generation.Test/test_output/MemberFormatTests.KebabCase/S.ISerdeInfoProvider.verified.cs
@@ -3,7 +3,7 @@
 #nullable enable
 partial struct S
 {
-    private static global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
+    private static readonly global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
         "S",
     typeof(S).GetCustomAttributesData(),
     new (string, global::Serde.ISerdeInfo, System.Reflection.MemberInfo?)[] {

--- a/test/Serde.Generation.Test/test_output/SerializeTests.ArrayOfGenerateSerialize/TestCase15.Class0.ISerdeInfoProvider.verified.cs
+++ b/test/Serde.Generation.Test/test_output/SerializeTests.ArrayOfGenerateSerialize/TestCase15.Class0.ISerdeInfoProvider.verified.cs
@@ -5,7 +5,7 @@ partial class TestCase15
 {
     partial class Class0
     {
-        private static global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
+        private static readonly global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
             "Class0",
         typeof(TestCase15.Class0).GetCustomAttributesData(),
         new (string, global::Serde.ISerdeInfo, System.Reflection.MemberInfo?)[] {

--- a/test/Serde.Generation.Test/test_output/SerializeTests.ArrayOfGenerateSerialize/TestCase15.Class1.ISerdeInfoProvider.verified.cs
+++ b/test/Serde.Generation.Test/test_output/SerializeTests.ArrayOfGenerateSerialize/TestCase15.Class1.ISerdeInfoProvider.verified.cs
@@ -5,7 +5,7 @@ partial class TestCase15
 {
     partial class Class1
     {
-        private static global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
+        private static readonly global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
             "Class1",
         typeof(TestCase15.Class1).GetCustomAttributesData(),
         new (string, global::Serde.ISerdeInfo, System.Reflection.MemberInfo?)[] {

--- a/test/Serde.Generation.Test/test_output/SerializeTests.BasicDU/Some.Nested.Namespace.Base._m_AProxy.ISerdeInfoProvider.verified.cs
+++ b/test/Serde.Generation.Test/test_output/SerializeTests.BasicDU/Some.Nested.Namespace.Base._m_AProxy.ISerdeInfoProvider.verified.cs
@@ -8,7 +8,7 @@ partial record Base
 {
     partial class _m_AProxy
     {
-        private static global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
+        private static readonly global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
             "A",
         typeof(Some.Nested.Namespace.Base.A).GetCustomAttributesData(),
         new (string, global::Serde.ISerdeInfo, System.Reflection.MemberInfo?)[] {

--- a/test/Serde.Generation.Test/test_output/SerializeTests.BasicDU/Some.Nested.Namespace.Base._m_BProxy.ISerdeInfoProvider.verified.cs
+++ b/test/Serde.Generation.Test/test_output/SerializeTests.BasicDU/Some.Nested.Namespace.Base._m_BProxy.ISerdeInfoProvider.verified.cs
@@ -8,7 +8,7 @@ partial record Base
 {
     partial class _m_BProxy
     {
-        private static global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
+        private static readonly global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
             "B",
         typeof(Some.Nested.Namespace.Base.B).GetCustomAttributesData(),
         new (string, global::Serde.ISerdeInfo, System.Reflection.MemberInfo?)[] {

--- a/test/Serde.Generation.Test/test_output/SerializeTests.DictionaryGenerate2/C.ISerdeInfoProvider.verified.cs
+++ b/test/Serde.Generation.Test/test_output/SerializeTests.DictionaryGenerate2/C.ISerdeInfoProvider.verified.cs
@@ -3,7 +3,7 @@
 #nullable enable
 partial record C
 {
-    private static global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
+    private static readonly global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
         "C",
     typeof(C).GetCustomAttributesData(),
     new (string, global::Serde.ISerdeInfo, System.Reflection.MemberInfo?)[] {

--- a/test/Serde.Generation.Test/test_output/SerializeTests.DictionaryGenerate2/C2.ISerdeInfoProvider.verified.cs
+++ b/test/Serde.Generation.Test/test_output/SerializeTests.DictionaryGenerate2/C2.ISerdeInfoProvider.verified.cs
@@ -3,7 +3,7 @@
 #nullable enable
 partial class C2
 {
-    private static global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
+    private static readonly global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
         "C2",
     typeof(C2).GetCustomAttributesData(),
     new (string, global::Serde.ISerdeInfo, System.Reflection.MemberInfo?)[] {

--- a/test/Serde.Generation.Test/test_output/SerializeTests.EnumMember/Some.Nested.Namespace.C.ISerdeInfoProvider.verified.cs
+++ b/test/Serde.Generation.Test/test_output/SerializeTests.EnumMember/Some.Nested.Namespace.C.ISerdeInfoProvider.verified.cs
@@ -6,7 +6,7 @@ namespace Some.Nested.Namespace;
 
 partial class C
 {
-    private static global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
+    private static readonly global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
         "C",
     typeof(Some.Nested.Namespace.C).GetCustomAttributesData(),
     new (string, global::Serde.ISerdeInfo, System.Reflection.MemberInfo?)[] {

--- a/test/Serde.Generation.Test/test_output/SerializeTests.NestedEnumWrapper/C.ISerdeInfoProvider.verified.cs
+++ b/test/Serde.Generation.Test/test_output/SerializeTests.NestedEnumWrapper/C.ISerdeInfoProvider.verified.cs
@@ -3,7 +3,7 @@
 #nullable enable
 partial class C
 {
-    private static global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
+    private static readonly global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
         "C",
     typeof(C).GetCustomAttributesData(),
     new (string, global::Serde.ISerdeInfo, System.Reflection.MemberInfo?)[] {

--- a/test/Serde.Generation.Test/test_output/SerializeTests.NestedExplicitSerializeWrapper/OPTSWrap.ISerdeInfoProvider.verified.cs
+++ b/test/Serde.Generation.Test/test_output/SerializeTests.NestedExplicitSerializeWrapper/OPTSWrap.ISerdeInfoProvider.verified.cs
@@ -3,7 +3,7 @@
 #nullable enable
 partial class OPTSWrap
 {
-    private static global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
+    private static readonly global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
         "BIND_OPTS",
     typeof(System.Runtime.InteropServices.ComTypes.BIND_OPTS).GetCustomAttributesData(),
     new (string, global::Serde.ISerdeInfo, System.Reflection.MemberInfo?)[] {

--- a/test/Serde.Generation.Test/test_output/SerializeTests.NestedExplicitSerializeWrapper/S.ISerdeInfoProvider.verified.cs
+++ b/test/Serde.Generation.Test/test_output/SerializeTests.NestedExplicitSerializeWrapper/S.ISerdeInfoProvider.verified.cs
@@ -3,7 +3,7 @@
 #nullable enable
 partial struct S
 {
-    private static global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
+    private static readonly global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
         "S",
     typeof(S).GetCustomAttributesData(),
     new (string, global::Serde.ISerdeInfo, System.Reflection.MemberInfo?)[] {

--- a/test/Serde.Generation.Test/test_output/SerializeTests.SerializeOnlyWrapper/SectionWrap.ISerdeInfoProvider.verified.cs
+++ b/test/Serde.Generation.Test/test_output/SerializeTests.SerializeOnlyWrapper/SectionWrap.ISerdeInfoProvider.verified.cs
@@ -3,7 +3,7 @@
 #nullable enable
 partial record struct SectionWrap
 {
-    private static global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
+    private static readonly global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
         "Section",
     typeof(System.Collections.Specialized.BitVector32.Section).GetCustomAttributesData(),
     new (string, global::Serde.ISerdeInfo, System.Reflection.MemberInfo?)[] {

--- a/test/Serde.Generation.Test/test_output/SerializeTests/DictionaryGenerate#C.ISerdeInfoProvider.verified.cs
+++ b/test/Serde.Generation.Test/test_output/SerializeTests/DictionaryGenerate#C.ISerdeInfoProvider.verified.cs
@@ -3,7 +3,7 @@
 #nullable enable
 partial class C
 {
-    private static global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
+    private static readonly global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
         "C",
     typeof(C).GetCustomAttributesData(),
     new (string, global::Serde.ISerdeInfo, System.Reflection.MemberInfo?)[] {

--- a/test/Serde.Generation.Test/test_output/SerializeTests/ExplicitGenericWrapper#C.ISerdeInfoProvider.verified.cs
+++ b/test/Serde.Generation.Test/test_output/SerializeTests/ExplicitGenericWrapper#C.ISerdeInfoProvider.verified.cs
@@ -3,7 +3,7 @@
 #nullable enable
 partial class C
 {
-    private static global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
+    private static readonly global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
         "C",
     typeof(C).GetCustomAttributesData(),
     new (string, global::Serde.ISerdeInfo, System.Reflection.MemberInfo?)[] {

--- a/test/Serde.Generation.Test/test_output/SerializeTests/ExplicitWrapper#C.ISerdeInfoProvider.verified.cs
+++ b/test/Serde.Generation.Test/test_output/SerializeTests/ExplicitWrapper#C.ISerdeInfoProvider.verified.cs
@@ -3,7 +3,7 @@
 #nullable enable
 partial class C
 {
-    private static global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
+    private static readonly global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
         "C",
     typeof(C).GetCustomAttributesData(),
     new (string, global::Serde.ISerdeInfo, System.Reflection.MemberInfo?)[] {

--- a/test/Serde.Generation.Test/test_output/SerializeTests/InlineMember#StringWrap.ISerdeInfoProvider.verified.cs
+++ b/test/Serde.Generation.Test/test_output/SerializeTests/InlineMember#StringWrap.ISerdeInfoProvider.verified.cs
@@ -1,0 +1,8 @@
+﻿//HintName: StringWrap.ISerdeInfoProvider.cs
+
+#nullable enable
+partial record StringWrap
+{
+    private static readonly global::Serde.ISerdeInfo s_serdeInfo
+        = global::Serde.SerdeInfoProvider.GetSerializeInfo<string, global::Serde.StringProxy>();
+}

--- a/test/Serde.Generation.Test/test_output/SerializeTests/InlineMember#StringWrap.ISerialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/SerializeTests/InlineMember#StringWrap.ISerialize.verified.cs
@@ -1,0 +1,25 @@
+﻿//HintName: StringWrap.ISerialize.cs
+
+#nullable enable
+
+using System;
+using Serde;
+partial record StringWrap : Serde.ISerializeProvider<StringWrap>
+{
+    static ISerialize<StringWrap> ISerializeProvider<StringWrap>.Instance
+        => _SerObj.Instance;
+
+    sealed partial class _SerObj  : global::Serde.ISerialize<StringWrap>
+    {
+        global::Serde.ISerdeInfo global::Serde.ISerdeInfoProvider.SerdeInfo => StringWrap.s_serdeInfo;
+
+        void global::Serde.ISerialize<StringWrap>.Serialize(StringWrap value, global::Serde.ISerializer serializer)
+        {
+            var serObj = global::Serde.SerializeProvider.GetSerialize<string, global::Serde.StringProxy>();
+            serObj.Serialize(value.Value, serializer);
+        }
+        public static readonly _SerObj Instance = new();
+        private _SerObj() { }
+
+    }
+}

--- a/test/Serde.Generation.Test/test_output/SerializeTests/MemberSkip#Rgb.ISerdeInfoProvider.verified.cs
+++ b/test/Serde.Generation.Test/test_output/SerializeTests/MemberSkip#Rgb.ISerdeInfoProvider.verified.cs
@@ -3,7 +3,7 @@
 #nullable enable
 partial struct Rgb
 {
-    private static global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
+    private static readonly global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
         "Rgb",
     typeof(Rgb).GetCustomAttributesData(),
     new (string, global::Serde.ISerdeInfo, System.Reflection.MemberInfo?)[] {

--- a/test/Serde.Generation.Test/test_output/SerializeTests/MemberSkipDeserialize#Rgb.ISerdeInfoProvider.verified.cs
+++ b/test/Serde.Generation.Test/test_output/SerializeTests/MemberSkipDeserialize#Rgb.ISerdeInfoProvider.verified.cs
@@ -3,7 +3,7 @@
 #nullable enable
 partial struct Rgb
 {
-    private static global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
+    private static readonly global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
         "Rgb",
     typeof(Rgb).GetCustomAttributesData(),
     new (string, global::Serde.ISerdeInfo, System.Reflection.MemberInfo?)[] {

--- a/test/Serde.Generation.Test/test_output/SerializeTests/MemberSkipSerialize#Rgb.ISerdeInfoProvider.verified.cs
+++ b/test/Serde.Generation.Test/test_output/SerializeTests/MemberSkipSerialize#Rgb.ISerdeInfoProvider.verified.cs
@@ -3,7 +3,7 @@
 #nullable enable
 partial struct Rgb
 {
-    private static global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
+    private static readonly global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
         "Rgb",
     typeof(Rgb).GetCustomAttributesData(),
     new (string, global::Serde.ISerdeInfo, System.Reflection.MemberInfo?)[] {

--- a/test/Serde.Generation.Test/test_output/SerializeTests/MultipleInlineMember#FinalDiagnostics.verified.txt
+++ b/test/Serde.Generation.Test/test_output/SerializeTests/MultipleInlineMember#FinalDiagnostics.verified.txt
@@ -1,0 +1,24 @@
+﻿[
+  {
+    "Id": "CS0535",
+    "Title": "",
+    "Severity": "Error",
+    "WarningLevel": "0",
+    "Location": "SerdeGenerator/Serde.SerdeImplRoslynGenerator/StringWrap.ISerialize.cs: (10,36)-(10,64)",
+    "HelpLink": "https://msdn.microsoft.com/query/roslyn.query?appId=roslyn&k=k(CS0535)",
+    "MessageFormat": "'{0}' does not implement interface member '{1}'",
+    "Message": "'StringWrap._SerObj' does not implement interface member 'ISerialize<StringWrap>.Serialize(StringWrap, ISerializer)'",
+    "Category": "Compiler"
+  },
+  {
+    "Id": "CS0117",
+    "Title": "",
+    "Severity": "Error",
+    "WarningLevel": "0",
+    "Location": "SerdeGenerator/Serde.SerdeImplRoslynGenerator/StringWrap.ISerialize.cs: (12,90)-(12,101)",
+    "HelpLink": "https://msdn.microsoft.com/query/roslyn.query?appId=roslyn&k=k(CS0117)",
+    "MessageFormat": "'{0}' does not contain a definition for '{1}'",
+    "Message": "'StringWrap' does not contain a definition for 's_serdeInfo'",
+    "Category": "Compiler"
+  }
+]

--- a/test/Serde.Generation.Test/test_output/SerializeTests/MultipleInlineMember#StringWrap.ISerialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/SerializeTests/MultipleInlineMember#StringWrap.ISerialize.verified.cs
@@ -1,0 +1,20 @@
+﻿//HintName: StringWrap.ISerialize.cs
+
+#nullable enable
+
+using System;
+using Serde;
+partial record StringWrap : Serde.ISerializeProvider<StringWrap>
+{
+    static ISerialize<StringWrap> ISerializeProvider<StringWrap>.Instance
+        => _SerObj.Instance;
+
+    sealed partial class _SerObj  : Serde.ISerialize<StringWrap>
+    {
+        global::Serde.ISerdeInfo global::Serde.ISerdeInfoProvider.SerdeInfo => StringWrap.s_serdeInfo;
+
+        public static readonly _SerObj Instance = new();
+        private _SerObj() { }
+
+    }
+}

--- a/test/Serde.Generation.Test/test_output/SerializeTests/MultipleInlineMember.verified.txt
+++ b/test/Serde.Generation.Test/test_output/SerializeTests/MultipleInlineMember.verified.txt
@@ -1,0 +1,14 @@
+﻿{
+  Diagnostics: [
+    {
+      Id: ERR_MultipleInline,
+      Title: ,
+      Severity: Error,
+      WarningLevel: 0,
+      Location: : (2,0)-(8,2),
+      MessageFormat: SerdeMemberOptions.Inline can only be appled to one member.,
+      Message: SerdeMemberOptions.Inline can only be appled to one member.,
+      Category: Serde
+    }
+  ]
+}

--- a/test/Serde.Generation.Test/test_output/SerializeTests/NestedArray#C.ISerdeInfoProvider.verified.cs
+++ b/test/Serde.Generation.Test/test_output/SerializeTests/NestedArray#C.ISerdeInfoProvider.verified.cs
@@ -3,7 +3,7 @@
 #nullable enable
 partial class C
 {
-    private static global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
+    private static readonly global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
         "C",
     typeof(C).GetCustomAttributesData(),
     new (string, global::Serde.ISerdeInfo, System.Reflection.MemberInfo?)[] {

--- a/test/Serde.Generation.Test/test_output/SerializeTests/NestedArray2#C.ISerdeInfoProvider.verified.cs
+++ b/test/Serde.Generation.Test/test_output/SerializeTests/NestedArray2#C.ISerdeInfoProvider.verified.cs
@@ -3,7 +3,7 @@
 #nullable enable
 partial class C
 {
-    private static global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
+    private static readonly global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
         "C",
     typeof(C).GetCustomAttributesData(),
     new (string, global::Serde.ISerdeInfo, System.Reflection.MemberInfo?)[] {

--- a/test/Serde.Generation.Test/test_output/SerializeTests/NestedPartialClasses#A.B.C.D.ISerdeInfoProvider.verified.cs
+++ b/test/Serde.Generation.Test/test_output/SerializeTests/NestedPartialClasses#A.B.C.D.ISerdeInfoProvider.verified.cs
@@ -9,7 +9,7 @@ partial class A
         {
             partial class D
             {
-                private static global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
+                private static readonly global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
                     "D",
                 typeof(A.B.C.D).GetCustomAttributesData(),
                 new (string, global::Serde.ISerdeInfo, System.Reflection.MemberInfo?)[] {

--- a/test/Serde.Generation.Test/test_output/SerializeTests/NoGenerateGeneric#C.ISerdeInfoProvider.verified.cs
+++ b/test/Serde.Generation.Test/test_output/SerializeTests/NoGenerateGeneric#C.ISerdeInfoProvider.verified.cs
@@ -3,7 +3,7 @@
 #nullable enable
 partial class C<T>
 {
-    private static global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
+    private static readonly global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
         "C",
     typeof(C<>).GetCustomAttributesData(),
     new (string, global::Serde.ISerdeInfo, System.Reflection.MemberInfo?)[] {

--- a/test/Serde.Generation.Test/test_output/SerializeTests/NullableFields#S.ISerdeInfoProvider.verified.cs
+++ b/test/Serde.Generation.Test/test_output/SerializeTests/NullableFields#S.ISerdeInfoProvider.verified.cs
@@ -3,7 +3,7 @@
 #nullable enable
 partial struct S<T1, T2, TSerialize>
 {
-    private static global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
+    private static readonly global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
         "S",
     typeof(S<,,>).GetCustomAttributesData(),
     new (string, global::Serde.ISerdeInfo, System.Reflection.MemberInfo?)[] {

--- a/test/Serde.Generation.Test/test_output/SerializeTests/NullableRefFields#S.ISerdeInfoProvider.verified.cs
+++ b/test/Serde.Generation.Test/test_output/SerializeTests/NullableRefFields#S.ISerdeInfoProvider.verified.cs
@@ -3,7 +3,7 @@
 #nullable enable
 partial struct S<T1, T2, T3, T4, T5>
 {
-    private static global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
+    private static readonly global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
         "S",
     typeof(S<,,,,>).GetCustomAttributesData(),
     new (string, global::Serde.ISerdeInfo, System.Reflection.MemberInfo?)[] {

--- a/test/Serde.Generation.Test/test_output/SerializeTests/Rgb#Rgb.ISerdeInfoProvider.verified.cs
+++ b/test/Serde.Generation.Test/test_output/SerializeTests/Rgb#Rgb.ISerdeInfoProvider.verified.cs
@@ -3,7 +3,7 @@
 #nullable enable
 partial struct Rgb
 {
-    private static global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
+    private static readonly global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
         "Rgb",
     typeof(Rgb).GetCustomAttributesData(),
     new (string, global::Serde.ISerdeInfo, System.Reflection.MemberInfo?)[] {

--- a/test/Serde.Generation.Test/test_output/SerializeTests/SingleInlineMemberWithOthers#FinalDiagnostics.verified.txt
+++ b/test/Serde.Generation.Test/test_output/SerializeTests/SingleInlineMemberWithOthers#FinalDiagnostics.verified.txt
@@ -1,0 +1,13 @@
+﻿[
+  {
+    "Id": "CS0535",
+    "Title": "",
+    "Severity": "Error",
+    "WarningLevel": "0",
+    "Location": "SerdeGenerator/Serde.SerdeImplRoslynGenerator/StringWrap.ISerialize.cs: (10,36)-(10,64)",
+    "HelpLink": "https://msdn.microsoft.com/query/roslyn.query?appId=roslyn&k=k(CS0535)",
+    "MessageFormat": "'{0}' does not implement interface member '{1}'",
+    "Message": "'StringWrap._SerObj' does not implement interface member 'ISerialize<StringWrap>.Serialize(StringWrap, ISerializer)'",
+    "Category": "Compiler"
+  }
+]

--- a/test/Serde.Generation.Test/test_output/SerializeTests/SingleInlineMemberWithOthers#StringWrap.ISerdeInfoProvider.verified.cs
+++ b/test/Serde.Generation.Test/test_output/SerializeTests/SingleInlineMemberWithOthers#StringWrap.ISerdeInfoProvider.verified.cs
@@ -1,0 +1,8 @@
+﻿//HintName: StringWrap.ISerdeInfoProvider.cs
+
+#nullable enable
+partial record StringWrap
+{
+    private static readonly global::Serde.ISerdeInfo s_serdeInfo
+        = global::Serde.SerdeInfoProvider.GetSerializeInfo<string, global::Serde.StringProxy>();
+}

--- a/test/Serde.Generation.Test/test_output/SerializeTests/SingleInlineMemberWithOthers#StringWrap.ISerialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/SerializeTests/SingleInlineMemberWithOthers#StringWrap.ISerialize.verified.cs
@@ -1,0 +1,20 @@
+﻿//HintName: StringWrap.ISerialize.cs
+
+#nullable enable
+
+using System;
+using Serde;
+partial record StringWrap : Serde.ISerializeProvider<StringWrap>
+{
+    static ISerialize<StringWrap> ISerializeProvider<StringWrap>.Instance
+        => _SerObj.Instance;
+
+    sealed partial class _SerObj  : Serde.ISerialize<StringWrap>
+    {
+        global::Serde.ISerdeInfo global::Serde.ISerdeInfoProvider.SerdeInfo => StringWrap.s_serdeInfo;
+
+        public static readonly _SerObj Instance = new();
+        private _SerObj() { }
+
+    }
+}

--- a/test/Serde.Generation.Test/test_output/SerializeTests/SingleInlineMemberWithOthers.verified.txt
+++ b/test/Serde.Generation.Test/test_output/SerializeTests/SingleInlineMemberWithOthers.verified.txt
@@ -1,0 +1,14 @@
+﻿{
+  Diagnostics: [
+    {
+      Id: ERR_InlineWithOtherMembers,
+      Title: ,
+      Severity: Error,
+      WarningLevel: 0,
+      Location: : (2,0)-(7,2),
+      MessageFormat: SerdeMemberOptions.Inline cannot be used when the type has multiple members.,
+      Message: SerdeMemberOptions.Inline cannot be used when the type has multiple members.,
+      Category: Serde
+    }
+  ]
+}

--- a/test/Serde.Generation.Test/test_output/SerializeTests/TypeDoesntImplementISerialize#S1.ISerdeInfoProvider.verified.cs
+++ b/test/Serde.Generation.Test/test_output/SerializeTests/TypeDoesntImplementISerialize#S1.ISerdeInfoProvider.verified.cs
@@ -3,7 +3,7 @@
 #nullable enable
 partial struct S1
 {
-    private static global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
+    private static readonly global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
         "S1",
     typeof(S1).GetCustomAttributesData(),
     new (string, global::Serde.ISerdeInfo, System.Reflection.MemberInfo?)[] {

--- a/test/Serde.Generation.Test/test_output/SerializeTests/TypeWithArray#C.ISerdeInfoProvider.verified.cs
+++ b/test/Serde.Generation.Test/test_output/SerializeTests/TypeWithArray#C.ISerdeInfoProvider.verified.cs
@@ -3,7 +3,7 @@
 #nullable enable
 partial class C
 {
-    private static global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
+    private static readonly global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
         "C",
     typeof(C).GetCustomAttributesData(),
     new (string, global::Serde.ISerdeInfo, System.Reflection.MemberInfo?)[] {

--- a/test/Serde.Generation.Test/test_output/SerializeTests/WrongGenericWrapperForm#C.ISerdeInfoProvider.verified.cs
+++ b/test/Serde.Generation.Test/test_output/SerializeTests/WrongGenericWrapperForm#C.ISerdeInfoProvider.verified.cs
@@ -3,7 +3,7 @@
 #nullable enable
 partial class C
 {
-    private static global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
+    private static readonly global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
         "C",
     typeof(C).GetCustomAttributesData(),
     new (string, global::Serde.ISerdeInfo, System.Reflection.MemberInfo?)[] {

--- a/test/Serde.Generation.Test/test_output/WrapperTests.AttributeWrapperTest/Address.ISerdeInfoProvider.verified.cs
+++ b/test/Serde.Generation.Test/test_output/WrapperTests.AttributeWrapperTest/Address.ISerdeInfoProvider.verified.cs
@@ -3,7 +3,7 @@
 #nullable enable
 partial class Address
 {
-    private static global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
+    private static readonly global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
         "Address",
     typeof(Address).GetCustomAttributesData(),
     new (string, global::Serde.ISerdeInfo, System.Reflection.MemberInfo?)[] {

--- a/test/Serde.Generation.Test/test_output/WrapperTests.ExplicitInvalidGenericWrapper/Container.ISerdeInfoProvider.verified.cs
+++ b/test/Serde.Generation.Test/test_output/WrapperTests.ExplicitInvalidGenericWrapper/Container.ISerdeInfoProvider.verified.cs
@@ -3,7 +3,7 @@
 #nullable enable
 partial record Container
 {
-    private static global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
+    private static readonly global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
         "Container",
     typeof(Container).GetCustomAttributesData(),
     new (string, global::Serde.ISerdeInfo, System.Reflection.MemberInfo?)[] {

--- a/test/Serde.Generation.Test/test_output/WrapperTests.ExplicitInvalidGenericWrapper/Original.ISerdeInfoProvider.verified.cs
+++ b/test/Serde.Generation.Test/test_output/WrapperTests.ExplicitInvalidGenericWrapper/Original.ISerdeInfoProvider.verified.cs
@@ -3,7 +3,7 @@
 #nullable enable
 partial record struct Original
 {
-    private static global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
+    private static readonly global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
         "Original",
     typeof(Original).GetCustomAttributesData(),
     new (string, global::Serde.ISerdeInfo, System.Reflection.MemberInfo?)[] {

--- a/test/Serde.Generation.Test/test_output/WrapperTests.ExplicitNullableProxy/Container.ISerdeInfoProvider.verified.cs
+++ b/test/Serde.Generation.Test/test_output/WrapperTests.ExplicitNullableProxy/Container.ISerdeInfoProvider.verified.cs
@@ -3,7 +3,7 @@
 #nullable enable
 partial record Container
 {
-    private static global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
+    private static readonly global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
         "Container",
     typeof(Container).GetCustomAttributesData(),
     new (string, global::Serde.ISerdeInfo, System.Reflection.MemberInfo?)[] {

--- a/test/Serde.Generation.Test/test_output/WrapperTests.ExplicitNullableProxy/Original.ISerdeInfoProvider.verified.cs
+++ b/test/Serde.Generation.Test/test_output/WrapperTests.ExplicitNullableProxy/Original.ISerdeInfoProvider.verified.cs
@@ -3,7 +3,7 @@
 #nullable enable
 partial record struct Original
 {
-    private static global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
+    private static readonly global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
         "Original",
     typeof(Original).GetCustomAttributesData(),
     new (string, global::Serde.ISerdeInfo, System.Reflection.MemberInfo?)[] {

--- a/test/Serde.Generation.Test/test_output/WrapperTests.GenerateSerdeWrap/OPTSWrap.ISerdeInfoProvider.verified.cs
+++ b/test/Serde.Generation.Test/test_output/WrapperTests.GenerateSerdeWrap/OPTSWrap.ISerdeInfoProvider.verified.cs
@@ -3,7 +3,7 @@
 #nullable enable
 partial record struct OPTSWrap
 {
-    private static global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
+    private static readonly global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
         "BIND_OPTS",
     typeof(System.Runtime.InteropServices.ComTypes.BIND_OPTS).GetCustomAttributesData(),
     new (string, global::Serde.ISerdeInfo, System.Reflection.MemberInfo?)[] {

--- a/test/Serde.Generation.Test/test_output/WrapperTests.ImmutableArrayEnumDeserialize/Test.ChannelList.ISerdeInfoProvider.verified.cs
+++ b/test/Serde.Generation.Test/test_output/WrapperTests.ImmutableArrayEnumDeserialize/Test.ChannelList.ISerdeInfoProvider.verified.cs
@@ -6,7 +6,7 @@ namespace Test;
 
 partial record struct ChannelList
 {
-    private static global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
+    private static readonly global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
         "ChannelList",
     typeof(Test.ChannelList).GetCustomAttributesData(),
     new (string, global::Serde.ISerdeInfo, System.Reflection.MemberInfo?)[] {

--- a/test/Serde.Generation.Test/test_output/WrapperTests.InvalidNestedWrapper/Outer.SectionWrap.ISerdeInfoProvider.verified.cs
+++ b/test/Serde.Generation.Test/test_output/WrapperTests.InvalidNestedWrapper/Outer.SectionWrap.ISerdeInfoProvider.verified.cs
@@ -5,7 +5,7 @@ partial class Outer
 {
     partial class SectionWrap
     {
-        private static global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
+        private static readonly global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
             "Section",
         typeof(System.Collections.Specialized.BitVector32.Section).GetCustomAttributesData(),
         new (string, global::Serde.ISerdeInfo, System.Reflection.MemberInfo?)[] {

--- a/test/Serde.Generation.Test/test_output/WrapperTests.InvalidNestedWrapper/S.ISerdeInfoProvider.verified.cs
+++ b/test/Serde.Generation.Test/test_output/WrapperTests.InvalidNestedWrapper/S.ISerdeInfoProvider.verified.cs
@@ -3,7 +3,7 @@
 #nullable enable
 partial struct S
 {
-    private static global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
+    private static readonly global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
         "S",
     typeof(S).GetCustomAttributesData(),
     new (string, global::Serde.ISerdeInfo, System.Reflection.MemberInfo?)[] {

--- a/test/Serde.Generation.Test/test_output/WrapperTests.NestedDeserializeWrap/C.ISerdeInfoProvider.verified.cs
+++ b/test/Serde.Generation.Test/test_output/WrapperTests.NestedDeserializeWrap/C.ISerdeInfoProvider.verified.cs
@@ -3,7 +3,7 @@
 #nullable enable
 partial class C
 {
-    private static global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
+    private static readonly global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
         "C",
     typeof(C).GetCustomAttributesData(),
     new (string, global::Serde.ISerdeInfo, System.Reflection.MemberInfo?)[] {

--- a/test/Serde.Generation.Test/test_output/WrapperTests.NestedDeserializeWrap/OPTSWrap.ISerdeInfoProvider.verified.cs
+++ b/test/Serde.Generation.Test/test_output/WrapperTests.NestedDeserializeWrap/OPTSWrap.ISerdeInfoProvider.verified.cs
@@ -3,7 +3,7 @@
 #nullable enable
 partial class OPTSWrap
 {
-    private static global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
+    private static readonly global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
         "BIND_OPTS",
     typeof(System.Runtime.InteropServices.ComTypes.BIND_OPTS).GetCustomAttributesData(),
     new (string, global::Serde.ISerdeInfo, System.Reflection.MemberInfo?)[] {

--- a/test/Serde.Generation.Test/test_output/WrapperTests.NestedExplicitWrapper/Outer.SectionWrap.ISerdeInfoProvider.verified.cs
+++ b/test/Serde.Generation.Test/test_output/WrapperTests.NestedExplicitWrapper/Outer.SectionWrap.ISerdeInfoProvider.verified.cs
@@ -5,7 +5,7 @@ partial class Outer
 {
     partial record struct SectionWrap
     {
-        private static global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
+        private static readonly global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
             "Section",
         typeof(System.Collections.Specialized.BitVector32.Section).GetCustomAttributesData(),
         new (string, global::Serde.ISerdeInfo, System.Reflection.MemberInfo?)[] {

--- a/test/Serde.Generation.Test/test_output/WrapperTests.NestedExplicitWrapper/S.ISerdeInfoProvider.verified.cs
+++ b/test/Serde.Generation.Test/test_output/WrapperTests.NestedExplicitWrapper/S.ISerdeInfoProvider.verified.cs
@@ -3,7 +3,7 @@
 #nullable enable
 partial struct S
 {
-    private static global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
+    private static readonly global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
         "S",
     typeof(S).GetCustomAttributesData(),
     new (string, global::Serde.ISerdeInfo, System.Reflection.MemberInfo?)[] {

--- a/test/Serde.Generation.Test/test_output/WrapperTests.PointWrap/PointWrap.ISerdeInfoProvider.verified.cs
+++ b/test/Serde.Generation.Test/test_output/WrapperTests.PointWrap/PointWrap.ISerdeInfoProvider.verified.cs
@@ -3,7 +3,7 @@
 #nullable enable
 partial struct PointWrap
 {
-    private static global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
+    private static readonly global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
         "Point",
     typeof(Point).GetCustomAttributesData(),
     new (string, global::Serde.ISerdeInfo, System.Reflection.MemberInfo?)[] {

--- a/test/Serde.Generation.Test/test_output/WrapperTests.PositionalRecordDeserialize/R.ISerdeInfoProvider.verified.cs
+++ b/test/Serde.Generation.Test/test_output/WrapperTests.PositionalRecordDeserialize/R.ISerdeInfoProvider.verified.cs
@@ -3,7 +3,7 @@
 #nullable enable
 partial record R
 {
-    private static global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
+    private static readonly global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
         "R",
     typeof(R).GetCustomAttributesData(),
     new (string, global::Serde.ISerdeInfo, System.Reflection.MemberInfo?)[] {

--- a/test/Serde.Generation.Test/test_output/WrapperTests.RecursiveType/Test.Parent.ISerdeInfoProvider.verified.cs
+++ b/test/Serde.Generation.Test/test_output/WrapperTests.RecursiveType/Test.Parent.ISerdeInfoProvider.verified.cs
@@ -6,7 +6,7 @@ namespace Test;
 
 partial record Parent
 {
-    private static global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
+    private static readonly global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
         "Parent",
     typeof(Test.Parent).GetCustomAttributesData(),
     new (string, global::Serde.ISerdeInfo, System.Reflection.MemberInfo?)[] {

--- a/test/Serde.Generation.Test/test_output/WrapperTests.RecursiveType/Test.RecursiveWrap.ISerdeInfoProvider.verified.cs
+++ b/test/Serde.Generation.Test/test_output/WrapperTests.RecursiveType/Test.RecursiveWrap.ISerdeInfoProvider.verified.cs
@@ -6,7 +6,7 @@ namespace Test;
 
 partial class RecursiveWrap
 {
-    private static global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
+    private static readonly global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
         "Recursive",
     typeof(Recursive).GetCustomAttributesData(),
     new (string, global::Serde.ISerdeInfo, System.Reflection.MemberInfo?)[] {

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Json.Test.InvalidJsonTests.ClassWithDictionaryOfIntArray.ISerdeInfoProvider.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Json.Test.InvalidJsonTests.ClassWithDictionaryOfIntArray.ISerdeInfoProvider.cs
@@ -7,7 +7,7 @@ partial class InvalidJsonTests
 {
     partial class ClassWithDictionaryOfIntArray
     {
-        private static global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
+        private static readonly global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
             "ClassWithDictionaryOfIntArray",
         typeof(Serde.Json.Test.InvalidJsonTests.ClassWithDictionaryOfIntArray).GetCustomAttributesData(),
         new (string, global::Serde.ISerdeInfo, System.Reflection.MemberInfo?)[] {

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Json.Test.InvalidJsonTests.ClassWithDictionaryOfPoco.ISerdeInfoProvider.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Json.Test.InvalidJsonTests.ClassWithDictionaryOfPoco.ISerdeInfoProvider.cs
@@ -7,7 +7,7 @@ partial class InvalidJsonTests
 {
     partial class ClassWithDictionaryOfPoco
     {
-        private static global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
+        private static readonly global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
             "ClassWithDictionaryOfPoco",
         typeof(Serde.Json.Test.InvalidJsonTests.ClassWithDictionaryOfPoco).GetCustomAttributesData(),
         new (string, global::Serde.ISerdeInfo, System.Reflection.MemberInfo?)[] {

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Json.Test.InvalidJsonTests.ClassWithDictionaryOfPocoList.ISerdeInfoProvider.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Json.Test.InvalidJsonTests.ClassWithDictionaryOfPocoList.ISerdeInfoProvider.cs
@@ -7,7 +7,7 @@ partial class InvalidJsonTests
 {
     partial class ClassWithDictionaryOfPocoList
     {
-        private static global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
+        private static readonly global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
             "ClassWithDictionaryOfPocoList",
         typeof(Serde.Json.Test.InvalidJsonTests.ClassWithDictionaryOfPocoList).GetCustomAttributesData(),
         new (string, global::Serde.ISerdeInfo, System.Reflection.MemberInfo?)[] {

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Json.Test.InvalidJsonTests.ClassWithInt.ISerdeInfoProvider.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Json.Test.InvalidJsonTests.ClassWithInt.ISerdeInfoProvider.cs
@@ -7,7 +7,7 @@ partial class InvalidJsonTests
 {
     partial class ClassWithInt
     {
-        private static global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
+        private static readonly global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
             "ClassWithInt",
         typeof(Serde.Json.Test.InvalidJsonTests.ClassWithInt).GetCustomAttributesData(),
         new (string, global::Serde.ISerdeInfo, System.Reflection.MemberInfo?)[] {

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Json.Test.InvalidJsonTests.ClassWithIntArray.ISerdeInfoProvider.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Json.Test.InvalidJsonTests.ClassWithIntArray.ISerdeInfoProvider.cs
@@ -7,7 +7,7 @@ partial class InvalidJsonTests
 {
     partial class ClassWithIntArray
     {
-        private static global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
+        private static readonly global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
             "ClassWithIntArray",
         typeof(Serde.Json.Test.InvalidJsonTests.ClassWithIntArray).GetCustomAttributesData(),
         new (string, global::Serde.ISerdeInfo, System.Reflection.MemberInfo?)[] {

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Json.Test.InvalidJsonTests.ClassWithIntList.ISerdeInfoProvider.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Json.Test.InvalidJsonTests.ClassWithIntList.ISerdeInfoProvider.cs
@@ -7,7 +7,7 @@ partial class InvalidJsonTests
 {
     partial class ClassWithIntList
     {
-        private static global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
+        private static readonly global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
             "ClassWithIntList",
         typeof(Serde.Json.Test.InvalidJsonTests.ClassWithIntList).GetCustomAttributesData(),
         new (string, global::Serde.ISerdeInfo, System.Reflection.MemberInfo?)[] {

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Json.Test.InvalidJsonTests.ClassWithPoco.ISerdeInfoProvider.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Json.Test.InvalidJsonTests.ClassWithPoco.ISerdeInfoProvider.cs
@@ -7,7 +7,7 @@ partial class InvalidJsonTests
 {
     partial class ClassWithPoco
     {
-        private static global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
+        private static readonly global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
             "ClassWithPoco",
         typeof(Serde.Json.Test.InvalidJsonTests.ClassWithPoco).GetCustomAttributesData(),
         new (string, global::Serde.ISerdeInfo, System.Reflection.MemberInfo?)[] {

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Json.Test.InvalidJsonTests.ClassWithPocoArray.ISerdeInfoProvider.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Json.Test.InvalidJsonTests.ClassWithPocoArray.ISerdeInfoProvider.cs
@@ -7,7 +7,7 @@ partial class InvalidJsonTests
 {
     partial class ClassWithPocoArray
     {
-        private static global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
+        private static readonly global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
             "ClassWithPocoArray",
         typeof(Serde.Json.Test.InvalidJsonTests.ClassWithPocoArray).GetCustomAttributesData(),
         new (string, global::Serde.ISerdeInfo, System.Reflection.MemberInfo?)[] {

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Json.Test.InvalidJsonTests.NoComma.ISerdeInfoProvider.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Json.Test.InvalidJsonTests.NoComma.ISerdeInfoProvider.cs
@@ -7,7 +7,7 @@ partial class InvalidJsonTests
 {
     partial record NoComma
     {
-        private static global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
+        private static readonly global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
             "NoComma",
         typeof(Serde.Json.Test.InvalidJsonTests.NoComma).GetCustomAttributesData(),
         new (string, global::Serde.ISerdeInfo, System.Reflection.MemberInfo?)[] {

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Json.Test.InvalidJsonTests.PocoWithParameterizedCtor.ISerdeInfoProvider.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Json.Test.InvalidJsonTests.PocoWithParameterizedCtor.ISerdeInfoProvider.cs
@@ -7,7 +7,7 @@ partial class InvalidJsonTests
 {
     partial class PocoWithParameterizedCtor
     {
-        private static global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
+        private static readonly global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
             "PocoWithParameterizedCtor",
         typeof(Serde.Json.Test.InvalidJsonTests.PocoWithParameterizedCtor).GetCustomAttributesData(),
         new (string, global::Serde.ISerdeInfo, System.Reflection.MemberInfo?)[] {

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Json.Test.InvalidJsonTests.SkipClass.ISerdeInfoProvider.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Json.Test.InvalidJsonTests.SkipClass.ISerdeInfoProvider.cs
@@ -7,7 +7,7 @@ partial class InvalidJsonTests
 {
     partial class SkipClass
     {
-        private static global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
+        private static readonly global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
             "SkipClass",
         typeof(Serde.Json.Test.InvalidJsonTests.SkipClass).GetCustomAttributesData(),
         new (string, global::Serde.ISerdeInfo, System.Reflection.MemberInfo?)[] {

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Json.Test.Poco.ISerdeInfoProvider.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Json.Test.Poco.ISerdeInfoProvider.cs
@@ -5,7 +5,7 @@ namespace Serde.Json.Test;
 
 partial class Poco
 {
-    private static global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
+    private static readonly global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
         "Poco",
     typeof(Serde.Json.Test.Poco).GetCustomAttributesData(),
     new (string, global::Serde.ISerdeInfo, System.Reflection.MemberInfo?)[] {

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Json.Test.PocoDictionary.ISerdeInfoProvider.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Json.Test.PocoDictionary.ISerdeInfoProvider.cs
@@ -5,7 +5,7 @@ namespace Serde.Json.Test;
 
 partial class PocoDictionary
 {
-    private static global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
+    private static readonly global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
         "PocoDictionary",
     typeof(Serde.Json.Test.PocoDictionary).GetCustomAttributesData(),
     new (string, global::Serde.ISerdeInfo, System.Reflection.MemberInfo?)[] {

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.AllInOne.ISerdeInfoProvider.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.AllInOne.ISerdeInfoProvider.cs
@@ -5,7 +5,7 @@ namespace Serde.Test;
 
 partial record AllInOne
 {
-    private static global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
+    private static readonly global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
         "AllInOne",
     typeof(Serde.Test.AllInOne).GetCustomAttributesData(),
     new (string, global::Serde.ISerdeInfo, System.Reflection.MemberInfo?)[] {

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.CustomImplTests.RgbWithFieldMap.ISerdeInfoProvider.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.CustomImplTests.RgbWithFieldMap.ISerdeInfoProvider.cs
@@ -7,7 +7,7 @@ partial class CustomImplTests
 {
     partial record RgbWithFieldMap
     {
-        private static global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
+        private static readonly global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
             "RgbWithFieldMap",
         typeof(Serde.Test.CustomImplTests.RgbWithFieldMap).GetCustomAttributesData(),
         new (string, global::Serde.ISerdeInfo, System.Reflection.MemberInfo?)[] {

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.GenericWrapperTests.CustomArrayWrapExplicitOnType.ISerdeInfoProvider.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.GenericWrapperTests.CustomArrayWrapExplicitOnType.ISerdeInfoProvider.cs
@@ -7,7 +7,7 @@ partial class GenericWrapperTests
 {
     partial record struct CustomArrayWrapExplicitOnType
     {
-        private static global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
+        private static readonly global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
             "CustomArrayWrapExplicitOnType",
         typeof(Serde.Test.GenericWrapperTests.CustomArrayWrapExplicitOnType).GetCustomAttributesData(),
         new (string, global::Serde.ISerdeInfo, System.Reflection.MemberInfo?)[] {

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.GenericWrapperTests.CustomImArrayExplicitWrapOnMember.ISerdeInfoProvider.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.GenericWrapperTests.CustomImArrayExplicitWrapOnMember.ISerdeInfoProvider.cs
@@ -7,7 +7,7 @@ partial class GenericWrapperTests
 {
     partial record struct CustomImArrayExplicitWrapOnMember
     {
-        private static global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
+        private static readonly global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
             "CustomImArrayExplicitWrapOnMember",
         typeof(Serde.Test.GenericWrapperTests.CustomImArrayExplicitWrapOnMember).GetCustomAttributesData(),
         new (string, global::Serde.ISerdeInfo, System.Reflection.MemberInfo?)[] {

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonDeserializeTests.BasicDU._m_AProxy.ISerdeInfoProvider.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonDeserializeTests.BasicDU._m_AProxy.ISerdeInfoProvider.cs
@@ -9,7 +9,7 @@ partial class JsonDeserializeTests
     {
         partial class _m_AProxy
         {
-            private static global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
+            private static readonly global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
                 "A",
             typeof(Serde.Test.JsonDeserializeTests.BasicDU.A).GetCustomAttributesData(),
             new (string, global::Serde.ISerdeInfo, System.Reflection.MemberInfo?)[] {

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonDeserializeTests.BasicDU._m_BProxy.ISerdeInfoProvider.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonDeserializeTests.BasicDU._m_BProxy.ISerdeInfoProvider.cs
@@ -9,7 +9,7 @@ partial class JsonDeserializeTests
     {
         partial class _m_BProxy
         {
-            private static global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
+            private static readonly global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
                 "B",
             typeof(Serde.Test.JsonDeserializeTests.BasicDU.B).GetCustomAttributesData(),
             new (string, global::Serde.ISerdeInfo, System.Reflection.MemberInfo?)[] {

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonDeserializeTests.DenyUnknown.ISerdeInfoProvider.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonDeserializeTests.DenyUnknown.ISerdeInfoProvider.cs
@@ -7,7 +7,7 @@ partial class JsonDeserializeTests
 {
     partial record struct DenyUnknown
     {
-        private static global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
+        private static readonly global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
             "DenyUnknown",
         typeof(Serde.Test.JsonDeserializeTests.DenyUnknown).GetCustomAttributesData(),
         new (string, global::Serde.ISerdeInfo, System.Reflection.MemberInfo?)[] {

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonDeserializeTests.ExtraMembers.ISerdeInfoProvider.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonDeserializeTests.ExtraMembers.ISerdeInfoProvider.cs
@@ -7,7 +7,7 @@ partial class JsonDeserializeTests
 {
     partial struct ExtraMembers
     {
-        private static global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
+        private static readonly global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
             "ExtraMembers",
         typeof(Serde.Test.JsonDeserializeTests.ExtraMembers).GetCustomAttributesData(),
         new (string, global::Serde.ISerdeInfo, System.Reflection.MemberInfo?)[] {

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonDeserializeTests.IdStruct.ISerdeInfoProvider.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonDeserializeTests.IdStruct.ISerdeInfoProvider.cs
@@ -7,7 +7,7 @@ partial class JsonDeserializeTests
 {
     partial struct IdStruct
     {
-        private static global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
+        private static readonly global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
             "IdStruct",
         typeof(Serde.Test.JsonDeserializeTests.IdStruct).GetCustomAttributesData(),
         new (string, global::Serde.ISerdeInfo, System.Reflection.MemberInfo?)[] {

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonDeserializeTests.IdStructList.ISerdeInfoProvider.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonDeserializeTests.IdStructList.ISerdeInfoProvider.cs
@@ -7,7 +7,7 @@ partial class JsonDeserializeTests
 {
     partial record struct IdStructList
     {
-        private static global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
+        private static readonly global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
             "IdStructList",
         typeof(Serde.Test.JsonDeserializeTests.IdStructList).GetCustomAttributesData(),
         new (string, global::Serde.ISerdeInfo, System.Reflection.MemberInfo?)[] {

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonDeserializeTests.Location.ISerdeInfoProvider.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonDeserializeTests.Location.ISerdeInfoProvider.cs
@@ -7,7 +7,7 @@ partial class JsonDeserializeTests
 {
     partial record Location
     {
-        private static global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
+        private static readonly global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
             "Location",
         typeof(Serde.Test.JsonDeserializeTests.Location).GetCustomAttributesData(),
         new (string, global::Serde.ISerdeInfo, System.Reflection.MemberInfo?)[] {

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonDeserializeTests.NullableFields.ISerdeInfoProvider.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonDeserializeTests.NullableFields.ISerdeInfoProvider.cs
@@ -7,7 +7,7 @@ partial class JsonDeserializeTests
 {
     partial class NullableFields
     {
-        private static global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
+        private static readonly global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
             "NullableFields",
         typeof(Serde.Test.JsonDeserializeTests.NullableFields).GetCustomAttributesData(),
         new (string, global::Serde.ISerdeInfo, System.Reflection.MemberInfo?)[] {

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonDeserializeTests.SetToNull.ISerdeInfoProvider.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonDeserializeTests.SetToNull.ISerdeInfoProvider.cs
@@ -7,7 +7,7 @@ partial class JsonDeserializeTests
 {
     partial record struct SetToNull
     {
-        private static global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
+        private static readonly global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
             "SetToNull",
         typeof(Serde.Test.JsonDeserializeTests.SetToNull).GetCustomAttributesData(),
         new (string, global::Serde.ISerdeInfo, System.Reflection.MemberInfo?)[] {

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonDeserializeTests.SkipDeserialize.ISerdeInfoProvider.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonDeserializeTests.SkipDeserialize.ISerdeInfoProvider.cs
@@ -7,7 +7,7 @@ partial class JsonDeserializeTests
 {
     partial record SkipDeserialize
     {
-        private static global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
+        private static readonly global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
             "SkipDeserialize",
         typeof(Serde.Test.JsonDeserializeTests.SkipDeserialize).GetCustomAttributesData(),
         new (string, global::Serde.ISerdeInfo, System.Reflection.MemberInfo?)[] {

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonDeserializeTests.ThrowMissing.ISerdeInfoProvider.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonDeserializeTests.ThrowMissing.ISerdeInfoProvider.cs
@@ -7,7 +7,7 @@ partial class JsonDeserializeTests
 {
     partial record struct ThrowMissing
     {
-        private static global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
+        private static readonly global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
             "ThrowMissing",
         typeof(Serde.Test.JsonDeserializeTests.ThrowMissing).GetCustomAttributesData(),
         new (string, global::Serde.ISerdeInfo, System.Reflection.MemberInfo?)[] {

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonDeserializeTests.ThrowMissingFalse.ISerdeInfoProvider.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonDeserializeTests.ThrowMissingFalse.ISerdeInfoProvider.cs
@@ -7,7 +7,7 @@ partial class JsonDeserializeTests
 {
     partial record ThrowMissingFalse
     {
-        private static global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
+        private static readonly global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
             "ThrowMissingFalse",
         typeof(Serde.Test.JsonDeserializeTests.ThrowMissingFalse).GetCustomAttributesData(),
         new (string, global::Serde.ISerdeInfo, System.Reflection.MemberInfo?)[] {

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonSerializerTests.BasicDU._m_AProxy.ISerdeInfoProvider.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonSerializerTests.BasicDU._m_AProxy.ISerdeInfoProvider.cs
@@ -9,7 +9,7 @@ partial class JsonSerializerTests
     {
         partial class _m_AProxy
         {
-            private static global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
+            private static readonly global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
                 "A",
             typeof(Serde.Test.JsonSerializerTests.BasicDU.A).GetCustomAttributesData(),
             new (string, global::Serde.ISerdeInfo, System.Reflection.MemberInfo?)[] {

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonSerializerTests.BasicDU._m_BProxy.ISerdeInfoProvider.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonSerializerTests.BasicDU._m_BProxy.ISerdeInfoProvider.cs
@@ -9,7 +9,7 @@ partial class JsonSerializerTests
     {
         partial class _m_BProxy
         {
-            private static global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
+            private static readonly global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
                 "B",
             typeof(Serde.Test.JsonSerializerTests.BasicDU.B).GetCustomAttributesData(),
             new (string, global::Serde.ISerdeInfo, System.Reflection.MemberInfo?)[] {

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonSerializerTests.Color.ISerdeInfoProvider.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonSerializerTests.Color.ISerdeInfoProvider.cs
@@ -7,7 +7,7 @@ partial class JsonSerializerTests
 {
     partial struct Color
     {
-        private static global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
+        private static readonly global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
             "Color",
         typeof(Serde.Test.JsonSerializerTests.Color).GetCustomAttributesData(),
         new (string, global::Serde.ISerdeInfo, System.Reflection.MemberInfo?)[] {

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonSerializerTests.NullableFields.ISerdeInfoProvider.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonSerializerTests.NullableFields.ISerdeInfoProvider.cs
@@ -7,7 +7,7 @@ partial class JsonSerializerTests
 {
     partial class NullableFields
     {
-        private static global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
+        private static readonly global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
             "NullableFields",
         typeof(Serde.Test.JsonSerializerTests.NullableFields).GetCustomAttributesData(),
         new (string, global::Serde.ISerdeInfo, System.Reflection.MemberInfo?)[] {

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.MaxSizeType.ISerdeInfoProvider.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.MaxSizeType.ISerdeInfoProvider.cs
@@ -5,7 +5,7 @@ namespace Serde.Test;
 
 partial struct MaxSizeType
 {
-    private static global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
+    private static readonly global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
         "MaxSizeType",
     typeof(Serde.Test.MaxSizeType).GetCustomAttributesData(),
     new (string, global::Serde.ISerdeInfo, System.Reflection.MemberInfo?)[] {

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.SerdeInfoTests.EmptyRecord.ISerdeInfoProvider.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.SerdeInfoTests.EmptyRecord.ISerdeInfoProvider.cs
@@ -7,7 +7,7 @@ partial class SerdeInfoTests
 {
     partial record EmptyRecord
     {
-        private static global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
+        private static readonly global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
             "EmptyRecord",
         typeof(Serde.Test.SerdeInfoTests.EmptyRecord).GetCustomAttributesData(),
         new (string, global::Serde.ISerdeInfo, System.Reflection.MemberInfo?)[] {

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.SerdeInfoTests.RgbProxy.ISerdeInfoProvider.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.SerdeInfoTests.RgbProxy.ISerdeInfoProvider.cs
@@ -7,7 +7,7 @@ partial class SerdeInfoTests
 {
     partial record RgbProxy
     {
-        private static global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
+        private static readonly global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
             "Rgb",
         typeof(Serde.Test.SerdeInfoTests.Rgb).GetCustomAttributesData(),
         new (string, global::Serde.ISerdeInfo, System.Reflection.MemberInfo?)[] {

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.SerdeInfoTests.UnionBase._m_AProxy.ISerdeInfoProvider.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.SerdeInfoTests.UnionBase._m_AProxy.ISerdeInfoProvider.cs
@@ -9,7 +9,7 @@ partial class SerdeInfoTests
     {
         partial class _m_AProxy
         {
-            private static global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
+            private static readonly global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
                 "A",
             typeof(Serde.Test.SerdeInfoTests.UnionBase.A).GetCustomAttributesData(),
             new (string, global::Serde.ISerdeInfo, System.Reflection.MemberInfo?)[] {

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.SerdeInfoTests.UnionBase._m_BProxy.ISerdeInfoProvider.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.SerdeInfoTests.UnionBase._m_BProxy.ISerdeInfoProvider.cs
@@ -9,7 +9,7 @@ partial class SerdeInfoTests
     {
         partial class _m_BProxy
         {
-            private static global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
+            private static readonly global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
                 "B",
             typeof(Serde.Test.SerdeInfoTests.UnionBase.B).GetCustomAttributesData(),
             new (string, global::Serde.ISerdeInfo, System.Reflection.MemberInfo?)[] {

--- a/test/Serde.Xml.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.AllInOne.ISerdeInfoProvider.cs
+++ b/test/Serde.Xml.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.AllInOne.ISerdeInfoProvider.cs
@@ -5,7 +5,7 @@ namespace Serde.Test;
 
 partial record AllInOne
 {
-    private static global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
+    private static readonly global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
         "AllInOne",
     typeof(Serde.Test.AllInOne).GetCustomAttributesData(),
     new (string, global::Serde.ISerdeInfo, System.Reflection.MemberInfo?)[] {

--- a/test/Serde.Xml.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.SampleTest.Address.ISerdeInfoProvider.cs
+++ b/test/Serde.Xml.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.SampleTest.Address.ISerdeInfoProvider.cs
@@ -7,7 +7,7 @@ partial class SampleTest
 {
     partial record Address
     {
-        private static global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
+        private static readonly global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
             "Address",
         typeof(Serde.Test.SampleTest.Address).GetCustomAttributesData(),
         new (string, global::Serde.ISerdeInfo, System.Reflection.MemberInfo?)[] {

--- a/test/Serde.Xml.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.SampleTest.OrderedItem.ISerdeInfoProvider.cs
+++ b/test/Serde.Xml.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.SampleTest.OrderedItem.ISerdeInfoProvider.cs
@@ -7,7 +7,7 @@ partial class SampleTest
 {
     partial record OrderedItem
     {
-        private static global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
+        private static readonly global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
             "OrderedItem",
         typeof(Serde.Test.SampleTest.OrderedItem).GetCustomAttributesData(),
         new (string, global::Serde.ISerdeInfo, System.Reflection.MemberInfo?)[] {

--- a/test/Serde.Xml.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.SampleTest.PurchaseOrder.ISerdeInfoProvider.cs
+++ b/test/Serde.Xml.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.SampleTest.PurchaseOrder.ISerdeInfoProvider.cs
@@ -7,7 +7,7 @@ partial class SampleTest
 {
     partial record PurchaseOrder
     {
-        private static global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
+        private static readonly global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
             "PurchaseOrder",
         typeof(Serde.Test.SampleTest.PurchaseOrder).GetCustomAttributesData(),
         new (string, global::Serde.ISerdeInfo, System.Reflection.MemberInfo?)[] {

--- a/test/Serde.Xml.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.XmlTests.BoolStruct.ISerdeInfoProvider.cs
+++ b/test/Serde.Xml.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.XmlTests.BoolStruct.ISerdeInfoProvider.cs
@@ -7,7 +7,7 @@ partial class XmlTests
 {
     partial struct BoolStruct
     {
-        private static global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
+        private static readonly global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
             "BoolStruct",
         typeof(Serde.Test.XmlTests.BoolStruct).GetCustomAttributesData(),
         new (string, global::Serde.ISerdeInfo, System.Reflection.MemberInfo?)[] {

--- a/test/Serde.Xml.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.XmlTests.MapTest1.ISerdeInfoProvider.cs
+++ b/test/Serde.Xml.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.XmlTests.MapTest1.ISerdeInfoProvider.cs
@@ -7,7 +7,7 @@ partial class XmlTests
 {
     partial class MapTest1
     {
-        private static global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
+        private static readonly global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
             "MapTest1",
         typeof(Serde.Test.XmlTests.MapTest1).GetCustomAttributesData(),
         new (string, global::Serde.ISerdeInfo, System.Reflection.MemberInfo?)[] {

--- a/test/Serde.Xml.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.XmlTests.NestedArrays.ISerdeInfoProvider.cs
+++ b/test/Serde.Xml.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.XmlTests.NestedArrays.ISerdeInfoProvider.cs
@@ -7,7 +7,7 @@ partial class XmlTests
 {
     partial class NestedArrays
     {
-        private static global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
+        private static readonly global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
             "NestedArrays",
         typeof(Serde.Test.XmlTests.NestedArrays).GetCustomAttributesData(),
         new (string, global::Serde.ISerdeInfo, System.Reflection.MemberInfo?)[] {

--- a/test/Serde.Xml.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.XmlTests.StructWithIntField.ISerdeInfoProvider.cs
+++ b/test/Serde.Xml.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.XmlTests.StructWithIntField.ISerdeInfoProvider.cs
@@ -7,7 +7,7 @@ partial class XmlTests
 {
     partial record StructWithIntField
     {
-        private static global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
+        private static readonly global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
             "StructWithIntField",
         typeof(Serde.Test.XmlTests.StructWithIntField).GetCustomAttributesData(),
         new (string, global::Serde.ISerdeInfo, System.Reflection.MemberInfo?)[] {

--- a/test/Serde.Xml.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.XmlTests.TypeWithArrayField.ISerdeInfoProvider.cs
+++ b/test/Serde.Xml.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.XmlTests.TypeWithArrayField.ISerdeInfoProvider.cs
@@ -7,7 +7,7 @@ partial class XmlTests
 {
     partial class TypeWithArrayField
     {
-        private static global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
+        private static readonly global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
             "TypeWithArrayField",
         typeof(Serde.Test.XmlTests.TypeWithArrayField).GetCustomAttributesData(),
         new (string, global::Serde.ISerdeInfo, System.Reflection.MemberInfo?)[] {


### PR DESCRIPTION
This allows creating 'wrapper' types that are serialized as though they are just their underlying field/property.