### PR TITLE
Add members from base types

### DIFF
--- a/test/Serde.Generation.Test/DeserializeTests.cs
+++ b/test/Serde.Generation.Test/DeserializeTests.cs
@@ -1,4 +1,3 @@
-
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using Xunit;
@@ -8,6 +7,48 @@ namespace Serde.Test
 {
     public class DeserializeTests
     {
+        [Fact]
+        public Task Inheritance()
+        {
+            var src = """
+using Serde;
+
+[GenerateDeserialize]
+partial class A
+{
+    public int X;
+}
+
+[GenerateDeserialize]
+partial class B : A
+{
+    public int Y;
+}
+
+[GenerateDeserialize]
+partial class C : B
+{
+    public int Z;
+}
+""";
+            return VerifyDeserialize(src);
+        }
+
+        [Fact]
+        public Task MemberOverrides()
+        {
+            var src = """
+using Serde;
+
+[GenerateDeserialize]
+partial record A(int X);
+
+[GenerateDeserialize]
+partial record B(int X, int Y) : A(X);
+""";
+            return VerifyDeserialize(src);
+        }
+
         [Fact]
         public Task NestedExplicitDeserializeWrapper()
         {

--- a/test/Serde.Generation.Test/SerializeTests.cs
+++ b/test/Serde.Generation.Test/SerializeTests.cs
@@ -1,4 +1,3 @@
-
 using System;
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
@@ -9,6 +8,70 @@ namespace Serde.Test
 {
     public class SerializeTests
     {
+        [Fact]
+        public Task Inheritance()
+        {
+            var src = """
+using Serde;
+
+[GenerateSerialize]
+partial class A
+{
+    public int X;
+}
+
+[GenerateSerialize]
+partial class B : A
+{
+    public int Y;
+}
+
+[GenerateSerialize]
+partial class C : B
+{
+    public int Z;
+}
+""";
+            return VerifySerialize(src);
+        }
+
+        [Fact]
+        public Task MemberOverrides()
+        {
+            var src = """
+using Serde;
+
+[GenerateSerialize]
+partial record A(int X);
+
+[GenerateSerialize]
+partial record B(int X, int Y) : A(X);
+""";
+            return VerifySerialize(src);
+        }
+
+        [Fact]
+        public Task HiddenMembers()
+        {
+            var src = """
+using Serde;
+
+[GenerateSerialize]
+partial class A
+{
+    public int X { get; }
+}
+
+[GenerateSerialize]
+partial class B : A
+{
+    public new int X { get; }
+    public int Y { get; }
+}
+""";
+            return VerifySerialize(src);
+        }
+
         [Fact]
         public Task NestedExplicitSerializeWrapper()
         {

--- a/test/Serde.Generation.Test/test_output/DeserializeTests/Inheritance#A.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/DeserializeTests/Inheritance#A.IDeserialize.verified.cs
@@ -1,0 +1,54 @@
+﻿//HintName: A.IDeserialize.cs
+
+#nullable enable
+
+using System;
+using Serde;
+partial class A : Serde.IDeserializeProvider<A>
+{
+    static IDeserialize<A> IDeserializeProvider<A>.Instance
+        => _DeObj.Instance;
+
+    sealed partial class _DeObj :Serde.IDeserialize<A>
+    {
+        global::Serde.ISerdeInfo global::Serde.ISerdeInfoProvider.SerdeInfo => A.s_serdeInfo;
+
+        A Serde.IDeserialize<A>.Deserialize(IDeserializer deserializer)
+        {
+            int _l_x = default!;
+
+            byte _r_assignedValid = 0;
+
+            var _l_serdeInfo = global::Serde.SerdeInfoProvider.GetInfo(this);
+            var typeDeserialize = deserializer.ReadType(_l_serdeInfo);
+            int _l_index_;
+            while ((_l_index_ = typeDeserialize.TryReadIndex(_l_serdeInfo, out _)) != ITypeDeserializer.EndOfType)
+            {
+                switch (_l_index_)
+                {
+                    case 0:
+                        _l_x = typeDeserialize.ReadI32(_l_serdeInfo, _l_index_);
+                        _r_assignedValid |= ((byte)1) << 0;
+                        break;
+                    case Serde.ITypeDeserializer.IndexNotFound:
+                        typeDeserialize.SkipValue(_l_serdeInfo, _l_index_);
+                        break;
+                    default:
+                        throw new InvalidOperationException("Unexpected index: " + _l_index_);
+                }
+            }
+            if ((_r_assignedValid & 0b1) != 0b1)
+            {
+                throw Serde.DeserializeException.UnassignedMember();
+            }
+            var newType = new A() {
+                X = _l_x,
+            };
+
+            return newType;
+        }
+        public static readonly _DeObj Instance = new();
+        private _DeObj() { }
+
+    }
+}

--- a/test/Serde.Generation.Test/test_output/DeserializeTests/Inheritance#A.ISerdeInfoProvider.verified.cs
+++ b/test/Serde.Generation.Test/test_output/DeserializeTests/Inheritance#A.ISerdeInfoProvider.verified.cs
@@ -1,0 +1,13 @@
+﻿//HintName: A.ISerdeInfoProvider.cs
+
+#nullable enable
+partial class A
+{
+    private static global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
+        "A",
+    typeof(A).GetCustomAttributesData(),
+    new (string, global::Serde.ISerdeInfo, System.Reflection.MemberInfo?)[] {
+        ("x", global::Serde.SerdeInfoProvider.GetDeserializeInfo<int, global::Serde.I32Proxy>(), typeof(A).GetField("X"))
+    }
+    );
+}

--- a/test/Serde.Generation.Test/test_output/DeserializeTests/Inheritance#B.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/DeserializeTests/Inheritance#B.IDeserialize.verified.cs
@@ -1,0 +1,60 @@
+﻿//HintName: B.IDeserialize.cs
+
+#nullable enable
+
+using System;
+using Serde;
+partial class B : Serde.IDeserializeProvider<B>
+{
+    static IDeserialize<B> IDeserializeProvider<B>.Instance
+        => _DeObj.Instance;
+
+    sealed partial class _DeObj :Serde.IDeserialize<B>
+    {
+        global::Serde.ISerdeInfo global::Serde.ISerdeInfoProvider.SerdeInfo => B.s_serdeInfo;
+
+        B Serde.IDeserialize<B>.Deserialize(IDeserializer deserializer)
+        {
+            int _l_y = default!;
+            int _l_x = default!;
+
+            byte _r_assignedValid = 0;
+
+            var _l_serdeInfo = global::Serde.SerdeInfoProvider.GetInfo(this);
+            var typeDeserialize = deserializer.ReadType(_l_serdeInfo);
+            int _l_index_;
+            while ((_l_index_ = typeDeserialize.TryReadIndex(_l_serdeInfo, out _)) != ITypeDeserializer.EndOfType)
+            {
+                switch (_l_index_)
+                {
+                    case 0:
+                        _l_y = typeDeserialize.ReadI32(_l_serdeInfo, _l_index_);
+                        _r_assignedValid |= ((byte)1) << 0;
+                        break;
+                    case 1:
+                        _l_x = typeDeserialize.ReadI32(_l_serdeInfo, _l_index_);
+                        _r_assignedValid |= ((byte)1) << 1;
+                        break;
+                    case Serde.ITypeDeserializer.IndexNotFound:
+                        typeDeserialize.SkipValue(_l_serdeInfo, _l_index_);
+                        break;
+                    default:
+                        throw new InvalidOperationException("Unexpected index: " + _l_index_);
+                }
+            }
+            if ((_r_assignedValid & 0b11) != 0b11)
+            {
+                throw Serde.DeserializeException.UnassignedMember();
+            }
+            var newType = new B() {
+                Y = _l_y,
+                X = _l_x,
+            };
+
+            return newType;
+        }
+        public static readonly _DeObj Instance = new();
+        private _DeObj() { }
+
+    }
+}

--- a/test/Serde.Generation.Test/test_output/DeserializeTests/Inheritance#B.ISerdeInfoProvider.verified.cs
+++ b/test/Serde.Generation.Test/test_output/DeserializeTests/Inheritance#B.ISerdeInfoProvider.verified.cs
@@ -1,0 +1,14 @@
+﻿//HintName: B.ISerdeInfoProvider.cs
+
+#nullable enable
+partial class B
+{
+    private static global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
+        "B",
+    typeof(B).GetCustomAttributesData(),
+    new (string, global::Serde.ISerdeInfo, System.Reflection.MemberInfo?)[] {
+        ("y", global::Serde.SerdeInfoProvider.GetDeserializeInfo<int, global::Serde.I32Proxy>(), typeof(B).GetField("Y")),
+        ("x", global::Serde.SerdeInfoProvider.GetDeserializeInfo<int, global::Serde.I32Proxy>(), typeof(B).GetField("X"))
+    }
+    );
+}

--- a/test/Serde.Generation.Test/test_output/DeserializeTests/Inheritance#C.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/DeserializeTests/Inheritance#C.IDeserialize.verified.cs
@@ -1,0 +1,66 @@
+﻿//HintName: C.IDeserialize.cs
+
+#nullable enable
+
+using System;
+using Serde;
+partial class C : Serde.IDeserializeProvider<C>
+{
+    static IDeserialize<C> IDeserializeProvider<C>.Instance
+        => _DeObj.Instance;
+
+    sealed partial class _DeObj :Serde.IDeserialize<C>
+    {
+        global::Serde.ISerdeInfo global::Serde.ISerdeInfoProvider.SerdeInfo => C.s_serdeInfo;
+
+        C Serde.IDeserialize<C>.Deserialize(IDeserializer deserializer)
+        {
+            int _l_z = default!;
+            int _l_y = default!;
+            int _l_x = default!;
+
+            byte _r_assignedValid = 0;
+
+            var _l_serdeInfo = global::Serde.SerdeInfoProvider.GetInfo(this);
+            var typeDeserialize = deserializer.ReadType(_l_serdeInfo);
+            int _l_index_;
+            while ((_l_index_ = typeDeserialize.TryReadIndex(_l_serdeInfo, out _)) != ITypeDeserializer.EndOfType)
+            {
+                switch (_l_index_)
+                {
+                    case 0:
+                        _l_z = typeDeserialize.ReadI32(_l_serdeInfo, _l_index_);
+                        _r_assignedValid |= ((byte)1) << 0;
+                        break;
+                    case 1:
+                        _l_y = typeDeserialize.ReadI32(_l_serdeInfo, _l_index_);
+                        _r_assignedValid |= ((byte)1) << 1;
+                        break;
+                    case 2:
+                        _l_x = typeDeserialize.ReadI32(_l_serdeInfo, _l_index_);
+                        _r_assignedValid |= ((byte)1) << 2;
+                        break;
+                    case Serde.ITypeDeserializer.IndexNotFound:
+                        typeDeserialize.SkipValue(_l_serdeInfo, _l_index_);
+                        break;
+                    default:
+                        throw new InvalidOperationException("Unexpected index: " + _l_index_);
+                }
+            }
+            if ((_r_assignedValid & 0b111) != 0b111)
+            {
+                throw Serde.DeserializeException.UnassignedMember();
+            }
+            var newType = new C() {
+                Z = _l_z,
+                Y = _l_y,
+                X = _l_x,
+            };
+
+            return newType;
+        }
+        public static readonly _DeObj Instance = new();
+        private _DeObj() { }
+
+    }
+}

--- a/test/Serde.Generation.Test/test_output/DeserializeTests/Inheritance#C.ISerdeInfoProvider.verified.cs
+++ b/test/Serde.Generation.Test/test_output/DeserializeTests/Inheritance#C.ISerdeInfoProvider.verified.cs
@@ -1,0 +1,15 @@
+﻿//HintName: C.ISerdeInfoProvider.cs
+
+#nullable enable
+partial class C
+{
+    private static global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
+        "C",
+    typeof(C).GetCustomAttributesData(),
+    new (string, global::Serde.ISerdeInfo, System.Reflection.MemberInfo?)[] {
+        ("z", global::Serde.SerdeInfoProvider.GetDeserializeInfo<int, global::Serde.I32Proxy>(), typeof(C).GetField("Z")),
+        ("y", global::Serde.SerdeInfoProvider.GetDeserializeInfo<int, global::Serde.I32Proxy>(), typeof(C).GetField("Y")),
+        ("x", global::Serde.SerdeInfoProvider.GetDeserializeInfo<int, global::Serde.I32Proxy>(), typeof(C).GetField("X"))
+    }
+    );
+}

--- a/test/Serde.Generation.Test/test_output/DeserializeTests/MemberOverrides#A.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/DeserializeTests/MemberOverrides#A.IDeserialize.verified.cs
@@ -1,0 +1,53 @@
+﻿//HintName: A.IDeserialize.cs
+
+#nullable enable
+
+using System;
+using Serde;
+partial record A : Serde.IDeserializeProvider<A>
+{
+    static IDeserialize<A> IDeserializeProvider<A>.Instance
+        => _DeObj.Instance;
+
+    sealed partial class _DeObj :Serde.IDeserialize<A>
+    {
+        global::Serde.ISerdeInfo global::Serde.ISerdeInfoProvider.SerdeInfo => A.s_serdeInfo;
+
+        A Serde.IDeserialize<A>.Deserialize(IDeserializer deserializer)
+        {
+            int _l_x = default!;
+
+            byte _r_assignedValid = 0;
+
+            var _l_serdeInfo = global::Serde.SerdeInfoProvider.GetInfo(this);
+            var typeDeserialize = deserializer.ReadType(_l_serdeInfo);
+            int _l_index_;
+            while ((_l_index_ = typeDeserialize.TryReadIndex(_l_serdeInfo, out _)) != ITypeDeserializer.EndOfType)
+            {
+                switch (_l_index_)
+                {
+                    case 0:
+                        _l_x = typeDeserialize.ReadI32(_l_serdeInfo, _l_index_);
+                        _r_assignedValid |= ((byte)1) << 0;
+                        break;
+                    case Serde.ITypeDeserializer.IndexNotFound:
+                        typeDeserialize.SkipValue(_l_serdeInfo, _l_index_);
+                        break;
+                    default:
+                        throw new InvalidOperationException("Unexpected index: " + _l_index_);
+                }
+            }
+            if ((_r_assignedValid & 0b1) != 0b1)
+            {
+                throw Serde.DeserializeException.UnassignedMember();
+            }
+            var newType = new A(_l_x) {
+            };
+
+            return newType;
+        }
+        public static readonly _DeObj Instance = new();
+        private _DeObj() { }
+
+    }
+}

--- a/test/Serde.Generation.Test/test_output/DeserializeTests/MemberOverrides#A.ISerdeInfoProvider.verified.cs
+++ b/test/Serde.Generation.Test/test_output/DeserializeTests/MemberOverrides#A.ISerdeInfoProvider.verified.cs
@@ -1,0 +1,13 @@
+﻿//HintName: A.ISerdeInfoProvider.cs
+
+#nullable enable
+partial record A
+{
+    private static global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
+        "A",
+    typeof(A).GetCustomAttributesData(),
+    new (string, global::Serde.ISerdeInfo, System.Reflection.MemberInfo?)[] {
+        ("x", global::Serde.SerdeInfoProvider.GetDeserializeInfo<int, global::Serde.I32Proxy>(), typeof(A).GetProperty("X"))
+    }
+    );
+}

--- a/test/Serde.Generation.Test/test_output/DeserializeTests/MemberOverrides#B.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/DeserializeTests/MemberOverrides#B.IDeserialize.verified.cs
@@ -1,0 +1,58 @@
+﻿//HintName: B.IDeserialize.cs
+
+#nullable enable
+
+using System;
+using Serde;
+partial record B : Serde.IDeserializeProvider<B>
+{
+    static IDeserialize<B> IDeserializeProvider<B>.Instance
+        => _DeObj.Instance;
+
+    sealed partial class _DeObj :Serde.IDeserialize<B>
+    {
+        global::Serde.ISerdeInfo global::Serde.ISerdeInfoProvider.SerdeInfo => B.s_serdeInfo;
+
+        B Serde.IDeserialize<B>.Deserialize(IDeserializer deserializer)
+        {
+            int _l_y = default!;
+            int _l_x = default!;
+
+            byte _r_assignedValid = 0;
+
+            var _l_serdeInfo = global::Serde.SerdeInfoProvider.GetInfo(this);
+            var typeDeserialize = deserializer.ReadType(_l_serdeInfo);
+            int _l_index_;
+            while ((_l_index_ = typeDeserialize.TryReadIndex(_l_serdeInfo, out _)) != ITypeDeserializer.EndOfType)
+            {
+                switch (_l_index_)
+                {
+                    case 0:
+                        _l_y = typeDeserialize.ReadI32(_l_serdeInfo, _l_index_);
+                        _r_assignedValid |= ((byte)1) << 0;
+                        break;
+                    case 1:
+                        _l_x = typeDeserialize.ReadI32(_l_serdeInfo, _l_index_);
+                        _r_assignedValid |= ((byte)1) << 1;
+                        break;
+                    case Serde.ITypeDeserializer.IndexNotFound:
+                        typeDeserialize.SkipValue(_l_serdeInfo, _l_index_);
+                        break;
+                    default:
+                        throw new InvalidOperationException("Unexpected index: " + _l_index_);
+                }
+            }
+            if ((_r_assignedValid & 0b11) != 0b11)
+            {
+                throw Serde.DeserializeException.UnassignedMember();
+            }
+            var newType = new B(_l_x, _l_y) {
+            };
+
+            return newType;
+        }
+        public static readonly _DeObj Instance = new();
+        private _DeObj() { }
+
+    }
+}

--- a/test/Serde.Generation.Test/test_output/DeserializeTests/MemberOverrides#B.ISerdeInfoProvider.verified.cs
+++ b/test/Serde.Generation.Test/test_output/DeserializeTests/MemberOverrides#B.ISerdeInfoProvider.verified.cs
@@ -1,0 +1,14 @@
+﻿//HintName: B.ISerdeInfoProvider.cs
+
+#nullable enable
+partial record B
+{
+    private static global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
+        "B",
+    typeof(B).GetCustomAttributesData(),
+    new (string, global::Serde.ISerdeInfo, System.Reflection.MemberInfo?)[] {
+        ("y", global::Serde.SerdeInfoProvider.GetDeserializeInfo<int, global::Serde.I32Proxy>(), typeof(B).GetProperty("Y")),
+        ("x", global::Serde.SerdeInfoProvider.GetDeserializeInfo<int, global::Serde.I32Proxy>(), typeof(B).GetProperty("X"))
+    }
+    );
+}

--- a/test/Serde.Generation.Test/test_output/SerializeTests/HiddenMembers#A.ISerdeInfoProvider.verified.cs
+++ b/test/Serde.Generation.Test/test_output/SerializeTests/HiddenMembers#A.ISerdeInfoProvider.verified.cs
@@ -1,0 +1,13 @@
+﻿//HintName: A.ISerdeInfoProvider.cs
+
+#nullable enable
+partial class A
+{
+    private static global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
+        "A",
+    typeof(A).GetCustomAttributesData(),
+    new (string, global::Serde.ISerdeInfo, System.Reflection.MemberInfo?)[] {
+        ("x", global::Serde.SerdeInfoProvider.GetSerializeInfo<int, global::Serde.I32Proxy>(), typeof(A).GetProperty("X"))
+    }
+    );
+}

--- a/test/Serde.Generation.Test/test_output/SerializeTests/HiddenMembers#A.ISerialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/SerializeTests/HiddenMembers#A.ISerialize.verified.cs
@@ -1,0 +1,27 @@
+﻿//HintName: A.ISerialize.cs
+
+#nullable enable
+
+using System;
+using Serde;
+partial class A : Serde.ISerializeProvider<A>
+{
+    static ISerialize<A> ISerializeProvider<A>.Instance
+        => _SerObj.Instance;
+
+    sealed partial class _SerObj :Serde.ISerialize<A>
+    {
+        global::Serde.ISerdeInfo global::Serde.ISerdeInfoProvider.SerdeInfo => A.s_serdeInfo;
+
+        void global::Serde.ISerialize<A>.Serialize(A value, global::Serde.ISerializer serializer)
+        {
+            var _l_info = global::Serde.SerdeInfoProvider.GetInfo(this);
+            var _l_type = serializer.WriteType(_l_info);
+            _l_type.WriteI32(_l_info, 0, value.X);
+            _l_type.End(_l_info);
+        }
+        public static readonly _SerObj Instance = new();
+        private _SerObj() { }
+
+    }
+}

--- a/test/Serde.Generation.Test/test_output/SerializeTests/HiddenMembers#B.ISerdeInfoProvider.verified.cs
+++ b/test/Serde.Generation.Test/test_output/SerializeTests/HiddenMembers#B.ISerdeInfoProvider.verified.cs
@@ -1,0 +1,14 @@
+﻿//HintName: B.ISerdeInfoProvider.cs
+
+#nullable enable
+partial class B
+{
+    private static global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
+        "B",
+    typeof(B).GetCustomAttributesData(),
+    new (string, global::Serde.ISerdeInfo, System.Reflection.MemberInfo?)[] {
+        ("x", global::Serde.SerdeInfoProvider.GetSerializeInfo<int, global::Serde.I32Proxy>(), typeof(B).GetProperty("X")),
+        ("y", global::Serde.SerdeInfoProvider.GetSerializeInfo<int, global::Serde.I32Proxy>(), typeof(B).GetProperty("Y"))
+    }
+    );
+}

--- a/test/Serde.Generation.Test/test_output/SerializeTests/HiddenMembers#B.ISerialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/SerializeTests/HiddenMembers#B.ISerialize.verified.cs
@@ -1,0 +1,28 @@
+﻿//HintName: B.ISerialize.cs
+
+#nullable enable
+
+using System;
+using Serde;
+partial class B : Serde.ISerializeProvider<B>
+{
+    static ISerialize<B> ISerializeProvider<B>.Instance
+        => _SerObj.Instance;
+
+    sealed partial class _SerObj :Serde.ISerialize<B>
+    {
+        global::Serde.ISerdeInfo global::Serde.ISerdeInfoProvider.SerdeInfo => B.s_serdeInfo;
+
+        void global::Serde.ISerialize<B>.Serialize(B value, global::Serde.ISerializer serializer)
+        {
+            var _l_info = global::Serde.SerdeInfoProvider.GetInfo(this);
+            var _l_type = serializer.WriteType(_l_info);
+            _l_type.WriteI32(_l_info, 0, value.X);
+            _l_type.WriteI32(_l_info, 1, value.Y);
+            _l_type.End(_l_info);
+        }
+        public static readonly _SerObj Instance = new();
+        private _SerObj() { }
+
+    }
+}

--- a/test/Serde.Generation.Test/test_output/SerializeTests/Inheritance#A.ISerdeInfoProvider.verified.cs
+++ b/test/Serde.Generation.Test/test_output/SerializeTests/Inheritance#A.ISerdeInfoProvider.verified.cs
@@ -1,0 +1,13 @@
+﻿//HintName: A.ISerdeInfoProvider.cs
+
+#nullable enable
+partial class A
+{
+    private static global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
+        "A",
+    typeof(A).GetCustomAttributesData(),
+    new (string, global::Serde.ISerdeInfo, System.Reflection.MemberInfo?)[] {
+        ("x", global::Serde.SerdeInfoProvider.GetSerializeInfo<int, global::Serde.I32Proxy>(), typeof(A).GetField("X"))
+    }
+    );
+}

--- a/test/Serde.Generation.Test/test_output/SerializeTests/Inheritance#A.ISerialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/SerializeTests/Inheritance#A.ISerialize.verified.cs
@@ -1,0 +1,27 @@
+﻿//HintName: A.ISerialize.cs
+
+#nullable enable
+
+using System;
+using Serde;
+partial class A : Serde.ISerializeProvider<A>
+{
+    static ISerialize<A> ISerializeProvider<A>.Instance
+        => _SerObj.Instance;
+
+    sealed partial class _SerObj :Serde.ISerialize<A>
+    {
+        global::Serde.ISerdeInfo global::Serde.ISerdeInfoProvider.SerdeInfo => A.s_serdeInfo;
+
+        void global::Serde.ISerialize<A>.Serialize(A value, global::Serde.ISerializer serializer)
+        {
+            var _l_info = global::Serde.SerdeInfoProvider.GetInfo(this);
+            var _l_type = serializer.WriteType(_l_info);
+            _l_type.WriteI32(_l_info, 0, value.X);
+            _l_type.End(_l_info);
+        }
+        public static readonly _SerObj Instance = new();
+        private _SerObj() { }
+
+    }
+}

--- a/test/Serde.Generation.Test/test_output/SerializeTests/Inheritance#B.ISerdeInfoProvider.verified.cs
+++ b/test/Serde.Generation.Test/test_output/SerializeTests/Inheritance#B.ISerdeInfoProvider.verified.cs
@@ -1,0 +1,14 @@
+﻿//HintName: B.ISerdeInfoProvider.cs
+
+#nullable enable
+partial class B
+{
+    private static global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
+        "B",
+    typeof(B).GetCustomAttributesData(),
+    new (string, global::Serde.ISerdeInfo, System.Reflection.MemberInfo?)[] {
+        ("y", global::Serde.SerdeInfoProvider.GetSerializeInfo<int, global::Serde.I32Proxy>(), typeof(B).GetField("Y")),
+        ("x", global::Serde.SerdeInfoProvider.GetSerializeInfo<int, global::Serde.I32Proxy>(), typeof(B).GetField("X"))
+    }
+    );
+}

--- a/test/Serde.Generation.Test/test_output/SerializeTests/Inheritance#B.ISerialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/SerializeTests/Inheritance#B.ISerialize.verified.cs
@@ -1,0 +1,28 @@
+﻿//HintName: B.ISerialize.cs
+
+#nullable enable
+
+using System;
+using Serde;
+partial class B : Serde.ISerializeProvider<B>
+{
+    static ISerialize<B> ISerializeProvider<B>.Instance
+        => _SerObj.Instance;
+
+    sealed partial class _SerObj :Serde.ISerialize<B>
+    {
+        global::Serde.ISerdeInfo global::Serde.ISerdeInfoProvider.SerdeInfo => B.s_serdeInfo;
+
+        void global::Serde.ISerialize<B>.Serialize(B value, global::Serde.ISerializer serializer)
+        {
+            var _l_info = global::Serde.SerdeInfoProvider.GetInfo(this);
+            var _l_type = serializer.WriteType(_l_info);
+            _l_type.WriteI32(_l_info, 0, value.Y);
+            _l_type.WriteI32(_l_info, 1, value.X);
+            _l_type.End(_l_info);
+        }
+        public static readonly _SerObj Instance = new();
+        private _SerObj() { }
+
+    }
+}

--- a/test/Serde.Generation.Test/test_output/SerializeTests/Inheritance#C.ISerdeInfoProvider.verified.cs
+++ b/test/Serde.Generation.Test/test_output/SerializeTests/Inheritance#C.ISerdeInfoProvider.verified.cs
@@ -1,0 +1,15 @@
+﻿//HintName: C.ISerdeInfoProvider.cs
+
+#nullable enable
+partial class C
+{
+    private static global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
+        "C",
+    typeof(C).GetCustomAttributesData(),
+    new (string, global::Serde.ISerdeInfo, System.Reflection.MemberInfo?)[] {
+        ("z", global::Serde.SerdeInfoProvider.GetSerializeInfo<int, global::Serde.I32Proxy>(), typeof(C).GetField("Z")),
+        ("y", global::Serde.SerdeInfoProvider.GetSerializeInfo<int, global::Serde.I32Proxy>(), typeof(C).GetField("Y")),
+        ("x", global::Serde.SerdeInfoProvider.GetSerializeInfo<int, global::Serde.I32Proxy>(), typeof(C).GetField("X"))
+    }
+    );
+}

--- a/test/Serde.Generation.Test/test_output/SerializeTests/Inheritance#C.ISerialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/SerializeTests/Inheritance#C.ISerialize.verified.cs
@@ -1,0 +1,29 @@
+﻿//HintName: C.ISerialize.cs
+
+#nullable enable
+
+using System;
+using Serde;
+partial class C : Serde.ISerializeProvider<C>
+{
+    static ISerialize<C> ISerializeProvider<C>.Instance
+        => _SerObj.Instance;
+
+    sealed partial class _SerObj :Serde.ISerialize<C>
+    {
+        global::Serde.ISerdeInfo global::Serde.ISerdeInfoProvider.SerdeInfo => C.s_serdeInfo;
+
+        void global::Serde.ISerialize<C>.Serialize(C value, global::Serde.ISerializer serializer)
+        {
+            var _l_info = global::Serde.SerdeInfoProvider.GetInfo(this);
+            var _l_type = serializer.WriteType(_l_info);
+            _l_type.WriteI32(_l_info, 0, value.Z);
+            _l_type.WriteI32(_l_info, 1, value.Y);
+            _l_type.WriteI32(_l_info, 2, value.X);
+            _l_type.End(_l_info);
+        }
+        public static readonly _SerObj Instance = new();
+        private _SerObj() { }
+
+    }
+}

--- a/test/Serde.Generation.Test/test_output/SerializeTests/MemberOverrides#A.ISerdeInfoProvider.verified.cs
+++ b/test/Serde.Generation.Test/test_output/SerializeTests/MemberOverrides#A.ISerdeInfoProvider.verified.cs
@@ -1,0 +1,13 @@
+﻿//HintName: A.ISerdeInfoProvider.cs
+
+#nullable enable
+partial record A
+{
+    private static global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
+        "A",
+    typeof(A).GetCustomAttributesData(),
+    new (string, global::Serde.ISerdeInfo, System.Reflection.MemberInfo?)[] {
+        ("x", global::Serde.SerdeInfoProvider.GetSerializeInfo<int, global::Serde.I32Proxy>(), typeof(A).GetProperty("X"))
+    }
+    );
+}

--- a/test/Serde.Generation.Test/test_output/SerializeTests/MemberOverrides#A.ISerialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/SerializeTests/MemberOverrides#A.ISerialize.verified.cs
@@ -1,0 +1,27 @@
+﻿//HintName: A.ISerialize.cs
+
+#nullable enable
+
+using System;
+using Serde;
+partial record A : Serde.ISerializeProvider<A>
+{
+    static ISerialize<A> ISerializeProvider<A>.Instance
+        => _SerObj.Instance;
+
+    sealed partial class _SerObj :Serde.ISerialize<A>
+    {
+        global::Serde.ISerdeInfo global::Serde.ISerdeInfoProvider.SerdeInfo => A.s_serdeInfo;
+
+        void global::Serde.ISerialize<A>.Serialize(A value, global::Serde.ISerializer serializer)
+        {
+            var _l_info = global::Serde.SerdeInfoProvider.GetInfo(this);
+            var _l_type = serializer.WriteType(_l_info);
+            _l_type.WriteI32(_l_info, 0, value.X);
+            _l_type.End(_l_info);
+        }
+        public static readonly _SerObj Instance = new();
+        private _SerObj() { }
+
+    }
+}

--- a/test/Serde.Generation.Test/test_output/SerializeTests/MemberOverrides#B.ISerdeInfoProvider.verified.cs
+++ b/test/Serde.Generation.Test/test_output/SerializeTests/MemberOverrides#B.ISerdeInfoProvider.verified.cs
@@ -1,0 +1,14 @@
+﻿//HintName: B.ISerdeInfoProvider.cs
+
+#nullable enable
+partial record B
+{
+    private static global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
+        "B",
+    typeof(B).GetCustomAttributesData(),
+    new (string, global::Serde.ISerdeInfo, System.Reflection.MemberInfo?)[] {
+        ("y", global::Serde.SerdeInfoProvider.GetSerializeInfo<int, global::Serde.I32Proxy>(), typeof(B).GetProperty("Y")),
+        ("x", global::Serde.SerdeInfoProvider.GetSerializeInfo<int, global::Serde.I32Proxy>(), typeof(B).GetProperty("X"))
+    }
+    );
+}

--- a/test/Serde.Generation.Test/test_output/SerializeTests/MemberOverrides#B.ISerialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/SerializeTests/MemberOverrides#B.ISerialize.verified.cs
@@ -1,0 +1,28 @@
+﻿//HintName: B.ISerialize.cs
+
+#nullable enable
+
+using System;
+using Serde;
+partial record B : Serde.ISerializeProvider<B>
+{
+    static ISerialize<B> ISerializeProvider<B>.Instance
+        => _SerObj.Instance;
+
+    sealed partial class _SerObj :Serde.ISerialize<B>
+    {
+        global::Serde.ISerdeInfo global::Serde.ISerdeInfoProvider.SerdeInfo => B.s_serdeInfo;
+
+        void global::Serde.ISerialize<B>.Serialize(B value, global::Serde.ISerializer serializer)
+        {
+            var _l_info = global::Serde.SerdeInfoProvider.GetInfo(this);
+            var _l_type = serializer.WriteType(_l_info);
+            _l_type.WriteI32(_l_info, 0, value.Y);
+            _l_type.WriteI32(_l_info, 1, value.X);
+            _l_type.End(_l_info);
+        }
+        public static readonly _SerObj Instance = new();
+        private _SerObj() { }
+
+    }
+}


### PR DESCRIPTION
The ordering is always derived-type first, then base types.