### PR TITLE
Add new attribute for using type parameters as proxies

### DIFF
--- a/samples/CustomSerialize.cs
+++ b/samples/CustomSerialize.cs
@@ -10,6 +10,10 @@ partial record Color(int R, int G, int B);
 partial record Color : ISerdeProvider<Color>
 {
     public static ISerde<Color> Instance { get; } = new ColorSerdeObj();
+
+    static ISerialize<Color> ISerializeProvider<Color>.Instance => Instance;
+
+    static IDeserialize<Color> IDeserializeProvider<Color>.Instance => Instance;
 }
 
 // Create a serde object for the Color type that serializes as a hex string

--- a/src/generator/Diagnostics.cs
+++ b/src/generator/Diagnostics.cs
@@ -18,6 +18,7 @@ namespace Serde
         ERR_CantFindNestedWrapper = 5,
         ERR_WrapperDoesntImplementInterface = 6,
         ERR_CantImplementAbstract = 7,
+        ERR_CantFindTypeParameter = 8,
     }
 
     internal static class Diagnostics
@@ -31,6 +32,7 @@ namespace Serde
             ERR_CantFindNestedWrapper => nameof(ERR_CantFindNestedWrapper),
             ERR_WrapperDoesntImplementInterface => nameof(ERR_WrapperDoesntImplementInterface),
             ERR_CantImplementAbstract => nameof(ERR_CantImplementAbstract),
+            ERR_CantFindTypeParameter => nameof(ERR_CantFindTypeParameter),
         };
 
         public static Diagnostic CreateDiagnostic(DiagId id, Location location, params object[] args)

--- a/src/generator/Resources.resx
+++ b/src/generator/Resources.resx
@@ -142,4 +142,7 @@
 - With only private constructors
 - With one or more nested records that inherit from the parent record</value>
   </data>
+  <data name="ERR_CantFindTypeParameter" xml:space="preserve">
+    <value>Could not find type parameter named '{0}' in the current context.</value>
+  </data>
 </root>

--- a/src/serde/Attributes.cs
+++ b/src/serde/Attributes.cs
@@ -167,6 +167,27 @@ sealed class SerdeMemberOptions : Attribute
     /// Proxy type for the IDeserialize implementation.
     /// </summary>
     public Type? DeserializeProxy { get; init; } = null;
+
+    /// <summary>
+    /// The name of the type parameter to use for the proxy type.  This is different from <see
+    /// cref="Proxy" /> in that it is only used for type parameters, which can't appear as `typeof`
+    /// arguments to attributes in C#.
+    /// </summary>
+    public string? TypeParameterProxy { get; init; } = null;
+
+    /// <summary>
+    /// The name of the type parameter to use for the proxy type.  This is different from <see
+    /// cref="Proxy" /> in that it is only used for type parameters, which can't appear as `typeof`
+    /// arguments to attributes in C#.
+    /// </summary>
+    public string? SerializeTypeParameterProxy { get; init; } = null;
+
+    /// <summary>
+    /// The name of the type parameter to use for the proxy type.  This is different from <see
+    /// cref="Proxy" /> in that it is only used for type parameters, which can't appear as `typeof`
+    /// arguments to attributes in C#.
+    /// </summary>
+    public string? DeserializeTypeParameterProxy { get; init; } = null;
 }
 
 /// <summary>

--- a/src/serde/ISerde.cs
+++ b/src/serde/ISerde.cs
@@ -26,11 +26,6 @@ public interface ISerdeProvider<TSelf, T> : ISerdeProvider<TSelf, ISerde<T>, T>
 
 /// <summary>
 /// Provider interface for retrieving the serialization and deserialization objects for a type.
-/// Assumes that the type is its own provider, which is the case for most types.
 /// </summary>
-/// <typeparam name="TSelf">
-/// The type that implements this interface.
-/// </typeparam>
-public interface ISerdeProvider<TSelf> : ISerdeProvider<TSelf, ISerde<TSelf>, TSelf>
-    where TSelf : ISerdeProvider<TSelf>
+public interface ISerdeProvider<T> : ISerializeProvider<T>, IDeserializeProvider<T>
 { }

--- a/test/Serde.Generation.Test/SerdeTests.cs
+++ b/test/Serde.Generation.Test/SerdeTests.cs
@@ -1,0 +1,64 @@
+using System.Threading.Tasks;
+using Xunit;
+using static Serde.Test.GeneratorTestUtils;
+
+namespace Serde.Test;
+
+public class SerdeTests
+{
+    [Fact]
+    public Task CommandResponseTest()
+    {
+        var src = """
+using Serde;
+using System.Collections.Generic;
+
+[GenerateSerde]
+public partial class CommandResponse<TResult, TProxy>
+    where TResult : class
+    where TProxy : ISerializeProvider<TResult>, IDeserializeProvider<TResult>
+{
+    public int Status { get; set; }
+
+    public string Message { get; set; } = string.Empty;
+
+    public List<ArgumentInfo>? Arguments { get; set; }
+
+    [SerdeMemberOptions(TypeParameterProxy = nameof(TProxy))]
+    public TResult? Results { get; set; }
+
+    public long Duration { get; set; }
+}
+
+[GenerateSerde]
+public partial class ArgumentInfo
+{
+    public string Name { get; set; } = string.Empty;
+    public string Value { get; set; } = string.Empty;
+}
+""";
+        return VerifyMultiFile(src);
+    }
+
+    [Fact]
+    public Task InvalidTypeParameterProxyTest()
+    {
+        var src = """
+using Serde;
+
+[GenerateSerde]
+public partial class InvalidProxyTest<T>
+{
+    [SerdeMemberOptions(TypeParameterProxy = "NonExistentProxy")]
+    public T? Value1 { get; set; }
+
+    [SerdeMemberOptions(SerializeTypeParameterProxy = "NonExistentProxy")]
+    public T? Value2 { get; set; }
+
+    [SerdeMemberOptions(DeserializeTypeParameterProxy = "NonExistentProxy")]
+    public T? Value3 { get; set; }
+}
+""";
+        return VerifyDiagnostics(src);
+    }
+}

--- a/test/Serde.Generation.Test/test_output/SerdeTests.CommandResponseTest/ArgumentInfo.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/SerdeTests.CommandResponseTest/ArgumentInfo.IDeserialize.verified.cs
@@ -1,0 +1,60 @@
+﻿//HintName: ArgumentInfo.IDeserialize.cs
+
+#nullable enable
+
+using System;
+using Serde;
+partial class ArgumentInfo : Serde.IDeserializeProvider<ArgumentInfo>
+{
+    static IDeserialize<ArgumentInfo> IDeserializeProvider<ArgumentInfo>.Instance
+        => _DeObj.Instance;
+
+    sealed partial class _DeObj :Serde.IDeserialize<ArgumentInfo>
+    {
+        global::Serde.ISerdeInfo global::Serde.ISerdeInfoProvider.SerdeInfo => ArgumentInfo.s_serdeInfo;
+
+        ArgumentInfo Serde.IDeserialize<ArgumentInfo>.Deserialize(IDeserializer deserializer)
+        {
+            string _l_name = default!;
+            string _l_value = default!;
+
+            byte _r_assignedValid = 0;
+
+            var _l_serdeInfo = global::Serde.SerdeInfoProvider.GetInfo(this);
+            var typeDeserialize = deserializer.ReadType(_l_serdeInfo);
+            int _l_index_;
+            while ((_l_index_ = typeDeserialize.TryReadIndex(_l_serdeInfo, out _)) != ITypeDeserializer.EndOfType)
+            {
+                switch (_l_index_)
+                {
+                    case 0:
+                        _l_name = typeDeserialize.ReadString(_l_serdeInfo, _l_index_);
+                        _r_assignedValid |= ((byte)1) << 0;
+                        break;
+                    case 1:
+                        _l_value = typeDeserialize.ReadString(_l_serdeInfo, _l_index_);
+                        _r_assignedValid |= ((byte)1) << 1;
+                        break;
+                    case Serde.ITypeDeserializer.IndexNotFound:
+                        typeDeserialize.SkipValue(_l_serdeInfo, _l_index_);
+                        break;
+                    default:
+                        throw new InvalidOperationException("Unexpected index: " + _l_index_);
+                }
+            }
+            if ((_r_assignedValid & 0b11) != 0b11)
+            {
+                throw Serde.DeserializeException.UnassignedMember();
+            }
+            var newType = new ArgumentInfo() {
+                Name = _l_name,
+                Value = _l_value,
+            };
+
+            return newType;
+        }
+        public static readonly _DeObj Instance = new();
+        private _DeObj() { }
+
+    }
+}

--- a/test/Serde.Generation.Test/test_output/SerdeTests.CommandResponseTest/ArgumentInfo.ISerdeInfoProvider.verified.cs
+++ b/test/Serde.Generation.Test/test_output/SerdeTests.CommandResponseTest/ArgumentInfo.ISerdeInfoProvider.verified.cs
@@ -1,0 +1,14 @@
+﻿//HintName: ArgumentInfo.ISerdeInfoProvider.cs
+
+#nullable enable
+partial class ArgumentInfo
+{
+    private static global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
+        "ArgumentInfo",
+    typeof(ArgumentInfo).GetCustomAttributesData(),
+    new (string, global::Serde.ISerdeInfo, System.Reflection.MemberInfo?)[] {
+        ("name", global::Serde.SerdeInfoProvider.GetSerializeInfo<string, global::Serde.StringProxy>(), typeof(ArgumentInfo).GetProperty("Name")),
+        ("value", global::Serde.SerdeInfoProvider.GetSerializeInfo<string, global::Serde.StringProxy>(), typeof(ArgumentInfo).GetProperty("Value"))
+    }
+    );
+}

--- a/test/Serde.Generation.Test/test_output/SerdeTests.CommandResponseTest/ArgumentInfo.ISerialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/SerdeTests.CommandResponseTest/ArgumentInfo.ISerialize.verified.cs
@@ -1,0 +1,28 @@
+﻿//HintName: ArgumentInfo.ISerialize.cs
+
+#nullable enable
+
+using System;
+using Serde;
+partial class ArgumentInfo : Serde.ISerializeProvider<ArgumentInfo>
+{
+    static ISerialize<ArgumentInfo> ISerializeProvider<ArgumentInfo>.Instance
+        => _SerObj.Instance;
+
+    sealed partial class _SerObj :Serde.ISerialize<ArgumentInfo>
+    {
+        global::Serde.ISerdeInfo global::Serde.ISerdeInfoProvider.SerdeInfo => ArgumentInfo.s_serdeInfo;
+
+        void global::Serde.ISerialize<ArgumentInfo>.Serialize(ArgumentInfo value, global::Serde.ISerializer serializer)
+        {
+            var _l_info = global::Serde.SerdeInfoProvider.GetInfo(this);
+            var _l_type = serializer.WriteType(_l_info);
+            _l_type.WriteString(_l_info, 0, value.Name);
+            _l_type.WriteString(_l_info, 1, value.Value);
+            _l_type.End(_l_info);
+        }
+        public static readonly _SerObj Instance = new();
+        private _SerObj() { }
+
+    }
+}

--- a/test/Serde.Generation.Test/test_output/SerdeTests.CommandResponseTest/CommandResponse.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/SerdeTests.CommandResponseTest/CommandResponse.IDeserialize.verified.cs
@@ -1,0 +1,78 @@
+﻿//HintName: CommandResponse.IDeserialize.cs
+
+#nullable enable
+
+using System;
+using Serde;
+partial class CommandResponse<TResult, TProxy> : Serde.IDeserializeProvider<CommandResponse<TResult, TProxy>>
+{
+    static IDeserialize<CommandResponse<TResult, TProxy>> IDeserializeProvider<CommandResponse<TResult, TProxy>>.Instance
+        => _DeObj.Instance;
+
+    sealed partial class _DeObj :Serde.IDeserialize<CommandResponse<TResult, TProxy>>
+    {
+        global::Serde.ISerdeInfo global::Serde.ISerdeInfoProvider.SerdeInfo => CommandResponse<TResult, TProxy>.s_serdeInfo;
+
+        CommandResponse<TResult, TProxy> Serde.IDeserialize<CommandResponse<TResult, TProxy>>.Deserialize(IDeserializer deserializer)
+        {
+            int _l_status = default!;
+            string _l_message = default!;
+            System.Collections.Generic.List<ArgumentInfo>? _l_arguments = default!;
+            TResult? _l_results = default!;
+            long _l_duration = default!;
+
+            byte _r_assignedValid = 0;
+
+            var _l_serdeInfo = global::Serde.SerdeInfoProvider.GetInfo(this);
+            var typeDeserialize = deserializer.ReadType(_l_serdeInfo);
+            int _l_index_;
+            while ((_l_index_ = typeDeserialize.TryReadIndex(_l_serdeInfo, out _)) != ITypeDeserializer.EndOfType)
+            {
+                switch (_l_index_)
+                {
+                    case 0:
+                        _l_status = typeDeserialize.ReadI32(_l_serdeInfo, _l_index_);
+                        _r_assignedValid |= ((byte)1) << 0;
+                        break;
+                    case 1:
+                        _l_message = typeDeserialize.ReadString(_l_serdeInfo, _l_index_);
+                        _r_assignedValid |= ((byte)1) << 1;
+                        break;
+                    case 2:
+                        _l_arguments = typeDeserialize.ReadValue<System.Collections.Generic.List<ArgumentInfo>?, Serde.NullableRefProxy.De<System.Collections.Generic.List<ArgumentInfo>, Serde.ListProxy.De<ArgumentInfo, ArgumentInfo>>>(_l_serdeInfo, _l_index_);
+                        _r_assignedValid |= ((byte)1) << 2;
+                        break;
+                    case 3:
+                        _l_results = typeDeserialize.ReadValue<TResult?, TProxy>(_l_serdeInfo, _l_index_);
+                        _r_assignedValid |= ((byte)1) << 3;
+                        break;
+                    case 4:
+                        _l_duration = typeDeserialize.ReadI64(_l_serdeInfo, _l_index_);
+                        _r_assignedValid |= ((byte)1) << 4;
+                        break;
+                    case Serde.ITypeDeserializer.IndexNotFound:
+                        typeDeserialize.SkipValue(_l_serdeInfo, _l_index_);
+                        break;
+                    default:
+                        throw new InvalidOperationException("Unexpected index: " + _l_index_);
+                }
+            }
+            if ((_r_assignedValid & 0b10011) != 0b10011)
+            {
+                throw Serde.DeserializeException.UnassignedMember();
+            }
+            var newType = new CommandResponse<TResult, TProxy>() {
+                Status = _l_status,
+                Message = _l_message,
+                Arguments = _l_arguments,
+                Results = _l_results,
+                Duration = _l_duration,
+            };
+
+            return newType;
+        }
+        public static readonly _DeObj Instance = new();
+        private _DeObj() { }
+
+    }
+}

--- a/test/Serde.Generation.Test/test_output/SerdeTests.CommandResponseTest/CommandResponse.ISerdeInfoProvider.verified.cs
+++ b/test/Serde.Generation.Test/test_output/SerdeTests.CommandResponseTest/CommandResponse.ISerdeInfoProvider.verified.cs
@@ -1,0 +1,17 @@
+﻿//HintName: CommandResponse.ISerdeInfoProvider.cs
+
+#nullable enable
+partial class CommandResponse<TResult, TProxy>
+{
+    private static global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
+        "CommandResponse",
+    typeof(CommandResponse<,>).GetCustomAttributesData(),
+    new (string, global::Serde.ISerdeInfo, System.Reflection.MemberInfo?)[] {
+        ("status", global::Serde.SerdeInfoProvider.GetSerializeInfo<int, global::Serde.I32Proxy>(), typeof(CommandResponse<,>).GetProperty("Status")),
+        ("message", global::Serde.SerdeInfoProvider.GetSerializeInfo<string, global::Serde.StringProxy>(), typeof(CommandResponse<,>).GetProperty("Message")),
+        ("arguments", global::Serde.SerdeInfoProvider.GetSerializeInfo<System.Collections.Generic.List<ArgumentInfo>?, Serde.NullableRefProxy.Ser<System.Collections.Generic.List<ArgumentInfo>, Serde.ListProxy.Ser<ArgumentInfo, ArgumentInfo>>>(), typeof(CommandResponse<,>).GetProperty("Arguments")),
+        ("results", global::Serde.SerdeInfoProvider.GetSerializeInfo<TResult?, TProxy>(), typeof(CommandResponse<,>).GetProperty("Results")),
+        ("duration", global::Serde.SerdeInfoProvider.GetSerializeInfo<long, global::Serde.I64Proxy>(), typeof(CommandResponse<,>).GetProperty("Duration"))
+    }
+    );
+}

--- a/test/Serde.Generation.Test/test_output/SerdeTests.CommandResponseTest/CommandResponse.ISerialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/SerdeTests.CommandResponseTest/CommandResponse.ISerialize.verified.cs
@@ -1,0 +1,31 @@
+﻿//HintName: CommandResponse.ISerialize.cs
+
+#nullable enable
+
+using System;
+using Serde;
+partial class CommandResponse<TResult, TProxy> : Serde.ISerializeProvider<CommandResponse<TResult, TProxy>>
+{
+    static ISerialize<CommandResponse<TResult, TProxy>> ISerializeProvider<CommandResponse<TResult, TProxy>>.Instance
+        => _SerObj.Instance;
+
+    sealed partial class _SerObj :Serde.ISerialize<CommandResponse<TResult, TProxy>>
+    {
+        global::Serde.ISerdeInfo global::Serde.ISerdeInfoProvider.SerdeInfo => CommandResponse<TResult, TProxy>.s_serdeInfo;
+
+        void global::Serde.ISerialize<CommandResponse<TResult, TProxy>>.Serialize(CommandResponse<TResult, TProxy> value, global::Serde.ISerializer serializer)
+        {
+            var _l_info = global::Serde.SerdeInfoProvider.GetInfo(this);
+            var _l_type = serializer.WriteType(_l_info);
+            _l_type.WriteI32(_l_info, 0, value.Status);
+            _l_type.WriteString(_l_info, 1, value.Message);
+            _l_type.WriteValueIfNotNull<System.Collections.Generic.List<ArgumentInfo>?, Serde.NullableRefProxy.Ser<System.Collections.Generic.List<ArgumentInfo>, Serde.ListProxy.Ser<ArgumentInfo, ArgumentInfo>>>(_l_info, 2, value.Arguments);
+            _l_type.WriteValueIfNotNull<TResult?, TProxy>(_l_info, 3, value.Results);
+            _l_type.WriteI64(_l_info, 4, value.Duration);
+            _l_type.End(_l_info);
+        }
+        public static readonly _SerObj Instance = new();
+        private _SerObj() { }
+
+    }
+}

--- a/test/Serde.Generation.Test/test_output/SerdeTests.InvalidTypeParameterProxyTest/FinalDiagnostics.verified.txt
+++ b/test/Serde.Generation.Test/test_output/SerdeTests.InvalidTypeParameterProxyTest/FinalDiagnostics.verified.txt
@@ -1,0 +1,68 @@
+﻿[
+  {
+    "Id": "CS0452",
+    "Title": "",
+    "Severity": "Error",
+    "WarningLevel": "0",
+    "Location": "SerdeGenerator/Serde.SerdeImplRoslynGenerator/InvalidProxyTest.IDeserialize.cs: (30,52)-(30,69)",
+    "HelpLink": "https://msdn.microsoft.com/query/roslyn.query?appId=roslyn&k=k(CS0452)",
+    "MessageFormat": "The type '{2}' must be a reference type in order to use it as parameter '{1}' in the generic type or method '{0}'",
+    "Message": "The type 'T' must be a reference type in order to use it as parameter 'T' in the generic type or method 'ITypeDeserializerExt.ReadValue<T, TProvider>(ITypeDeserializer, ISerdeInfo, int)'",
+    "Category": "Compiler"
+  },
+  {
+    "Id": "CS0314",
+    "Title": "",
+    "Severity": "Error",
+    "WarningLevel": "0",
+    "Location": "SerdeGenerator/Serde.SerdeImplRoslynGenerator/InvalidProxyTest.IDeserialize.cs: (30,52)-(30,69)",
+    "HelpLink": "https://msdn.microsoft.com/query/roslyn.query?appId=roslyn&k=k(CS0314)",
+    "MessageFormat": "The type '{3}' cannot be used as type parameter '{2}' in the generic type or method '{0}'. There is no boxing conversion or type parameter conversion from '{3}' to '{1}'.",
+    "Message": "The type 'T' cannot be used as type parameter 'TProvider' in the generic type or method 'ITypeDeserializerExt.ReadValue<T, TProvider>(ITypeDeserializer, ISerdeInfo, int)'. There is no boxing conversion or type parameter conversion from 'T' to 'Serde.IDeserializeProvider<T?>'.",
+    "Category": "Compiler"
+  },
+  {
+    "Id": "CS0452",
+    "Title": "",
+    "Severity": "Error",
+    "WarningLevel": "0",
+    "Location": "SerdeGenerator/Serde.SerdeImplRoslynGenerator/InvalidProxyTest.IDeserialize.cs: (34,52)-(34,69)",
+    "HelpLink": "https://msdn.microsoft.com/query/roslyn.query?appId=roslyn&k=k(CS0452)",
+    "MessageFormat": "The type '{2}' must be a reference type in order to use it as parameter '{1}' in the generic type or method '{0}'",
+    "Message": "The type 'T' must be a reference type in order to use it as parameter 'T' in the generic type or method 'ITypeDeserializerExt.ReadValue<T, TProvider>(ITypeDeserializer, ISerdeInfo, int)'",
+    "Category": "Compiler"
+  },
+  {
+    "Id": "CS0314",
+    "Title": "",
+    "Severity": "Error",
+    "WarningLevel": "0",
+    "Location": "SerdeGenerator/Serde.SerdeImplRoslynGenerator/InvalidProxyTest.IDeserialize.cs: (34,52)-(34,69)",
+    "HelpLink": "https://msdn.microsoft.com/query/roslyn.query?appId=roslyn&k=k(CS0314)",
+    "MessageFormat": "The type '{3}' cannot be used as type parameter '{2}' in the generic type or method '{0}'. There is no boxing conversion or type parameter conversion from '{3}' to '{1}'.",
+    "Message": "The type 'T' cannot be used as type parameter 'TProvider' in the generic type or method 'ITypeDeserializerExt.ReadValue<T, TProvider>(ITypeDeserializer, ISerdeInfo, int)'. There is no boxing conversion or type parameter conversion from 'T' to 'Serde.IDeserializeProvider<T?>'.",
+    "Category": "Compiler"
+  },
+  {
+    "Id": "CS0452",
+    "Title": "",
+    "Severity": "Error",
+    "WarningLevel": "0",
+    "Location": "SerdeGenerator/Serde.SerdeImplRoslynGenerator/InvalidProxyTest.IDeserialize.cs: (38,52)-(38,69)",
+    "HelpLink": "https://msdn.microsoft.com/query/roslyn.query?appId=roslyn&k=k(CS0452)",
+    "MessageFormat": "The type '{2}' must be a reference type in order to use it as parameter '{1}' in the generic type or method '{0}'",
+    "Message": "The type 'T' must be a reference type in order to use it as parameter 'T' in the generic type or method 'ITypeDeserializerExt.ReadValue<T, TProvider>(ITypeDeserializer, ISerdeInfo, int)'",
+    "Category": "Compiler"
+  },
+  {
+    "Id": "CS0314",
+    "Title": "",
+    "Severity": "Error",
+    "WarningLevel": "0",
+    "Location": "SerdeGenerator/Serde.SerdeImplRoslynGenerator/InvalidProxyTest.IDeserialize.cs: (38,52)-(38,69)",
+    "HelpLink": "https://msdn.microsoft.com/query/roslyn.query?appId=roslyn&k=k(CS0314)",
+    "MessageFormat": "The type '{3}' cannot be used as type parameter '{2}' in the generic type or method '{0}'. There is no boxing conversion or type parameter conversion from '{3}' to '{1}'.",
+    "Message": "The type 'T' cannot be used as type parameter 'TProvider' in the generic type or method 'ITypeDeserializerExt.ReadValue<T, TProvider>(ITypeDeserializer, ISerdeInfo, int)'. There is no boxing conversion or type parameter conversion from 'T' to 'Serde.IDeserializeProvider<T?>'.",
+    "Category": "Compiler"
+  }
+]

--- a/test/Serde.Generation.Test/test_output/SerdeTests.InvalidTypeParameterProxyTest/InvalidProxyTest.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/SerdeTests.InvalidTypeParameterProxyTest/InvalidProxyTest.IDeserialize.verified.cs
@@ -1,0 +1,66 @@
+﻿//HintName: InvalidProxyTest.IDeserialize.cs
+
+#nullable enable
+
+using System;
+using Serde;
+partial class InvalidProxyTest<T> : Serde.IDeserializeProvider<InvalidProxyTest<T>>
+{
+    static IDeserialize<InvalidProxyTest<T>> IDeserializeProvider<InvalidProxyTest<T>>.Instance
+        => _DeObj.Instance;
+
+    sealed partial class _DeObj :Serde.IDeserialize<InvalidProxyTest<T>>
+    {
+        global::Serde.ISerdeInfo global::Serde.ISerdeInfoProvider.SerdeInfo => InvalidProxyTest<T>.s_serdeInfo;
+
+        InvalidProxyTest<T> Serde.IDeserialize<InvalidProxyTest<T>>.Deserialize(IDeserializer deserializer)
+        {
+            T? _l_value1 = default!;
+            T? _l_value2 = default!;
+            T? _l_value3 = default!;
+
+            byte _r_assignedValid = 0;
+
+            var _l_serdeInfo = global::Serde.SerdeInfoProvider.GetInfo(this);
+            var typeDeserialize = deserializer.ReadType(_l_serdeInfo);
+            int _l_index_;
+            while ((_l_index_ = typeDeserialize.TryReadIndex(_l_serdeInfo, out _)) != ITypeDeserializer.EndOfType)
+            {
+                switch (_l_index_)
+                {
+                    case 0:
+                        _l_value1 = typeDeserialize.ReadValue<T?, T?>(_l_serdeInfo, _l_index_);
+                        _r_assignedValid |= ((byte)1) << 0;
+                        break;
+                    case 1:
+                        _l_value2 = typeDeserialize.ReadValue<T?, T?>(_l_serdeInfo, _l_index_);
+                        _r_assignedValid |= ((byte)1) << 1;
+                        break;
+                    case 2:
+                        _l_value3 = typeDeserialize.ReadValue<T?, T?>(_l_serdeInfo, _l_index_);
+                        _r_assignedValid |= ((byte)1) << 2;
+                        break;
+                    case Serde.ITypeDeserializer.IndexNotFound:
+                        typeDeserialize.SkipValue(_l_serdeInfo, _l_index_);
+                        break;
+                    default:
+                        throw new InvalidOperationException("Unexpected index: " + _l_index_);
+                }
+            }
+            if ((_r_assignedValid & 0b0) != 0b0)
+            {
+                throw Serde.DeserializeException.UnassignedMember();
+            }
+            var newType = new InvalidProxyTest<T>() {
+                Value1 = _l_value1,
+                Value2 = _l_value2,
+                Value3 = _l_value3,
+            };
+
+            return newType;
+        }
+        public static readonly _DeObj Instance = new();
+        private _DeObj() { }
+
+    }
+}

--- a/test/Serde.Generation.Test/test_output/SerdeTests.InvalidTypeParameterProxyTest/InvalidProxyTest.ISerdeInfoProvider.verified.cs
+++ b/test/Serde.Generation.Test/test_output/SerdeTests.InvalidTypeParameterProxyTest/InvalidProxyTest.ISerdeInfoProvider.verified.cs
@@ -1,0 +1,13 @@
+﻿//HintName: InvalidProxyTest.ISerdeInfoProvider.cs
+
+#nullable enable
+partial class InvalidProxyTest<T>
+{
+    private static global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
+        "InvalidProxyTest",
+    typeof(InvalidProxyTest<>).GetCustomAttributesData(),
+    new (string, global::Serde.ISerdeInfo, System.Reflection.MemberInfo?)[] {
+
+    }
+    );
+}

--- a/test/Serde.Generation.Test/test_output/SerdeTests.InvalidTypeParameterProxyTest/InvalidProxyTest.ISerialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/SerdeTests.InvalidTypeParameterProxyTest/InvalidProxyTest.ISerialize.verified.cs
@@ -1,0 +1,26 @@
+﻿//HintName: InvalidProxyTest.ISerialize.cs
+
+#nullable enable
+
+using System;
+using Serde;
+partial class InvalidProxyTest<T> : Serde.ISerializeProvider<InvalidProxyTest<T>>
+{
+    static ISerialize<InvalidProxyTest<T>> ISerializeProvider<InvalidProxyTest<T>>.Instance
+        => _SerObj.Instance;
+
+    sealed partial class _SerObj :Serde.ISerialize<InvalidProxyTest<T>>
+    {
+        global::Serde.ISerdeInfo global::Serde.ISerdeInfoProvider.SerdeInfo => InvalidProxyTest<T>.s_serdeInfo;
+
+        void global::Serde.ISerialize<InvalidProxyTest<T>>.Serialize(InvalidProxyTest<T> value, global::Serde.ISerializer serializer)
+        {
+            var _l_info = global::Serde.SerdeInfoProvider.GetInfo(this);
+            var _l_type = serializer.WriteType(_l_info);
+            _l_type.End(_l_info);
+        }
+        public static readonly _SerObj Instance = new();
+        private _SerObj() { }
+
+    }
+}

--- a/test/Serde.Generation.Test/test_output/SerdeTests.InvalidTypeParameterProxyTest/target.verified.txt
+++ b/test/Serde.Generation.Test/test_output/SerdeTests.InvalidTypeParameterProxyTest/target.verified.txt
@@ -1,0 +1,94 @@
+﻿{
+  Diagnostics: [
+    {
+      Id: ERR_CantFindTypeParameter,
+      Title: ,
+      Severity: Error,
+      WarningLevel: 0,
+      Location: : (6,14)-(6,20),
+      MessageFormat: Could not find type parameter named 'NonExistentProxy' in the current context.,
+      Message: Could not find type parameter named 'NonExistentProxy' in the current context.,
+      Category: Serde
+    },
+    {
+      Id: ERR_CantFindTypeParameter,
+      Title: ,
+      Severity: Error,
+      WarningLevel: 0,
+      Location: : (9,14)-(9,20),
+      MessageFormat: Could not find type parameter named 'NonExistentProxy' in the current context.,
+      Message: Could not find type parameter named 'NonExistentProxy' in the current context.,
+      Category: Serde
+    },
+    {
+      Id: ERR_DoesntImplementInterface,
+      Title: ,
+      Severity: Error,
+      WarningLevel: 0,
+      Location: : (6,14)-(6,20),
+      MessageFormat: The member 'InvalidProxyTest<T>.Value1's return type 'T?' doesn't implement Serde.ISerializeProvider<T>. Either implement 'Serde.ISerializeProvider<T>' on T?, or specify a proxy type.,
+      Message: The member 'InvalidProxyTest<T>.Value1's return type 'T?' doesn't implement Serde.ISerializeProvider<T>. Either implement 'Serde.ISerializeProvider<T>' on T?, or specify a proxy type.,
+      Category: Serde
+    },
+    {
+      Id: ERR_DoesntImplementInterface,
+      Title: ,
+      Severity: Error,
+      WarningLevel: 0,
+      Location: : (9,14)-(9,20),
+      MessageFormat: The member 'InvalidProxyTest<T>.Value2's return type 'T?' doesn't implement Serde.ISerializeProvider<T>. Either implement 'Serde.ISerializeProvider<T>' on T?, or specify a proxy type.,
+      Message: The member 'InvalidProxyTest<T>.Value2's return type 'T?' doesn't implement Serde.ISerializeProvider<T>. Either implement 'Serde.ISerializeProvider<T>' on T?, or specify a proxy type.,
+      Category: Serde
+    },
+    {
+      Id: ERR_DoesntImplementInterface,
+      Title: ,
+      Severity: Error,
+      WarningLevel: 0,
+      Location: : (12,14)-(12,20),
+      MessageFormat: The member 'InvalidProxyTest<T>.Value3's return type 'T?' doesn't implement Serde.ISerializeProvider<T>. Either implement 'Serde.ISerializeProvider<T>' on T?, or specify a proxy type.,
+      Message: The member 'InvalidProxyTest<T>.Value3's return type 'T?' doesn't implement Serde.ISerializeProvider<T>. Either implement 'Serde.ISerializeProvider<T>' on T?, or specify a proxy type.,
+      Category: Serde
+    },
+    {
+      Id: ERR_DoesntImplementInterface,
+      Title: ,
+      Severity: Error,
+      WarningLevel: 0,
+      Location: : (6,14)-(6,20),
+      MessageFormat: The member 'InvalidProxyTest<T>.Value1's return type 'T?' doesn't implement Serde.IDeserializeProvider<T>. Either implement 'Serde.IDeserializeProvider<T>' on T?, or specify a proxy type.,
+      Message: The member 'InvalidProxyTest<T>.Value1's return type 'T?' doesn't implement Serde.IDeserializeProvider<T>. Either implement 'Serde.IDeserializeProvider<T>' on T?, or specify a proxy type.,
+      Category: Serde
+    },
+    {
+      Id: ERR_DoesntImplementInterface,
+      Title: ,
+      Severity: Error,
+      WarningLevel: 0,
+      Location: : (9,14)-(9,20),
+      MessageFormat: The member 'InvalidProxyTest<T>.Value2's return type 'T?' doesn't implement Serde.IDeserializeProvider<T>. Either implement 'Serde.IDeserializeProvider<T>' on T?, or specify a proxy type.,
+      Message: The member 'InvalidProxyTest<T>.Value2's return type 'T?' doesn't implement Serde.IDeserializeProvider<T>. Either implement 'Serde.IDeserializeProvider<T>' on T?, or specify a proxy type.,
+      Category: Serde
+    },
+    {
+      Id: ERR_CantFindTypeParameter,
+      Title: ,
+      Severity: Error,
+      WarningLevel: 0,
+      Location: : (12,14)-(12,20),
+      MessageFormat: Could not find type parameter named 'NonExistentProxy' in the current context.,
+      Message: Could not find type parameter named 'NonExistentProxy' in the current context.,
+      Category: Serde
+    },
+    {
+      Id: ERR_DoesntImplementInterface,
+      Title: ,
+      Severity: Error,
+      WarningLevel: 0,
+      Location: : (12,14)-(12,20),
+      MessageFormat: The member 'InvalidProxyTest<T>.Value3's return type 'T?' doesn't implement Serde.IDeserializeProvider<T>. Either implement 'Serde.IDeserializeProvider<T>' on T?, or specify a proxy type.,
+      Message: The member 'InvalidProxyTest<T>.Value3's return type 'T?' doesn't implement Serde.IDeserializeProvider<T>. Either implement 'Serde.IDeserializeProvider<T>' on T?, or specify a proxy type.,
+      Category: Serde
+    }
+  ]
+}


### PR DESCRIPTION
The existing system won't allow type parameter proxies because type parameters can't appear as typeof arguments in attribute arguments. This works around the problem by using a string name instead.