### PR TITLE
Add 'bytes' as a Serde primitive

### DIFF
--- a/src/generator/Proxies.cs
+++ b/src/generator/Proxies.cs
@@ -125,6 +125,8 @@ sealed partial class {{proxyName}}
                 Name: "System",
                 ContainingNamespace: { IsGlobalNamespace: true } } }
             => new("global::System.DateTime", "global::Serde.DateTimeProxy"),
+            IArrayTypeSymbol { ElementType: { SpecialType: SpecialType.System_Byte } }
+            => new("global::System.Byte[]", "global::Serde.ByteArrayProxy"),
             _ => null
         };
     }

--- a/src/serde/IDeserialize.cs
+++ b/src/serde/IDeserialize.cs
@@ -1,5 +1,6 @@
 
 using System;
+using System.Buffers;
 
 namespace Serde;
 
@@ -47,6 +48,7 @@ public interface IDeserializer : IDisposable
     decimal ReadDecimal();
     string ReadString();
     DateTimeOffset ReadDateTimeOffset();
+    void ReadBytes(IBufferWriter<byte> writer);
     ITypeDeserializer ReadType(ISerdeInfo typeInfo);
 }
 
@@ -102,6 +104,7 @@ public interface ITypeDeserializer
     decimal ReadDecimal(ISerdeInfo info, int index);
     string ReadString(ISerdeInfo info, int index);
     DateTimeOffset ReadDateTimeOffset(ISerdeInfo info, int index);
+    void ReadBytes(ISerdeInfo info, int index, IBufferWriter<byte> writer);
 }
 
 public static class ITypeDeserializerExt

--- a/src/serde/ISerialize.cs
+++ b/src/serde/ISerialize.cs
@@ -90,6 +90,7 @@ public interface ISerializer
     void WriteString(string s);
     void WriteNull();
     void WriteDateTimeOffset(DateTimeOffset dt);
+    void WriteBytes(ReadOnlyMemory<byte> bytes);
 
     /// <summary>
     /// Write a collection type -- either a list or a dictionary.
@@ -173,6 +174,7 @@ public interface ITypeSerializer
     void WriteString(ISerdeInfo typeInfo, int index, string s);
     void WriteNull(ISerdeInfo typeInfo, int index);
     void WriteDateTimeOffset(ISerdeInfo typeInfo, int index, DateTimeOffset dt);
+    void WriteBytes(ISerdeInfo typeInfo, int index, ReadOnlyMemory<byte> bytes);
 
     /// <summary>
     /// Write an arbitrary value with custom serialization. For reference types this method may be

--- a/src/serde/Proxies.cs
+++ b/src/serde/Proxies.cs
@@ -2,9 +2,7 @@
 
 using System;
 using System.Buffers;
-using System.Buffers.Text;
 using System.Diagnostics;
-using System.Text.Json;
 using System.Threading;
 
 namespace Serde;

--- a/src/serde/Proxies.cs
+++ b/src/serde/Proxies.cs
@@ -3,7 +3,9 @@
 using System;
 using System.Buffers;
 using System.Buffers.Text;
+using System.Diagnostics;
 using System.Text.Json;
+using System.Threading;
 
 namespace Serde;
 
@@ -500,4 +502,130 @@ public sealed class DateTimeProxy : ISerdePrimitive<DateTimeProxy, DateTime>
         => deserializer.ReadDateTimeOffset().DateTime;
     DateTime ITypeDeserialize<DateTime>.Deserialize(ITypeDeserializer deserializer, ISerdeInfo info, int index)
         => deserializer.ReadDateTimeOffset(info, index).DateTime;
+}
+
+public sealed class ByteArrayProxy : ISerdePrimitive<ByteArrayProxy, byte[]>
+{
+    private sealed class ArrayWriter : IBufferWriter<byte>
+    {
+        public byte[]? _buffer;
+        public int _written = 0;
+
+        public void Advance(int count)
+        {
+            if (_buffer is null)
+            {
+                throw new InvalidOperationException("Buffer is null");
+            }
+            _written = count;
+        }
+
+        public Memory<byte> GetMemory(int sizeHint = 0)
+        {
+            if (sizeHint == 0)
+            {
+                sizeHint = 1;
+            }
+            if (_buffer == null || _buffer.Length < sizeHint)
+            {
+                _buffer = new byte[sizeHint];
+            }
+            return _buffer;
+        }
+
+        public Span<byte> GetSpan(int sizeHint = 0) => GetMemory(sizeHint).Span;
+
+        public void Clear()
+        {
+            _written = 0;
+            _buffer = null;
+        }
+
+        public byte[] GetArray()
+        {
+            var buffer = _buffer;
+            if (buffer is null)
+            {
+                Debug.Assert(_written == 0);
+                return Array.Empty<byte>();
+            }
+            if (_written != buffer.Length)
+            {
+                var newBuffer = new byte[_written];
+                Array.Copy(buffer, newBuffer, _written);
+                return newBuffer;
+            }
+            return buffer;
+        }
+    }
+    private ArrayWriter? _bufferWriter = new();
+
+    private (ArrayWriter, bool Owned) BorrowBufferWriter()
+    {
+        var bufferWriter = Interlocked.Exchange(ref _bufferWriter, null);
+        if (bufferWriter is null)
+        {
+            return (new ArrayWriter(), false);
+        }
+        return (bufferWriter, true);
+    }
+
+    private void ReturnBufferWriter(ArrayWriter bufferWriter)
+    {
+        bufferWriter.Clear();
+        if (Interlocked.Exchange(ref _bufferWriter, bufferWriter) is not null)
+        {
+            throw new InvalidOperationException("Buffer writer released twice");
+        }
+    }
+
+    public static ByteArrayProxy Instance { get; } = new();
+    private ByteArrayProxy() { }
+
+    public static ISerdeInfo SerdeInfo { get; } = Serde.SerdeInfo.MakeEnumerable("byte[]");
+    ISerdeInfo ISerdeInfoProvider.SerdeInfo => SerdeInfo;
+
+    void ISerialize<byte[]>.Serialize(byte[] value, ISerializer serializer)
+        => serializer.WriteBytes(value);
+
+    byte[] IDeserialize<byte[]>.Deserialize(IDeserializer deserializer)
+    {
+        // Take ownership of the buffer writer
+        var (bufferWriter, owned) = BorrowBufferWriter();
+        try
+        {
+            deserializer.ReadBytes(bufferWriter);
+            return bufferWriter.GetArray();
+        }
+        finally
+        {
+            if (owned)
+            {
+                ReturnBufferWriter(bufferWriter);
+            }
+        }
+    }
+
+    public void Serialize(byte[] value, ITypeSerializer serializer, ISerdeInfo info, int index)
+    {
+        serializer.WriteBytes(info, index, value);
+    }
+
+    byte[] ITypeDeserialize<byte[]>.Deserialize(ITypeDeserializer deserializer, ISerdeInfo info, int index)
+    {
+        // Take ownership of the buffer writer
+        var (bufferWriter, owned) = BorrowBufferWriter();
+        try
+        {
+            deserializer.ReadBytes(info, index, bufferWriter);
+            return bufferWriter.GetArray();
+        }
+        finally
+        {
+            if (owned)
+            {
+                ReturnBufferWriter(bufferWriter);
+            }
+        }
+    }
 }

--- a/src/serde/json/JsonDeserializer.Collection.cs
+++ b/src/serde/json/JsonDeserializer.Collection.cs
@@ -1,5 +1,7 @@
 
 using System;
+using System.Buffers;
+using System.Buffers.Text;
 using System.Diagnostics.CodeAnalysis;
 using static Serde.Json.ThrowHelpers;
 
@@ -204,6 +206,12 @@ partial class JsonDeserializer<TReader>
             var v = _deserializer.ReadDateTimeOffset();
             _index++;
             return v;
+        }
+
+        void ITypeDeserializer.ReadBytes(ISerdeInfo info, int index, IBufferWriter<byte> writer)
+        {
+            _deserializer.ReadBytes(writer);
+            _index++;
         }
     }
 }

--- a/src/serde/json/JsonDeserializer.Type.cs
+++ b/src/serde/json/JsonDeserializer.Type.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Buffers;
+using System.Buffers.Text;
 using static Serde.Json.ThrowHelpers;
 
 namespace Serde.Json;
@@ -143,6 +145,11 @@ partial class JsonDeserializer<TReader> : ITypeDeserializer
     {
         ReadColon();
         return ReadDateTimeOffset();
+    }
+    void ITypeDeserializer.ReadBytes(ISerdeInfo info, int index, IBufferWriter<byte> writer)
+    {
+        ReadColon();
+        ReadBytes(writer);
     }
 
     void ITypeDeserializer.SkipValue(ISerdeInfo info, int index)

--- a/src/serde/json/JsonSerializer.Collection.cs
+++ b/src/serde/json/JsonSerializer.Collection.cs
@@ -88,6 +88,10 @@ partial class JsonSerializer
         {
             serializer.WriteDateTimeOffset(dt);
         }
+        public void WriteBytes(ISerdeInfo typeInfo, int index, ReadOnlyMemory<byte> bytes)
+        {
+            serializer.WriteBytes(bytes);
+        }
 
         public void WriteValue<T>(ISerdeInfo typeInfo, int index, T value, ISerialize<T> serialize)
             where T : class?
@@ -113,6 +117,7 @@ partial class JsonSerializer
         public void WriteF64(double d) => throw new KeyNotStringException();
         public void WriteDecimal(decimal d) => throw new KeyNotStringException();
         public void WriteDateTimeOffset(DateTimeOffset dt) => throw new KeyNotStringException();
+        public void WriteBytes(ReadOnlyMemory<byte> bytes) => throw new KeyNotStringException();
 
         public void WriteString(string s)
         {
@@ -150,6 +155,7 @@ partial class JsonSerializer
         public void WriteU64(ISerdeInfo typeInfo, int index, ulong u64) => GetSerializer(index).WriteU64(u64);
         public void WriteU8(ISerdeInfo typeInfo, int index, byte b) => GetSerializer(index).WriteU8(b);
         public void WriteDateTimeOffset(ISerdeInfo typeInfo, int index, DateTimeOffset dt) => GetSerializer(index).WriteDateTimeOffset(dt);
+        public void WriteBytes(ISerdeInfo typeInfo, int index, ReadOnlyMemory<byte> bytes) => GetSerializer(index).WriteBytes(bytes);
         public void WriteValue<T>(ISerdeInfo typeInfo, int index, T value, ISerialize<T> serialize)
             where T : class?
             => serialize.Serialize(value, GetSerializer(index));

--- a/src/serde/json/JsonSerializer.Serialize.cs
+++ b/src/serde/json/JsonSerializer.Serialize.cs
@@ -40,6 +40,7 @@ partial class JsonSerializer : ISerializer
     public void WriteString(string s) => _writer.WriteStringValue(s);
     public void WriteNull() => _writer.WriteNullValue();
     public void WriteDateTimeOffset(DateTimeOffset dt) => _writer.WriteStringValue(dt);
+    public void WriteBytes(ReadOnlyMemory<byte> bytes) => _writer.WriteBase64StringValue(bytes.Span);
 
     ITypeSerializer ISerializer.WriteCollection(ISerdeInfo info, int? size)
     {
@@ -96,6 +97,7 @@ partial class JsonSerializer : ISerializer
         public void WriteU32(ISerdeInfo typeInfo, int index, uint u32) => WriteEnumName(typeInfo, index);
         public void WriteU64(ISerdeInfo typeInfo, int index, ulong u64) => WriteEnumName(typeInfo, index);
         public void WriteDateTimeOffset(ISerdeInfo typeInfo, int index, DateTimeOffset dt) => ThrowInvalidEnum();
+        public void WriteBytes(ISerdeInfo typeInfo, int index, ReadOnlyMemory<byte> bytes) => ThrowInvalidEnum();
         private void ThrowInvalidEnum() => throw new InvalidOperationException("Invalid operation for enum serialization, expected integer value.");
     }
 
@@ -210,5 +212,10 @@ partial class JsonSerializer : ITypeSerializer
     {
         _writer.WritePropertyName(typeInfo.GetFieldName(index));
         WriteDateTimeOffset(dt);
+    }
+    void ITypeSerializer.WriteBytes(ISerdeInfo typeInfo, int index, ReadOnlyMemory<byte> bytes)
+    {
+        _writer.WritePropertyName(typeInfo.GetFieldName(index));
+        _writer.WriteBase64StringValue(bytes.Span);
     }
 }

--- a/test/Serde.Generation.Test/test_output/AllInOneTest.GeneratorTest/Serde.Test.AllInOne.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/AllInOneTest.GeneratorTest/Serde.Test.AllInOne.IDeserialize.verified.cs
@@ -36,6 +36,7 @@ partial record AllInOne : Serde.IDeserializeProvider<Serde.Test.AllInOne>
             string? _l_nullstringfield = default!;
             uint[] _l_uintarr = default!;
             int[][] _l_nestedarr = default!;
+            byte[] _l_bytearr = default!;
             System.Collections.Immutable.ImmutableArray<int> _l_intimm = default!;
             Serde.Test.AllInOne.ColorEnum _l_color = default!;
 
@@ -121,12 +122,16 @@ partial record AllInOne : Serde.IDeserializeProvider<Serde.Test.AllInOne>
                         _r_assignedValid |= ((uint)1) << 17;
                         break;
                     case 18:
-                        _l_intimm = typeDeserialize.ReadBoxedValue<System.Collections.Immutable.ImmutableArray<int>, Serde.ImmutableArrayProxy.De<int, global::Serde.I32Proxy>>(_l_serdeInfo, _l_index_);
+                        _l_bytearr = typeDeserialize.ReadValue<byte[], global::Serde.ByteArrayProxy>(_l_serdeInfo, _l_index_);
                         _r_assignedValid |= ((uint)1) << 18;
                         break;
                     case 19:
-                        _l_color = typeDeserialize.ReadBoxedValue<Serde.Test.AllInOne.ColorEnum, Serde.Test.AllInOne.ColorEnumProxy>(_l_serdeInfo, _l_index_);
+                        _l_intimm = typeDeserialize.ReadBoxedValue<System.Collections.Immutable.ImmutableArray<int>, Serde.ImmutableArrayProxy.De<int, global::Serde.I32Proxy>>(_l_serdeInfo, _l_index_);
                         _r_assignedValid |= ((uint)1) << 19;
+                        break;
+                    case 20:
+                        _l_color = typeDeserialize.ReadBoxedValue<Serde.Test.AllInOne.ColorEnum, Serde.Test.AllInOne.ColorEnumProxy>(_l_serdeInfo, _l_index_);
+                        _r_assignedValid |= ((uint)1) << 20;
                         break;
                     case Serde.ITypeDeserializer.IndexNotFound:
                         typeDeserialize.SkipValue(_l_serdeInfo, _l_index_);
@@ -135,7 +140,7 @@ partial record AllInOne : Serde.IDeserializeProvider<Serde.Test.AllInOne>
                         throw new InvalidOperationException("Unexpected index: " + _l_index_);
                 }
             }
-            if ((_r_assignedValid & 0b11110111111111111111) != 0b11110111111111111111)
+            if ((_r_assignedValid & 0b111110111111111111111) != 0b111110111111111111111)
             {
                 throw Serde.DeserializeException.UnassignedMember();
             }
@@ -158,6 +163,7 @@ partial record AllInOne : Serde.IDeserializeProvider<Serde.Test.AllInOne>
                 NullStringField = _l_nullstringfield,
                 UIntArr = _l_uintarr,
                 NestedArr = _l_nestedarr,
+                ByteArr = _l_bytearr,
                 IntImm = _l_intimm,
                 Color = _l_color,
             };

--- a/test/Serde.Generation.Test/test_output/AllInOneTest.GeneratorTest/Serde.Test.AllInOne.ISerdeInfoProvider.verified.cs
+++ b/test/Serde.Generation.Test/test_output/AllInOneTest.GeneratorTest/Serde.Test.AllInOne.ISerdeInfoProvider.verified.cs
@@ -28,6 +28,7 @@ partial record AllInOne
         ("nullStringField", global::Serde.SerdeInfoProvider.GetSerializeInfo<string?, Serde.NullableRefProxy.Ser<string, global::Serde.StringProxy>>(), typeof(Serde.Test.AllInOne).GetField("NullStringField")),
         ("uIntArr", global::Serde.SerdeInfoProvider.GetSerializeInfo<uint[], Serde.ArrayProxy.Ser<uint, global::Serde.U32Proxy>>(), typeof(Serde.Test.AllInOne).GetField("UIntArr")),
         ("nestedArr", global::Serde.SerdeInfoProvider.GetSerializeInfo<int[][], Serde.ArrayProxy.Ser<int[], Serde.ArrayProxy.Ser<int, global::Serde.I32Proxy>>>(), typeof(Serde.Test.AllInOne).GetField("NestedArr")),
+        ("byteArr", global::Serde.SerdeInfoProvider.GetSerializeInfo<byte[], global::Serde.ByteArrayProxy>(), typeof(Serde.Test.AllInOne).GetField("ByteArr")),
         ("intImm", global::Serde.SerdeInfoProvider.GetSerializeInfo<System.Collections.Immutable.ImmutableArray<int>, Serde.ImmutableArrayProxy.Ser<int, global::Serde.I32Proxy>>(), typeof(Serde.Test.AllInOne).GetField("IntImm")),
         ("color", global::Serde.SerdeInfoProvider.GetSerializeInfo<Serde.Test.AllInOne.ColorEnum, Serde.Test.AllInOne.ColorEnumProxy>(), typeof(Serde.Test.AllInOne).GetField("Color"))
     }

--- a/test/Serde.Generation.Test/test_output/AllInOneTest.GeneratorTest/Serde.Test.AllInOne.ISerialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/AllInOneTest.GeneratorTest/Serde.Test.AllInOne.ISerialize.verified.cs
@@ -38,8 +38,9 @@ partial record AllInOne : Serde.ISerializeProvider<Serde.Test.AllInOne>
             _l_type.WriteStringIfNotNull(_l_info, 15, value.NullStringField);
             _l_type.WriteValue<uint[], Serde.ArrayProxy.Ser<uint, global::Serde.U32Proxy>>(_l_info, 16, value.UIntArr);
             _l_type.WriteValue<int[][], Serde.ArrayProxy.Ser<int[], Serde.ArrayProxy.Ser<int, global::Serde.I32Proxy>>>(_l_info, 17, value.NestedArr);
-            _l_type.WriteBoxedValue<System.Collections.Immutable.ImmutableArray<int>, Serde.ImmutableArrayProxy.Ser<int, global::Serde.I32Proxy>>(_l_info, 18, value.IntImm);
-            _l_type.WriteBoxedValue<Serde.Test.AllInOne.ColorEnum, Serde.Test.AllInOne.ColorEnumProxy>(_l_info, 19, value.Color);
+            _l_type.WriteValue<global::System.Byte[], global::Serde.ByteArrayProxy>(_l_info, 18, value.ByteArr);
+            _l_type.WriteBoxedValue<System.Collections.Immutable.ImmutableArray<int>, Serde.ImmutableArrayProxy.Ser<int, global::Serde.I32Proxy>>(_l_info, 19, value.IntImm);
+            _l_type.WriteBoxedValue<Serde.Test.AllInOne.ColorEnum, Serde.Test.AllInOne.ColorEnumProxy>(_l_info, 20, value.Color);
             _l_type.End(_l_info);
         }
         public static readonly _SerObj Instance = new();

--- a/test/Serde.Test/AllInOneSrc.cs
+++ b/test/Serde.Test/AllInOneSrc.cs
@@ -38,6 +38,7 @@ namespace Serde.Test
 
         public uint[] UIntArr = null!;
         public int[][] NestedArr = null!;
+        public byte[] ByteArr = null!;
 
         public ImmutableArray<int> IntImm;
 
@@ -74,6 +75,7 @@ namespace Serde.Test
                 UIntArr.AsSpan().SequenceEqual(other.UIntArr.AsSpan()) &&
                 NestedArr.AsSpan().SequenceEqual(other.NestedArr.AsSpan(),
                     new Comparer()) &&
+                ByteArr.AsSpan().SequenceEqual(other.ByteArr.AsSpan()) &&
                 IntImm.AsSpan().SequenceEqual(other.IntImm.AsSpan()) &&
                 Color == other.Color;
         }
@@ -122,6 +124,7 @@ namespace Serde.Test
 
             UIntArr = new uint[] { 1, 2, 3 },
             NestedArr = new[] { new[] { 1 }, new[] { 2 } },
+            ByteArr = new byte[] { 1, 2, 3 },
 
             IntImm = ImmutableArray.Create<int>(1, 2),
 
@@ -158,6 +161,7 @@ namespace Serde.Test
       2
     ]
   ],
+  "byteArr": "AQID",
   "intImm": [
     1,
     2

--- a/test/Serde.Test/JsonFsCheck.cs
+++ b/test/Serde.Test/JsonFsCheck.cs
@@ -490,6 +490,7 @@ public static class DeepEquals
         public static class TestTypeGenerators
         {
             public static Gen<TestType> GenPrimitive { get; } = Gen.OneOf(new[] {
+                    Gen.Constant<TestType>(new TestByte()),
                     Gen.Constant<TestType>(new TestChar()),
                     Gen.Constant<TestType>(new TestBool()),
                     Gen.Constant<TestType>(new TestInt()),

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.AllInOne.IDeserialize.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.AllInOne.IDeserialize.cs
@@ -35,6 +35,7 @@ partial record AllInOne : Serde.IDeserializeProvider<Serde.Test.AllInOne>
             string? _l_nullstringfield = default!;
             uint[] _l_uintarr = default!;
             int[][] _l_nestedarr = default!;
+            byte[] _l_bytearr = default!;
             System.Collections.Immutable.ImmutableArray<int> _l_intimm = default!;
             Serde.Test.AllInOne.ColorEnum _l_color = default!;
 
@@ -120,12 +121,16 @@ partial record AllInOne : Serde.IDeserializeProvider<Serde.Test.AllInOne>
                         _r_assignedValid |= ((uint)1) << 17;
                         break;
                     case 18:
-                        _l_intimm = typeDeserialize.ReadBoxedValue<System.Collections.Immutable.ImmutableArray<int>, Serde.ImmutableArrayProxy.De<int, global::Serde.I32Proxy>>(_l_serdeInfo, _l_index_);
+                        _l_bytearr = typeDeserialize.ReadValue<byte[], global::Serde.ByteArrayProxy>(_l_serdeInfo, _l_index_);
                         _r_assignedValid |= ((uint)1) << 18;
                         break;
                     case 19:
-                        _l_color = typeDeserialize.ReadBoxedValue<Serde.Test.AllInOne.ColorEnum, Serde.Test.AllInOne.ColorEnumProxy>(_l_serdeInfo, _l_index_);
+                        _l_intimm = typeDeserialize.ReadBoxedValue<System.Collections.Immutable.ImmutableArray<int>, Serde.ImmutableArrayProxy.De<int, global::Serde.I32Proxy>>(_l_serdeInfo, _l_index_);
                         _r_assignedValid |= ((uint)1) << 19;
+                        break;
+                    case 20:
+                        _l_color = typeDeserialize.ReadBoxedValue<Serde.Test.AllInOne.ColorEnum, Serde.Test.AllInOne.ColorEnumProxy>(_l_serdeInfo, _l_index_);
+                        _r_assignedValid |= ((uint)1) << 20;
                         break;
                     case Serde.ITypeDeserializer.IndexNotFound:
                         typeDeserialize.SkipValue(_l_serdeInfo, _l_index_);
@@ -134,7 +139,7 @@ partial record AllInOne : Serde.IDeserializeProvider<Serde.Test.AllInOne>
                         throw new InvalidOperationException("Unexpected index: " + _l_index_);
                 }
             }
-            if ((_r_assignedValid & 0b11110111111111111111) != 0b11110111111111111111)
+            if ((_r_assignedValid & 0b111110111111111111111) != 0b111110111111111111111)
             {
                 throw Serde.DeserializeException.UnassignedMember();
             }
@@ -157,6 +162,7 @@ partial record AllInOne : Serde.IDeserializeProvider<Serde.Test.AllInOne>
                 NullStringField = _l_nullstringfield,
                 UIntArr = _l_uintarr,
                 NestedArr = _l_nestedarr,
+                ByteArr = _l_bytearr,
                 IntImm = _l_intimm,
                 Color = _l_color,
             };

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.AllInOne.ISerdeInfoProvider.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.AllInOne.ISerdeInfoProvider.cs
@@ -27,6 +27,7 @@ partial record AllInOne
         ("nullStringField", global::Serde.SerdeInfoProvider.GetSerializeInfo<string?, Serde.NullableRefProxy.Ser<string, global::Serde.StringProxy>>(), typeof(Serde.Test.AllInOne).GetField("NullStringField")),
         ("uIntArr", global::Serde.SerdeInfoProvider.GetSerializeInfo<uint[], Serde.ArrayProxy.Ser<uint, global::Serde.U32Proxy>>(), typeof(Serde.Test.AllInOne).GetField("UIntArr")),
         ("nestedArr", global::Serde.SerdeInfoProvider.GetSerializeInfo<int[][], Serde.ArrayProxy.Ser<int[], Serde.ArrayProxy.Ser<int, global::Serde.I32Proxy>>>(), typeof(Serde.Test.AllInOne).GetField("NestedArr")),
+        ("byteArr", global::Serde.SerdeInfoProvider.GetSerializeInfo<byte[], global::Serde.ByteArrayProxy>(), typeof(Serde.Test.AllInOne).GetField("ByteArr")),
         ("intImm", global::Serde.SerdeInfoProvider.GetSerializeInfo<System.Collections.Immutable.ImmutableArray<int>, Serde.ImmutableArrayProxy.Ser<int, global::Serde.I32Proxy>>(), typeof(Serde.Test.AllInOne).GetField("IntImm")),
         ("color", global::Serde.SerdeInfoProvider.GetSerializeInfo<Serde.Test.AllInOne.ColorEnum, Serde.Test.AllInOne.ColorEnumProxy>(), typeof(Serde.Test.AllInOne).GetField("Color"))
     }

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.AllInOne.ISerialize.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.AllInOne.ISerialize.cs
@@ -37,8 +37,9 @@ partial record AllInOne : Serde.ISerializeProvider<Serde.Test.AllInOne>
             _l_type.WriteStringIfNotNull(_l_info, 15, value.NullStringField);
             _l_type.WriteValue<uint[], Serde.ArrayProxy.Ser<uint, global::Serde.U32Proxy>>(_l_info, 16, value.UIntArr);
             _l_type.WriteValue<int[][], Serde.ArrayProxy.Ser<int[], Serde.ArrayProxy.Ser<int, global::Serde.I32Proxy>>>(_l_info, 17, value.NestedArr);
-            _l_type.WriteBoxedValue<System.Collections.Immutable.ImmutableArray<int>, Serde.ImmutableArrayProxy.Ser<int, global::Serde.I32Proxy>>(_l_info, 18, value.IntImm);
-            _l_type.WriteBoxedValue<Serde.Test.AllInOne.ColorEnum, Serde.Test.AllInOne.ColorEnumProxy>(_l_info, 19, value.Color);
+            _l_type.WriteValue<global::System.Byte[], global::Serde.ByteArrayProxy>(_l_info, 18, value.ByteArr);
+            _l_type.WriteBoxedValue<System.Collections.Immutable.ImmutableArray<int>, Serde.ImmutableArrayProxy.Ser<int, global::Serde.I32Proxy>>(_l_info, 19, value.IntImm);
+            _l_type.WriteBoxedValue<Serde.Test.AllInOne.ColorEnum, Serde.Test.AllInOne.ColorEnumProxy>(_l_info, 20, value.Color);
             _l_type.End(_l_info);
         }
         public static readonly _SerObj Instance = new();


### PR DESCRIPTION
Bytes corresponds to any contiguous array of bytes that can be represented with `ReadOnlyMemory<byte>`.

Fixes #81 