### PR TITLE
Update DateTime/DateTimeOffset primitives

### DIFF
--- a/src/generator/Proxies.cs
+++ b/src/generator/Proxies.cs
@@ -90,12 +90,12 @@ sealed partial class {{proxyName}}
         {
             return spTypeMatch;
         }
-        if (type is { Name: "DateTimeOffset",
+        if (type is { Name: "DateTime",
                       ContainingNamespace: {
                         Name: "System",
                         ContainingNamespace: { IsGlobalNamespace: true } } })
         {
-            return "DateTimeOffset";
+            return "DateTime";
         }
         return null;
     }
@@ -120,11 +120,11 @@ sealed partial class {{proxyName}}
                 Name: "System",
                 ContainingNamespace: { IsGlobalNamespace: true } } }
             => new("global::System.Guid", "global::Serde.GuidProxy"),
-            { Name: "DateTime",
+            { Name: "DateTimeOffset",
               ContainingNamespace: {
                 Name: "System",
                 ContainingNamespace: { IsGlobalNamespace: true } } }
-            => new("global::System.DateTime", "global::Serde.DateTimeProxy"),
+            => new("global::System.DateTimeOffset", "global::Serde.DateTimeOffsetProxy"),
             IArrayTypeSymbol { ElementType: { SpecialType: SpecialType.System_Byte } }
             => new("global::System.Byte[]", "global::Serde.ByteArrayProxy"),
             _ => null

--- a/src/serde/IDeserialize.cs
+++ b/src/serde/IDeserialize.cs
@@ -47,7 +47,7 @@ public interface IDeserializer : IDisposable
     double ReadF64();
     decimal ReadDecimal();
     string ReadString();
-    DateTimeOffset ReadDateTimeOffset();
+    DateTime ReadDateTime();
     void ReadBytes(IBufferWriter<byte> writer);
     ITypeDeserializer ReadType(ISerdeInfo typeInfo);
 }
@@ -103,7 +103,7 @@ public interface ITypeDeserializer
     double ReadF64(ISerdeInfo info, int index);
     decimal ReadDecimal(ISerdeInfo info, int index);
     string ReadString(ISerdeInfo info, int index);
-    DateTimeOffset ReadDateTimeOffset(ISerdeInfo info, int index);
+    DateTime ReadDateTime(ISerdeInfo info, int index);
     void ReadBytes(ISerdeInfo info, int index, IBufferWriter<byte> writer);
 }
 

--- a/src/serde/ISerdeInfo.cs
+++ b/src/serde/ISerdeInfo.cs
@@ -92,7 +92,7 @@ public enum PrimitiveKind
     F64,
     Decimal,
     String,
-    DateTimeOffset,
+    DateTime,
     Bytes,
 }
 

--- a/src/serde/ISerialize.cs
+++ b/src/serde/ISerialize.cs
@@ -89,6 +89,7 @@ public interface ISerializer
     void WriteDecimal(decimal d);
     void WriteString(string s);
     void WriteNull();
+    void WriteDateTime(DateTime dt);
     void WriteDateTimeOffset(DateTimeOffset dt);
     void WriteBytes(ReadOnlyMemory<byte> bytes);
 
@@ -173,6 +174,7 @@ public interface ITypeSerializer
     void WriteDecimal(ISerdeInfo typeInfo, int index, decimal d);
     void WriteString(ISerdeInfo typeInfo, int index, string s);
     void WriteNull(ISerdeInfo typeInfo, int index);
+    void WriteDateTime(ISerdeInfo typeInfo, int index, DateTime dt);
     void WriteDateTimeOffset(ISerdeInfo typeInfo, int index, DateTimeOffset dt);
     void WriteBytes(ISerdeInfo typeInfo, int index, ReadOnlyMemory<byte> bytes);
 

--- a/src/serde/Proxies.cs
+++ b/src/serde/Proxies.cs
@@ -431,27 +431,6 @@ public static class NullableRefProxy
     }
 }
 
-public sealed class DateTimeOffsetProxy : ISerdePrimitive<DateTimeOffsetProxy, DateTimeOffset>
-{
-    public static DateTimeOffsetProxy Instance { get; } = new();
-    private DateTimeOffsetProxy() { }
-
-    public static ISerdeInfo SerdeInfo { get; }
-        = Serde.SerdeInfo.MakePrimitive("System.DateTimeOffset", PrimitiveKind.DateTimeOffset);
-    ISerdeInfo ISerdeInfoProvider.SerdeInfo => SerdeInfo;
-
-    void ISerialize<DateTimeOffset>.Serialize(DateTimeOffset value, ISerializer serializer)
-        => serializer.WriteDateTimeOffset(value);
-    DateTimeOffset IDeserialize<DateTimeOffset>.Deserialize(IDeserializer deserializer)
-        => deserializer.ReadDateTimeOffset();
-
-    void ITypeSerialize<DateTimeOffset>.Serialize(DateTimeOffset value, ITypeSerializer serializer, ISerdeInfo info, int index)
-        => serializer.WriteDateTimeOffset(info, index, value);
-
-    DateTimeOffset ITypeDeserialize<DateTimeOffset>.Deserialize(ITypeDeserializer deserializer, ISerdeInfo info, int index)
-        => deserializer.ReadDateTimeOffset(info, index);
-}
-
 public sealed class GuidProxy : ISerdePrimitive<GuidProxy, Guid>
 {
     public static GuidProxy Instance { get; } = new();
@@ -492,18 +471,40 @@ public sealed class DateTimeProxy : ISerdePrimitive<DateTimeProxy, DateTime>
     private DateTimeProxy() { }
 
     public static ISerdeInfo SerdeInfo { get; }
-        = Serde.SerdeInfo.MakePrimitive("System.DateTime", PrimitiveKind.DateTimeOffset);
+        = Serde.SerdeInfo.MakePrimitive("System.DateTime", PrimitiveKind.DateTime);
     ISerdeInfo ISerdeInfoProvider.SerdeInfo => SerdeInfo;
 
     void ISerialize<DateTime>.Serialize(DateTime value, ISerializer serializer)
-        => serializer.WriteDateTimeOffset(value);
+        => serializer.WriteDateTime(value);
     void ITypeSerialize<DateTime>.Serialize(DateTime value, ITypeSerializer serializer, ISerdeInfo info, int index)
-        => serializer.WriteDateTimeOffset(info, index, value);
+        => serializer.WriteDateTime(info, index, value);
     DateTime IDeserialize<DateTime>.Deserialize(IDeserializer deserializer)
-        => deserializer.ReadDateTimeOffset().DateTime;
+        => deserializer.ReadDateTime();
     DateTime ITypeDeserialize<DateTime>.Deserialize(ITypeDeserializer deserializer, ISerdeInfo info, int index)
-        => deserializer.ReadDateTimeOffset(info, index).DateTime;
+        => deserializer.ReadDateTime(info, index);
 }
+
+public sealed class DateTimeOffsetProxy : ISerdePrimitive<DateTimeOffsetProxy, DateTimeOffset>
+{
+    public static DateTimeOffsetProxy Instance { get; } = new();
+    private DateTimeOffsetProxy() { }
+
+    public static ISerdeInfo SerdeInfo { get; }
+        = Serde.SerdeInfo.MakePrimitive("System.DateTimeOffset", PrimitiveKind.String);
+    ISerdeInfo ISerdeInfoProvider.SerdeInfo => SerdeInfo;
+
+    void ISerialize<DateTimeOffset>.Serialize(DateTimeOffset value, ISerializer serializer)
+        => serializer.WriteDateTimeOffset(value);
+    DateTimeOffset IDeserialize<DateTimeOffset>.Deserialize(IDeserializer deserializer)
+        => deserializer.ReadDateTime();
+
+    void ITypeSerialize<DateTimeOffset>.Serialize(DateTimeOffset value, ITypeSerializer serializer, ISerdeInfo info, int index)
+        => serializer.WriteDateTimeOffset(info, index, value);
+
+    DateTimeOffset ITypeDeserialize<DateTimeOffset>.Deserialize(ITypeDeserializer deserializer, ISerdeInfo info, int index)
+        => deserializer.ReadDateTime(info, index);
+}
+
 
 public sealed class ByteArrayProxy : ISerdePrimitive<ByteArrayProxy, byte[]>
 {

--- a/src/serde/json/JsonDeserializer.Collection.cs
+++ b/src/serde/json/JsonDeserializer.Collection.cs
@@ -201,9 +201,9 @@ partial class JsonDeserializer<TReader>
             return v;
         }
 
-        public DateTimeOffset ReadDateTimeOffset(ISerdeInfo info, int index)
+        public DateTime ReadDateTime(ISerdeInfo info, int index)
         {
-            var v = _deserializer.ReadDateTimeOffset();
+            var v = _deserializer.ReadDateTime();
             _index++;
             return v;
         }

--- a/src/serde/json/JsonDeserializer.Type.cs
+++ b/src/serde/json/JsonDeserializer.Type.cs
@@ -141,10 +141,10 @@ partial class JsonDeserializer<TReader> : ITypeDeserializer
         ReadColon();
         return this.ReadString();
     }
-    DateTimeOffset ITypeDeserializer.ReadDateTimeOffset(ISerdeInfo info, int index)
+    DateTime ITypeDeserializer.ReadDateTime(ISerdeInfo info, int index)
     {
         ReadColon();
-        return ReadDateTimeOffset();
+        return ReadDateTime();
     }
     void ITypeDeserializer.ReadBytes(ISerdeInfo info, int index, IBufferWriter<byte> writer)
     {

--- a/src/serde/json/JsonDeserializer.cs
+++ b/src/serde/json/JsonDeserializer.cs
@@ -186,10 +186,10 @@ internal sealed partial class JsonDeserializer<TReader> : IDeserializer
 
     public char ReadChar() => ReadString().Single();
 
-    public DateTimeOffset ReadDateTimeOffset()
+    public DateTime ReadDateTime()
     {
         var s = ReadString();
-        return DateTimeOffset.Parse(s, formatProvider: null, styles: DateTimeStyles.RoundtripKind);
+        return DateTime.Parse(s, styles: DateTimeStyles.RoundtripKind);
     }
 
     public void Eof()

--- a/src/serde/json/JsonSerializer.Collection.cs
+++ b/src/serde/json/JsonSerializer.Collection.cs
@@ -84,6 +84,10 @@ partial class JsonSerializer
             serializer.WriteNull();
         }
 
+        public void WriteDateTime(ISerdeInfo typeInfo, int index, DateTime dt)
+        {
+            serializer.WriteDateTime(dt);
+        }
         public void WriteDateTimeOffset(ISerdeInfo typeInfo, int index, DateTimeOffset dt)
         {
             serializer.WriteDateTimeOffset(dt);
@@ -116,6 +120,7 @@ partial class JsonSerializer
         public void WriteF32(float f) => throw new KeyNotStringException();
         public void WriteF64(double d) => throw new KeyNotStringException();
         public void WriteDecimal(decimal d) => throw new KeyNotStringException();
+        public void WriteDateTime(DateTime dt) => throw new KeyNotStringException();
         public void WriteDateTimeOffset(DateTimeOffset dt) => throw new KeyNotStringException();
         public void WriteBytes(ReadOnlyMemory<byte> bytes) => throw new KeyNotStringException();
 
@@ -154,6 +159,7 @@ partial class JsonSerializer
         public void WriteU32(ISerdeInfo typeInfo, int index, uint u32) => GetSerializer(index).WriteU32(u32);
         public void WriteU64(ISerdeInfo typeInfo, int index, ulong u64) => GetSerializer(index).WriteU64(u64);
         public void WriteU8(ISerdeInfo typeInfo, int index, byte b) => GetSerializer(index).WriteU8(b);
+        public void WriteDateTime(ISerdeInfo typeInfo, int index, DateTime dt) => GetSerializer(index).WriteDateTime(dt);
         public void WriteDateTimeOffset(ISerdeInfo typeInfo, int index, DateTimeOffset dt) => GetSerializer(index).WriteDateTimeOffset(dt);
         public void WriteBytes(ISerdeInfo typeInfo, int index, ReadOnlyMemory<byte> bytes) => GetSerializer(index).WriteBytes(bytes);
         public void WriteValue<T>(ISerdeInfo typeInfo, int index, T value, ISerialize<T> serialize)

--- a/test/Serde.Generation.Test/test_output/AllInOneTest.GeneratorTest/Serde.Test.AllInOne.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/AllInOneTest.GeneratorTest/Serde.Test.AllInOne.IDeserialize.verified.cs
@@ -94,11 +94,11 @@ partial record AllInOne : Serde.IDeserializeProvider<Serde.Test.AllInOne>
                         _r_assignedValid |= ((uint)1) << 10;
                         break;
                     case 11:
-                        _l_datetimeoffsetfield = typeDeserialize.ReadDateTimeOffset(_l_serdeInfo, _l_index_);
+                        _l_datetimeoffsetfield = typeDeserialize.ReadBoxedValue<System.DateTimeOffset, global::Serde.DateTimeOffsetProxy>(_l_serdeInfo, _l_index_);
                         _r_assignedValid |= ((uint)1) << 11;
                         break;
                     case 12:
-                        _l_datetimefield = typeDeserialize.ReadBoxedValue<System.DateTime, global::Serde.DateTimeProxy>(_l_serdeInfo, _l_index_);
+                        _l_datetimefield = typeDeserialize.ReadDateTime(_l_serdeInfo, _l_index_);
                         _r_assignedValid |= ((uint)1) << 12;
                         break;
                     case 13:

--- a/test/Serde.Generation.Test/test_output/AllInOneTest.GeneratorTest/Serde.Test.AllInOne.ISerialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/AllInOneTest.GeneratorTest/Serde.Test.AllInOne.ISerialize.verified.cs
@@ -31,8 +31,8 @@ partial record AllInOne : Serde.ISerializeProvider<Serde.Test.AllInOne>
             _l_type.WriteI32(_l_info, 8, value.IntField);
             _l_type.WriteI64(_l_info, 9, value.LongField);
             _l_type.WriteString(_l_info, 10, value.StringField);
-            _l_type.WriteDateTimeOffset(_l_info, 11, value.DateTimeOffsetField);
-            _l_type.WriteBoxedValue<global::System.DateTime, global::Serde.DateTimeProxy>(_l_info, 12, value.DateTimeField);
+            _l_type.WriteBoxedValue<global::System.DateTimeOffset, global::Serde.DateTimeOffsetProxy>(_l_info, 11, value.DateTimeOffsetField);
+            _l_type.WriteDateTime(_l_info, 12, value.DateTimeField);
             _l_type.WriteBoxedValue<global::System.Guid, global::Serde.GuidProxy>(_l_info, 13, value.GuidField);
             _l_type.WriteString(_l_info, 14, value.EscapedStringField);
             _l_type.WriteStringIfNotNull(_l_info, 15, value.NullStringField);

--- a/test/Serde.Test/AllInOneSrc.cs
+++ b/test/Serde.Test/AllInOneSrc.cs
@@ -111,7 +111,7 @@ namespace Serde.Test
             IntField = int.MaxValue,
             LongField = long.MaxValue,
             StringField = "StringValue",
-            DateTimeOffsetField = new DateTimeOffset(2040, 1, 1, 1, 1, 1, TimeSpan.Zero),
+            DateTimeOffsetField = new DateTimeOffset(2040, 1, 1, 1, 1, 1, TimeSpan.FromHours(-7)),
             DateTimeField = new DateTime(2040, 1, 1, 1, 1, 1, DateTimeKind.Utc),
             GuidField = new Guid(new byte[] {
                 0x01, 0x02, 0x03, 0x04,
@@ -144,8 +144,8 @@ namespace Serde.Test
   "intField": 2147483647,
   "longField": 9223372036854775807,
   "stringField": "StringValue",
-  "dateTimeOffsetField": "2040-01-01T01:01:01\u002B00:00",
-  "dateTimeField": "2040-01-01T01:01:01\u002B00:00",
+  "dateTimeOffsetField": "2040-01-01T01:01:01-07:00",
+  "dateTimeField": "2040-01-01T01:01:01Z",
   "guidField": "04030201-0605-0807-090a-0b0c0d0e0f10",
   "escapedStringField": "\u002B0 11 222 333 44",
   "uIntArr": [

--- a/test/Serde.Test/JsonFsCheck.cs
+++ b/test/Serde.Test/JsonFsCheck.cs
@@ -80,12 +80,12 @@ Serde.Json.JsonSerializer.Serialize({localName});");
 Serde.Json.JsonSerializer.Deserialize<{typeName}>({serName});");
                 serializeStatements.Add($@"if ({localName} != {deName})
 {{
-    throw new Exception(""Expected: "" + {localName} + Environment.NewLine + ""Actual: "" + {deName});
+    throw new Exception(""De Expected: "" + {localName} + Environment.NewLine + ""Actual: "" + {deName});
 }}");
                 serializeStatements.Add($"var stj{i} = System.Text.Json.JsonSerializer.Serialize({localName}, options);");
                 serializeStatements.Add($@"if ({serName} != stj{i})
 {{
-    throw new Exception(""Expected: "" + {serName} + Environment.NewLine + ""Actual: "" + stj{i});
+    throw new Exception(""Ser Expected: "" + stj{i} + Environment.NewLine + ""Actual: "" + {serName});
 }}");
             }
 
@@ -388,11 +388,18 @@ public static class DeepEquals
         {
             public sealed override SyntaxKind SyntaxKind => SyntaxKind.DecimalKeyword;
         }
+        public sealed record TestDateTime : TestType
+        {
+            public override TypeSyntax TypeSyntax(int typeIndex) => IdentifierName("DateTime");
+            public override ExpressionSyntax Value(int typeIndex) => ParseExpression(
+                "new DateTime(2023, 1, 1, 1, 1, 1, DateTimeKind.Utc)"
+            );
+        }
         public sealed record TestDateTimeOffset : TestType
         {
             public override TypeSyntax TypeSyntax(int typeIndex) => IdentifierName("DateTimeOffset");
             public override ExpressionSyntax Value(int typeIndex) => ParseExpression(
-                "new DateTimeOffset(2023, 1, 1, 1, 1, 1, TimeSpan.Zero)"
+                "new DateTimeOffset(2024, 1, 1, 1, 1, 1, TimeSpan.Zero)"
             );
         }
         public record TestTypeDef(ImmutableArray<TestType> FieldTypes) : TestType

--- a/test/Serde.Test/JsonSerializerTests.cs
+++ b/test/Serde.Test/JsonSerializerTests.cs
@@ -36,6 +36,37 @@ namespace Serde.Test
         }
 
         [Fact]
+        public void DateTime()
+        {
+            var date = new DtWrap(new(2023, 10, 1, 12, 0, 0, System.DateTimeKind.Utc));
+            var js = Serde.Json.JsonSerializer.Serialize(date);
+            Assert.Equal("""
+            {"value":"2023-10-01T12:00:00Z"}
+            """, js);
+        }
+
+        [GenerateSerialize]
+        private partial record DtWrap(System.DateTime Value);
+
+
+        [Fact]
+        public void DateTimeOffset()
+        {
+            var date = new DtoWrap(new(2023, 10, 1, 12, 0, 0, System.TimeSpan.FromHours(7)));
+            var js = Serde.Json.JsonSerializer.Serialize(date);
+            Assert.Equal("""
+            {"value":"2023-10-01T12:00:00+07:00"}
+            """, js);
+            Assert.Equal("""
+            {"value":"2023-10-01T12:00:00+07:00"}
+            """, System.Text.Json.JsonSerializer.Serialize(date, new JsonSerializerOptions()
+                { PropertyNamingPolicy = JsonNamingPolicy.CamelCase }));
+        }
+
+        [GenerateSerialize]
+        private partial record DtoWrap(System.DateTimeOffset Value);
+
+        [Fact]
         public void SerializeRgb()
         {
             var color = new Color { Red = 3, Green = 5, Blue = 7 };

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.AllInOne.IDeserialize.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.AllInOne.IDeserialize.cs
@@ -93,11 +93,11 @@ partial record AllInOne : Serde.IDeserializeProvider<Serde.Test.AllInOne>
                         _r_assignedValid |= ((uint)1) << 10;
                         break;
                     case 11:
-                        _l_datetimeoffsetfield = typeDeserialize.ReadDateTimeOffset(_l_serdeInfo, _l_index_);
+                        _l_datetimeoffsetfield = typeDeserialize.ReadBoxedValue<System.DateTimeOffset, global::Serde.DateTimeOffsetProxy>(_l_serdeInfo, _l_index_);
                         _r_assignedValid |= ((uint)1) << 11;
                         break;
                     case 12:
-                        _l_datetimefield = typeDeserialize.ReadBoxedValue<System.DateTime, global::Serde.DateTimeProxy>(_l_serdeInfo, _l_index_);
+                        _l_datetimefield = typeDeserialize.ReadDateTime(_l_serdeInfo, _l_index_);
                         _r_assignedValid |= ((uint)1) << 12;
                         break;
                     case 13:

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.AllInOne.ISerialize.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.AllInOne.ISerialize.cs
@@ -30,8 +30,8 @@ partial record AllInOne : Serde.ISerializeProvider<Serde.Test.AllInOne>
             _l_type.WriteI32(_l_info, 8, value.IntField);
             _l_type.WriteI64(_l_info, 9, value.LongField);
             _l_type.WriteString(_l_info, 10, value.StringField);
-            _l_type.WriteDateTimeOffset(_l_info, 11, value.DateTimeOffsetField);
-            _l_type.WriteBoxedValue<global::System.DateTime, global::Serde.DateTimeProxy>(_l_info, 12, value.DateTimeField);
+            _l_type.WriteBoxedValue<global::System.DateTimeOffset, global::Serde.DateTimeOffsetProxy>(_l_info, 11, value.DateTimeOffsetField);
+            _l_type.WriteDateTime(_l_info, 12, value.DateTimeField);
             _l_type.WriteBoxedValue<global::System.Guid, global::Serde.GuidProxy>(_l_info, 13, value.GuidField);
             _l_type.WriteString(_l_info, 14, value.EscapedStringField);
             _l_type.WriteStringIfNotNull(_l_info, 15, value.NullStringField);

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonSerializerTests.DtWrap.ISerdeInfoProvider.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonSerializerTests.DtWrap.ISerdeInfoProvider.cs
@@ -1,0 +1,18 @@
+
+#nullable enable
+
+namespace Serde.Test;
+
+partial class JsonSerializerTests
+{
+    partial record DtWrap
+    {
+        private static global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
+            "DtWrap",
+        typeof(Serde.Test.JsonSerializerTests.DtWrap).GetCustomAttributesData(),
+        new (string, global::Serde.ISerdeInfo, System.Reflection.MemberInfo?)[] {
+            ("value", global::Serde.SerdeInfoProvider.GetSerializeInfo<System.DateTime, global::Serde.DateTimeProxy>(), typeof(Serde.Test.JsonSerializerTests.DtWrap).GetProperty("Value"))
+        }
+        );
+    }
+}

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonSerializerTests.DtWrap.ISerialize.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonSerializerTests.DtWrap.ISerialize.cs
@@ -1,0 +1,32 @@
+
+#nullable enable
+
+using System;
+using Serde;
+
+namespace Serde.Test;
+
+partial class JsonSerializerTests
+{
+    partial record DtWrap : Serde.ISerializeProvider<Serde.Test.JsonSerializerTests.DtWrap>
+    {
+        static ISerialize<Serde.Test.JsonSerializerTests.DtWrap> ISerializeProvider<Serde.Test.JsonSerializerTests.DtWrap>.Instance
+            => _SerObj.Instance;
+
+        sealed partial class _SerObj :Serde.ISerialize<Serde.Test.JsonSerializerTests.DtWrap>
+        {
+            global::Serde.ISerdeInfo global::Serde.ISerdeInfoProvider.SerdeInfo => Serde.Test.JsonSerializerTests.DtWrap.s_serdeInfo;
+
+            void global::Serde.ISerialize<Serde.Test.JsonSerializerTests.DtWrap>.Serialize(Serde.Test.JsonSerializerTests.DtWrap value, global::Serde.ISerializer serializer)
+            {
+                var _l_info = global::Serde.SerdeInfoProvider.GetInfo(this);
+                var _l_type = serializer.WriteType(_l_info);
+                _l_type.WriteDateTime(_l_info, 0, value.Value);
+                _l_type.End(_l_info);
+            }
+            public static readonly _SerObj Instance = new();
+            private _SerObj() { }
+
+        }
+    }
+}

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonSerializerTests.DtoWrap.ISerdeInfoProvider.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonSerializerTests.DtoWrap.ISerdeInfoProvider.cs
@@ -1,0 +1,18 @@
+
+#nullable enable
+
+namespace Serde.Test;
+
+partial class JsonSerializerTests
+{
+    partial record DtoWrap
+    {
+        private static global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
+            "DtoWrap",
+        typeof(Serde.Test.JsonSerializerTests.DtoWrap).GetCustomAttributesData(),
+        new (string, global::Serde.ISerdeInfo, System.Reflection.MemberInfo?)[] {
+            ("value", global::Serde.SerdeInfoProvider.GetSerializeInfo<System.DateTimeOffset, global::Serde.DateTimeOffsetProxy>(), typeof(Serde.Test.JsonSerializerTests.DtoWrap).GetProperty("Value"))
+        }
+        );
+    }
+}

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonSerializerTests.DtoWrap.ISerialize.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonSerializerTests.DtoWrap.ISerialize.cs
@@ -1,0 +1,32 @@
+
+#nullable enable
+
+using System;
+using Serde;
+
+namespace Serde.Test;
+
+partial class JsonSerializerTests
+{
+    partial record DtoWrap : Serde.ISerializeProvider<Serde.Test.JsonSerializerTests.DtoWrap>
+    {
+        static ISerialize<Serde.Test.JsonSerializerTests.DtoWrap> ISerializeProvider<Serde.Test.JsonSerializerTests.DtoWrap>.Instance
+            => _SerObj.Instance;
+
+        sealed partial class _SerObj :Serde.ISerialize<Serde.Test.JsonSerializerTests.DtoWrap>
+        {
+            global::Serde.ISerdeInfo global::Serde.ISerdeInfoProvider.SerdeInfo => Serde.Test.JsonSerializerTests.DtoWrap.s_serdeInfo;
+
+            void global::Serde.ISerialize<Serde.Test.JsonSerializerTests.DtoWrap>.Serialize(Serde.Test.JsonSerializerTests.DtoWrap value, global::Serde.ISerializer serializer)
+            {
+                var _l_info = global::Serde.SerdeInfoProvider.GetInfo(this);
+                var _l_type = serializer.WriteType(_l_info);
+                _l_type.WriteBoxedValue<global::System.DateTimeOffset, global::Serde.DateTimeOffsetProxy>(_l_info, 0, value.Value);
+                _l_type.End(_l_info);
+            }
+            public static readonly _SerObj Instance = new();
+            private _SerObj() { }
+
+        }
+    }
+}


### PR DESCRIPTION
It turns out the S.T.J serializer has special behavior for DateTimeOffset(the '+' is not escaped). The result is adding both DateTime and DateTimeOffset as primitives for serialization, but moving to just DateTime for deserialization.