### PR TITLE
Fix size of preallocated list so that we can use direct indexed assignment to liat

### DIFF
--- a/src/serde/Proxies.List.cs
+++ b/src/serde/Proxies.List.cs
@@ -181,7 +181,9 @@ public static class ListProxy
         {
             if (sizeOpt is int size)
             {
-                return new List<T>(size);
+                var list = new List<T>(size);
+                CollectionsMarshal.SetCount(list, size);
+                return list;
             }
             return new List<T>();
         }

--- a/src/serde/Proxies.List.cs
+++ b/src/serde/Proxies.List.cs
@@ -76,7 +76,7 @@ public abstract class DeListBase<
             var builder = GetFixBuilder(size);
             for (int i = 0; i < size; i++)
             {
-                builder[i] = _de.Deserialize(deCollection, info, i);
+                builder.Add(_de.Deserialize(deCollection, info, i));
             }
             return FromFix(builder);
         }
@@ -181,9 +181,7 @@ public static class ListProxy
         {
             if (sizeOpt is int size)
             {
-                var list = new List<T>(size);
-                CollectionsMarshal.SetCount(list, size);
-                return list;
+                return new List<T>(size);
             }
             return new List<T>();
         }


### PR DESCRIPTION
[In this code](https://github.com/serdedotnet/serde/blob/771fb8b588c9ae237ffb77f1cc167ce32a77baa7/src/serde/Proxies.List.cs#L181) we are using SizeOpt from the collection deserializer to set the capacity of the list. And then there is an attempt to exploit it [here](https://github.com/serdedotnet/serde/blob/771fb8b588c9ae237ffb77f1cc167ce32a77baa7/src/serde/Proxies.List.cs#L79) by setting via the indexer. But apparently you can't do that (i though you could 🤷‍♀️)

[See this sharplab example](https://sharplab.io/#v2:C4LgTgrgdgPgAgJgAwFgBQiCM65IARyYAsA3OjpgJwAUARIDwbgIPu0CUZa6AbgIZh4A2ASwDOwPAF48UAKYB3PABkRwADyCowAHzUArG3RDRAbUwBdCXjxISQA=)

There are two approaches to fix this.
1. Change the indexer set operation to `Add`
2. Use `CollectionsMarshall.SetCount(int)` so that the indexer can work

I think the latter is better, but it would be optimal if combined with `CollectionsMarshal.GetSpan()` so that we could write directly into the span without the List machinery overhead. But the abstractions mean that we have to go through the IList abstraction (although specialized). But we'd need to know that we had a List<T> so that we could rely on that optimization