### PR TITLE
Change enum proxy deserialize

### DIFF
--- a/test/Serde.Generation.Test/test_output/AllInOneTest.GeneratorTest/Serde.Test.AllInOne.ColorEnumProxy.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/AllInOneTest.GeneratorTest/Serde.Test.AllInOne.ColorEnumProxy.IDeserialize.verified.cs
@@ -15,10 +15,15 @@ partial record AllInOne
         {
             var serdeInfo = global::Serde.SerdeInfoProvider.GetInfo(this);
             var de = deserializer.ReadType(serdeInfo);
-            int index;
-            if ((index = de.TryReadIndex(serdeInfo, out var errorName)) == ITypeDeserializer.IndexNotFound)
+            int index = de.TryReadIndex(serdeInfo, out var errorName);
+            if (index == ITypeDeserializer.IndexNotFound)
             {
                 throw Serde.DeserializeException.UnknownMember(errorName!, serdeInfo);
+            }
+            if (index == ITypeDeserializer.EndOfType)
+            {
+                // Assume we want to read the underlying value
+                return (Serde.Test.AllInOne.ColorEnum)de.ReadI32(serdeInfo, index);
             }
             return index switch {
                 0 => Serde.Test.AllInOne.ColorEnum.Red,

--- a/test/Serde.Generation.Test/test_output/DeserializeTests.EnumMember/ColorByteProxy.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/DeserializeTests.EnumMember/ColorByteProxy.IDeserialize.verified.cs
@@ -10,10 +10,15 @@ sealed partial class ColorByteProxy :Serde.IDeserialize<ColorByte>,Serde.IDeseri
     {
         var serdeInfo = global::Serde.SerdeInfoProvider.GetInfo(this);
         var de = deserializer.ReadType(serdeInfo);
-        int index;
-        if ((index = de.TryReadIndex(serdeInfo, out var errorName)) == ITypeDeserializer.IndexNotFound)
+        int index = de.TryReadIndex(serdeInfo, out var errorName);
+        if (index == ITypeDeserializer.IndexNotFound)
         {
             throw Serde.DeserializeException.UnknownMember(errorName!, serdeInfo);
+        }
+        if (index == ITypeDeserializer.EndOfType)
+        {
+            // Assume we want to read the underlying value
+            return (ColorByte)de.ReadU8(serdeInfo, index);
         }
         return index switch {
             0 => ColorByte.Red,

--- a/test/Serde.Generation.Test/test_output/DeserializeTests.EnumMember/ColorIntProxy.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/DeserializeTests.EnumMember/ColorIntProxy.IDeserialize.verified.cs
@@ -10,10 +10,15 @@ sealed partial class ColorIntProxy :Serde.IDeserialize<ColorInt>,Serde.IDeserial
     {
         var serdeInfo = global::Serde.SerdeInfoProvider.GetInfo(this);
         var de = deserializer.ReadType(serdeInfo);
-        int index;
-        if ((index = de.TryReadIndex(serdeInfo, out var errorName)) == ITypeDeserializer.IndexNotFound)
+        int index = de.TryReadIndex(serdeInfo, out var errorName);
+        if (index == ITypeDeserializer.IndexNotFound)
         {
             throw Serde.DeserializeException.UnknownMember(errorName!, serdeInfo);
+        }
+        if (index == ITypeDeserializer.EndOfType)
+        {
+            // Assume we want to read the underlying value
+            return (ColorInt)de.ReadI32(serdeInfo, index);
         }
         return index switch {
             0 => ColorInt.Red,

--- a/test/Serde.Generation.Test/test_output/DeserializeTests.EnumMember/ColorLongProxy.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/DeserializeTests.EnumMember/ColorLongProxy.IDeserialize.verified.cs
@@ -10,10 +10,15 @@ sealed partial class ColorLongProxy :Serde.IDeserialize<ColorLong>,Serde.IDeseri
     {
         var serdeInfo = global::Serde.SerdeInfoProvider.GetInfo(this);
         var de = deserializer.ReadType(serdeInfo);
-        int index;
-        if ((index = de.TryReadIndex(serdeInfo, out var errorName)) == ITypeDeserializer.IndexNotFound)
+        int index = de.TryReadIndex(serdeInfo, out var errorName);
+        if (index == ITypeDeserializer.IndexNotFound)
         {
             throw Serde.DeserializeException.UnknownMember(errorName!, serdeInfo);
+        }
+        if (index == ITypeDeserializer.EndOfType)
+        {
+            // Assume we want to read the underlying value
+            return (ColorLong)de.ReadI64(serdeInfo, index);
         }
         return index switch {
             0 => ColorLong.Red,

--- a/test/Serde.Generation.Test/test_output/DeserializeTests.EnumMember/ColorULongProxy.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/DeserializeTests.EnumMember/ColorULongProxy.IDeserialize.verified.cs
@@ -10,10 +10,15 @@ sealed partial class ColorULongProxy :Serde.IDeserialize<ColorULong>,Serde.IDese
     {
         var serdeInfo = global::Serde.SerdeInfoProvider.GetInfo(this);
         var de = deserializer.ReadType(serdeInfo);
-        int index;
-        if ((index = de.TryReadIndex(serdeInfo, out var errorName)) == ITypeDeserializer.IndexNotFound)
+        int index = de.TryReadIndex(serdeInfo, out var errorName);
+        if (index == ITypeDeserializer.IndexNotFound)
         {
             throw Serde.DeserializeException.UnknownMember(errorName!, serdeInfo);
+        }
+        if (index == ITypeDeserializer.EndOfType)
+        {
+            // Assume we want to read the underlying value
+            return (ColorULong)de.ReadU64(serdeInfo, index);
         }
         return index switch {
             0 => ColorULong.Red,

--- a/test/Serde.Generation.Test/test_output/MemberFormatTests.EnumFormat/ColorEnumProxy.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/MemberFormatTests.EnumFormat/ColorEnumProxy.IDeserialize.verified.cs
@@ -10,10 +10,15 @@ sealed partial class ColorEnumProxy :Serde.IDeserialize<ColorEnum>,Serde.IDeseri
     {
         var serdeInfo = global::Serde.SerdeInfoProvider.GetInfo(this);
         var de = deserializer.ReadType(serdeInfo);
-        int index;
-        if ((index = de.TryReadIndex(serdeInfo, out var errorName)) == ITypeDeserializer.IndexNotFound)
+        int index = de.TryReadIndex(serdeInfo, out var errorName);
+        if (index == ITypeDeserializer.IndexNotFound)
         {
             throw Serde.DeserializeException.UnknownMember(errorName!, serdeInfo);
+        }
+        if (index == ITypeDeserializer.EndOfType)
+        {
+            // Assume we want to read the underlying value
+            return (ColorEnum)de.ReadI32(serdeInfo, index);
         }
         return index switch {
             0 => ColorEnum.Red,

--- a/test/Serde.Generation.Test/test_output/MemberFormatTests.EnumValues/ColorEnumProxy.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/MemberFormatTests.EnumValues/ColorEnumProxy.IDeserialize.verified.cs
@@ -10,10 +10,15 @@ sealed partial class ColorEnumProxy :Serde.IDeserialize<ColorEnum>,Serde.IDeseri
     {
         var serdeInfo = global::Serde.SerdeInfoProvider.GetInfo(this);
         var de = deserializer.ReadType(serdeInfo);
-        int index;
-        if ((index = de.TryReadIndex(serdeInfo, out var errorName)) == ITypeDeserializer.IndexNotFound)
+        int index = de.TryReadIndex(serdeInfo, out var errorName);
+        if (index == ITypeDeserializer.IndexNotFound)
         {
             throw Serde.DeserializeException.UnknownMember(errorName!, serdeInfo);
+        }
+        if (index == ITypeDeserializer.EndOfType)
+        {
+            // Assume we want to read the underlying value
+            return (ColorEnum)de.ReadI32(serdeInfo, index);
         }
         return index switch {
             0 => ColorEnum.Red,

--- a/test/Serde.Generation.Test/test_output/ProxyTests.ImmutableArrayEnumDeserialize/Test.ChannelProxy.IDeserialize.verified.cs
+++ b/test/Serde.Generation.Test/test_output/ProxyTests.ImmutableArrayEnumDeserialize/Test.ChannelProxy.IDeserialize.verified.cs
@@ -13,10 +13,15 @@ sealed partial class ChannelProxy :Serde.IDeserialize<Test.Channel>,Serde.IDeser
     {
         var serdeInfo = global::Serde.SerdeInfoProvider.GetInfo(this);
         var de = deserializer.ReadType(serdeInfo);
-        int index;
-        if ((index = de.TryReadIndex(serdeInfo, out var errorName)) == ITypeDeserializer.IndexNotFound)
+        int index = de.TryReadIndex(serdeInfo, out var errorName);
+        if (index == ITypeDeserializer.IndexNotFound)
         {
             throw Serde.DeserializeException.UnknownMember(errorName!, serdeInfo);
+        }
+        if (index == ITypeDeserializer.EndOfType)
+        {
+            // Assume we want to read the underlying value
+            return (Test.Channel)de.ReadI32(serdeInfo, index);
         }
         return index switch {
             0 => Test.Channel.A,

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.AllInOne.ColorEnumProxy.IDeserialize.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.AllInOne.ColorEnumProxy.IDeserialize.cs
@@ -14,10 +14,15 @@ partial record AllInOne
         {
             var serdeInfo = global::Serde.SerdeInfoProvider.GetInfo(this);
             var de = deserializer.ReadType(serdeInfo);
-            int index;
-            if ((index = de.TryReadIndex(serdeInfo, out var errorName)) == ITypeDeserializer.IndexNotFound)
+            int index = de.TryReadIndex(serdeInfo, out var errorName);
+            if (index == ITypeDeserializer.IndexNotFound)
             {
                 throw Serde.DeserializeException.UnknownMember(errorName!, serdeInfo);
+            }
+            if (index == ITypeDeserializer.EndOfType)
+            {
+                // Assume we want to read the underlying value
+                return (Serde.Test.AllInOne.ColorEnum)de.ReadI32(serdeInfo, index);
             }
             return index switch {
                 0 => Serde.Test.AllInOne.ColorEnum.Red,


### PR DESCRIPTION
The existing implementation expects to be able to decode an enum from TryReadIndex. This means that it can only rely on information from the ISerdeInfo. ISerdeInfo only has access to the name, not the enum value, which means it's not possible for deserializer implementations to use the enum value without a custom proxy. By checking for EndOfType, deserializer implementations can indicate that they want to encode the value directly.