### PR TITLE
Add support for DateOnly and TimeOnly as primitives

### DIFF
--- a/src/generator/Proxies.cs
+++ b/src/generator/Proxies.cs
@@ -108,6 +108,16 @@ sealed partial class {{proxyName}};
                 Name: "System",
                 ContainingNamespace: { IsGlobalNamespace: true } } }
             => new("global::System.DateTimeOffset", "global::Serde.DateTimeOffsetProxy"),
+            { Name: "DateOnly",
+              ContainingNamespace: {
+                Name: "System",
+                ContainingNamespace: { IsGlobalNamespace: true } } }
+            => new("global::System.DateOnly", "global::Serde.DateOnlyProxy"),
+            { Name: "TimeOnly",
+              ContainingNamespace: {
+                Name: "System",
+                ContainingNamespace: { IsGlobalNamespace: true } } }
+            => new("global::System.TimeOnly", "global::Serde.TimeOnlyProxy"),
             IArrayTypeSymbol { ElementType: { SpecialType: SpecialType.System_Byte } }
             => new("global::System.Byte[]", "global::Serde.ByteArrayProxy"),
             _ => null

--- a/src/serde/IDeserializer.cs
+++ b/src/serde/IDeserializer.cs
@@ -23,6 +23,19 @@ public interface IDeserializer : IDisposable
     decimal ReadDecimal();
     string ReadString();
     DateTime ReadDateTime();
+    DateTimeOffset ReadDateTimeOffset();
+    DateOnly ReadDateOnly()
+    {
+        // Default implementation: parse ISO 8601 date string
+        var s = ReadString();
+        return DateOnly.Parse(s);
+    }
+    TimeOnly ReadTimeOnly()
+    {
+        // Default implementation: parse ISO 8601 time string
+        var s = ReadString();
+        return TimeOnly.Parse(s);
+    }
     void ReadBytes(IBufferWriter<byte> writer);
     ITypeDeserializer ReadType(ISerdeInfo typeInfo);
 }
@@ -87,6 +100,19 @@ public interface ITypeDeserializer : IDisposable
     decimal ReadDecimal(ISerdeInfo info, int index);
     string ReadString(ISerdeInfo info, int index);
     DateTime ReadDateTime(ISerdeInfo info, int index);
+    DateTimeOffset ReadDateTimeOffset(ISerdeInfo info, int index);
+    DateOnly ReadDateOnly(ISerdeInfo info, int index)
+    {
+        // Default implementation: parse ISO 8601 date string
+        var s = ReadString(info, index);
+        return DateOnly.Parse(s);
+    }
+    TimeOnly ReadTimeOnly(ISerdeInfo info, int index)
+    {
+        // Default implementation: parse ISO 8601 time string
+        var s = ReadString(info, index);
+        return TimeOnly.Parse(s);
+    }
     void ReadBytes(ISerdeInfo info, int index, IBufferWriter<byte> writer);
 
     void IDisposable.Dispose() { }

--- a/src/serde/ISerdeInfo.cs
+++ b/src/serde/ISerdeInfo.cs
@@ -94,6 +94,8 @@ public enum PrimitiveKind
     String,
     DateTime,
     Bytes,
+    DateOnly,
+    TimeOnly,
 }
 
 /// <summary>

--- a/src/serde/ISerialize.cs
+++ b/src/serde/ISerialize.cs
@@ -92,6 +92,16 @@ public interface ISerializer
     void WriteDateTime(DateTime dt);
     void WriteDateTimeOffset(DateTimeOffset dt);
     void WriteBytes(ReadOnlyMemory<byte> bytes);
+    void WriteDateOnly(DateOnly d)
+    {
+        // Default implementation: serialize as ISO 8601 date string
+        WriteString(d.ToString("yyyy-MM-dd"));
+    }
+    void WriteTimeOnly(TimeOnly t)
+    {
+        // Default implementation: serialize as ISO 8601 time string
+        WriteString(t.ToString("HH:mm:ss"));
+    }
 
     /// <summary>
     /// Write a collection type -- either a list or a dictionary.
@@ -176,6 +186,16 @@ public interface ITypeSerializer
     void WriteNull(ISerdeInfo typeInfo, int index);
     void WriteDateTime(ISerdeInfo typeInfo, int index, DateTime dt);
     void WriteDateTimeOffset(ISerdeInfo typeInfo, int index, DateTimeOffset dt);
+    void WriteDateOnly(ISerdeInfo typeInfo, int index, DateOnly d)
+    {
+        // Default implementation: serialize as ISO 8601 date string
+        WriteString(typeInfo, index, d.ToString("yyyy-MM-dd"));
+    }
+    void WriteTimeOnly(ISerdeInfo typeInfo, int index, TimeOnly t)
+    {
+        // Default implementation: serialize as ISO 8601 time string
+        WriteString(typeInfo, index, t.ToString("HH:mm:ss"));
+    }
     void WriteBytes(ISerdeInfo typeInfo, int index, ReadOnlyMemory<byte> bytes);
 
     /// <summary>

--- a/src/serde/Proxies.DateTime.cs
+++ b/src/serde/Proxies.DateTime.cs
@@ -1,0 +1,82 @@
+
+using System;
+
+namespace Serde;
+
+public sealed class DateTimeProxy : ISerdePrimitive<DateTimeProxy, DateTime>
+{
+    public static DateTimeProxy Instance { get; } = new();
+    private DateTimeProxy() { }
+
+    public static ISerdeInfo SerdeInfo { get; }
+        = Serde.SerdeInfo.MakePrimitive("System.DateTime", PrimitiveKind.DateTime);
+    ISerdeInfo ISerdeInfoProvider.SerdeInfo => SerdeInfo;
+
+    void ISerialize<DateTime>.Serialize(DateTime value, ISerializer serializer)
+        => serializer.WriteDateTime(value);
+    void ITypeSerialize<DateTime>.Serialize(DateTime value, ITypeSerializer serializer, ISerdeInfo info, int index)
+        => serializer.WriteDateTime(info, index, value);
+    DateTime IDeserialize<DateTime>.Deserialize(IDeserializer deserializer)
+        => deserializer.ReadDateTime();
+    DateTime ITypeDeserialize<DateTime>.Deserialize(ITypeDeserializer deserializer, ISerdeInfo info, int index)
+        => deserializer.ReadDateTime(info, index);
+}
+
+public sealed class DateTimeOffsetProxy : ISerdePrimitive<DateTimeOffsetProxy, DateTimeOffset>
+{
+    public static DateTimeOffsetProxy Instance { get; } = new();
+    private DateTimeOffsetProxy() { }
+
+    public static ISerdeInfo SerdeInfo { get; }
+        = Serde.SerdeInfo.MakePrimitive("System.DateTimeOffset", PrimitiveKind.String);
+    ISerdeInfo ISerdeInfoProvider.SerdeInfo => SerdeInfo;
+
+    void ISerialize<DateTimeOffset>.Serialize(DateTimeOffset value, ISerializer serializer)
+        => serializer.WriteDateTimeOffset(value);
+    DateTimeOffset IDeserialize<DateTimeOffset>.Deserialize(IDeserializer deserializer)
+        => deserializer.ReadDateTimeOffset();
+
+    void ITypeSerialize<DateTimeOffset>.Serialize(DateTimeOffset value, ITypeSerializer serializer, ISerdeInfo info, int index)
+        => serializer.WriteDateTimeOffset(info, index, value);
+
+    DateTimeOffset ITypeDeserialize<DateTimeOffset>.Deserialize(ITypeDeserializer deserializer, ISerdeInfo info, int index)
+        => deserializer.ReadDateTimeOffset(info, index);
+}
+
+public sealed class DateOnlyProxy : ISerdePrimitive<DateOnlyProxy, DateOnly>
+{
+    public static DateOnlyProxy Instance { get; } = new();
+    private DateOnlyProxy() { }
+
+    public static ISerdeInfo SerdeInfo { get; }
+        = Serde.SerdeInfo.MakePrimitive("System.DateOnly", PrimitiveKind.DateOnly);
+    ISerdeInfo ISerdeInfoProvider.SerdeInfo => SerdeInfo;
+
+    void ISerialize<DateOnly>.Serialize(DateOnly value, ISerializer serializer)
+        => serializer.WriteDateOnly(value);
+    void ITypeSerialize<DateOnly>.Serialize(DateOnly value, ITypeSerializer serializer, ISerdeInfo info, int index)
+        => serializer.WriteDateOnly(info, index, value);
+    DateOnly IDeserialize<DateOnly>.Deserialize(IDeserializer deserializer)
+        => deserializer.ReadDateOnly();
+    DateOnly ITypeDeserialize<DateOnly>.Deserialize(ITypeDeserializer deserializer, ISerdeInfo info, int index)
+        => deserializer.ReadDateOnly(info, index);
+}
+
+public sealed class TimeOnlyProxy : ISerdePrimitive<TimeOnlyProxy, TimeOnly>
+{
+    public static TimeOnlyProxy Instance { get; } = new();
+    private TimeOnlyProxy() { }
+
+    public static ISerdeInfo SerdeInfo { get; }
+        = Serde.SerdeInfo.MakePrimitive("System.TimeOnly", PrimitiveKind.TimeOnly);
+    ISerdeInfo ISerdeInfoProvider.SerdeInfo => SerdeInfo;
+
+    void ISerialize<TimeOnly>.Serialize(TimeOnly value, ISerializer serializer)
+        => serializer.WriteTimeOnly(value);
+    void ITypeSerialize<TimeOnly>.Serialize(TimeOnly value, ITypeSerializer serializer, ISerdeInfo info, int index)
+        => serializer.WriteTimeOnly(info, index, value);
+    TimeOnly IDeserialize<TimeOnly>.Deserialize(IDeserializer deserializer)
+        => deserializer.ReadTimeOnly();
+    TimeOnly ITypeDeserialize<TimeOnly>.Deserialize(ITypeDeserializer deserializer, ISerdeInfo info, int index)
+        => deserializer.ReadTimeOnly(info, index);
+}

--- a/src/serde/Proxies.cs
+++ b/src/serde/Proxies.cs
@@ -465,47 +465,6 @@ public sealed class GuidProxy : ISerdePrimitive<GuidProxy, Guid>
     }
 }
 
-public sealed class DateTimeProxy : ISerdePrimitive<DateTimeProxy, DateTime>
-{
-    public static DateTimeProxy Instance { get; } = new();
-    private DateTimeProxy() { }
-
-    public static ISerdeInfo SerdeInfo { get; }
-        = Serde.SerdeInfo.MakePrimitive("System.DateTime", PrimitiveKind.DateTime);
-    ISerdeInfo ISerdeInfoProvider.SerdeInfo => SerdeInfo;
-
-    void ISerialize<DateTime>.Serialize(DateTime value, ISerializer serializer)
-        => serializer.WriteDateTime(value);
-    void ITypeSerialize<DateTime>.Serialize(DateTime value, ITypeSerializer serializer, ISerdeInfo info, int index)
-        => serializer.WriteDateTime(info, index, value);
-    DateTime IDeserialize<DateTime>.Deserialize(IDeserializer deserializer)
-        => deserializer.ReadDateTime();
-    DateTime ITypeDeserialize<DateTime>.Deserialize(ITypeDeserializer deserializer, ISerdeInfo info, int index)
-        => deserializer.ReadDateTime(info, index);
-}
-
-public sealed class DateTimeOffsetProxy : ISerdePrimitive<DateTimeOffsetProxy, DateTimeOffset>
-{
-    public static DateTimeOffsetProxy Instance { get; } = new();
-    private DateTimeOffsetProxy() { }
-
-    public static ISerdeInfo SerdeInfo { get; }
-        = Serde.SerdeInfo.MakePrimitive("System.DateTimeOffset", PrimitiveKind.String);
-    ISerdeInfo ISerdeInfoProvider.SerdeInfo => SerdeInfo;
-
-    void ISerialize<DateTimeOffset>.Serialize(DateTimeOffset value, ISerializer serializer)
-        => serializer.WriteDateTimeOffset(value);
-    DateTimeOffset IDeserialize<DateTimeOffset>.Deserialize(IDeserializer deserializer)
-        => deserializer.ReadDateTime();
-
-    void ITypeSerialize<DateTimeOffset>.Serialize(DateTimeOffset value, ITypeSerializer serializer, ISerdeInfo info, int index)
-        => serializer.WriteDateTimeOffset(info, index, value);
-
-    DateTimeOffset ITypeDeserialize<DateTimeOffset>.Deserialize(ITypeDeserializer deserializer, ISerdeInfo info, int index)
-        => deserializer.ReadDateTime(info, index);
-}
-
-
 public sealed class ByteArrayProxy : ISerdePrimitive<ByteArrayProxy, byte[]>
 {
     private sealed class ArrayWriter : IBufferWriter<byte>

--- a/src/serde/json/JsonDeserializer.Collection.cs
+++ b/src/serde/json/JsonDeserializer.Collection.cs
@@ -212,6 +212,27 @@ partial class JsonDeserializer<TReader>
             return v;
         }
 
+        public DateTimeOffset ReadDateTimeOffset(ISerdeInfo info, int index)
+        {
+            var v = _deserializer.ReadDateTimeOffset();
+            _index++;
+            return v;
+        }
+
+        public DateOnly ReadDateOnly(ISerdeInfo info, int index)
+        {
+            var v = _deserializer.ReadDateOnly();
+            _index++;
+            return v;
+        }
+
+        public TimeOnly ReadTimeOnly(ISerdeInfo info, int index)
+        {
+            var v = _deserializer.ReadTimeOnly();
+            _index++;
+            return v;
+        }
+
         void ITypeDeserializer.ReadBytes(ISerdeInfo info, int index, IBufferWriter<byte> writer)
         {
             _deserializer.ReadBytes(writer);

--- a/src/serde/json/JsonDeserializer.Type.cs
+++ b/src/serde/json/JsonDeserializer.Type.cs
@@ -162,6 +162,21 @@ partial class JsonDeserializer<TReader>
             ReadColon();
             return _deserializer.ReadDateTime();
         }
+        DateTimeOffset ITypeDeserializer.ReadDateTimeOffset(ISerdeInfo info, int index)
+        {
+            ReadColon();
+            return _deserializer.ReadDateTimeOffset();
+        }
+        DateOnly ITypeDeserializer.ReadDateOnly(ISerdeInfo info, int index)
+        {
+            ReadColon();
+            return _deserializer.ReadDateOnly();
+        }
+        TimeOnly ITypeDeserializer.ReadTimeOnly(ISerdeInfo info, int index)
+        {
+            ReadColon();
+            return _deserializer.ReadTimeOnly();
+        }
         void ITypeDeserializer.ReadBytes(ISerdeInfo info, int index, IBufferWriter<byte> writer)
         {
             ReadColon();

--- a/src/serde/json/JsonDeserializer.cs
+++ b/src/serde/json/JsonDeserializer.cs
@@ -197,6 +197,24 @@ internal sealed partial class JsonDeserializer<TReader> : BaseJsonDeserializer, 
         return DateTime.Parse(s, styles: DateTimeStyles.RoundtripKind);
     }
 
+    public DateTimeOffset ReadDateTimeOffset()
+    {
+        var s = ReadString();
+        return DateTimeOffset.Parse(s, styles: DateTimeStyles.RoundtripKind);
+    }
+
+    public DateOnly ReadDateOnly()
+    {
+        var s = ReadString();
+        return DateOnly.Parse(s);
+    }
+
+    public TimeOnly ReadTimeOnly()
+    {
+        var s = ReadString();
+        return TimeOnly.Parse(s);
+    }
+
     public void Eof()
     {
         if (Reader.SkipWhitespace() != IByteReader.EndOfStream)

--- a/src/serde/json/JsonSerializer.Collection.cs
+++ b/src/serde/json/JsonSerializer.Collection.cs
@@ -92,6 +92,14 @@ partial class JsonSerializer
         {
             serializer.WriteDateTimeOffset(dt);
         }
+        public void WriteDateOnly(ISerdeInfo typeInfo, int index, DateOnly d)
+        {
+            serializer.WriteDateOnly(d);
+        }
+        public void WriteTimeOnly(ISerdeInfo typeInfo, int index, TimeOnly t)
+        {
+            serializer.WriteTimeOnly(t);
+        }
         public void WriteBytes(ISerdeInfo typeInfo, int index, ReadOnlyMemory<byte> bytes)
         {
             serializer.WriteBytes(bytes);
@@ -122,6 +130,8 @@ partial class JsonSerializer
         public void WriteDecimal(decimal d) => throw new KeyNotStringException();
         public void WriteDateTime(DateTime dt) => throw new KeyNotStringException();
         public void WriteDateTimeOffset(DateTimeOffset dt) => throw new KeyNotStringException();
+        public void WriteDateOnly(DateOnly d) => throw new KeyNotStringException();
+        public void WriteTimeOnly(TimeOnly t) => throw new KeyNotStringException();
         public void WriteBytes(ReadOnlyMemory<byte> bytes) => throw new KeyNotStringException();
 
         public void WriteString(string s)
@@ -161,6 +171,8 @@ partial class JsonSerializer
         public void WriteU8(ISerdeInfo typeInfo, int index, byte b) => GetSerializer(index).WriteU8(b);
         public void WriteDateTime(ISerdeInfo typeInfo, int index, DateTime dt) => GetSerializer(index).WriteDateTime(dt);
         public void WriteDateTimeOffset(ISerdeInfo typeInfo, int index, DateTimeOffset dt) => GetSerializer(index).WriteDateTimeOffset(dt);
+        public void WriteDateOnly(ISerdeInfo typeInfo, int index, DateOnly d) => GetSerializer(index).WriteDateOnly(d);
+        public void WriteTimeOnly(ISerdeInfo typeInfo, int index, TimeOnly t) => GetSerializer(index).WriteTimeOnly(t);
         public void WriteBytes(ISerdeInfo typeInfo, int index, ReadOnlyMemory<byte> bytes) => GetSerializer(index).WriteBytes(bytes);
         public void WriteValue<T>(ISerdeInfo typeInfo, int index, T value, ISerialize<T> serialize)
             where T : class?

--- a/src/serde/json/JsonSerializer.Serialize.cs
+++ b/src/serde/json/JsonSerializer.Serialize.cs
@@ -51,6 +51,14 @@ partial class JsonSerializer : ISerializer
     {
         _writer.WriteStringValue(dt);
     }
+    public void WriteDateOnly(DateOnly d)
+    {
+        _writer.WriteStringValue(d.ToString("yyyy-MM-dd"));
+    }
+    public void WriteTimeOnly(TimeOnly t)
+    {
+        _writer.WriteStringValue(t.ToString("HH:mm:ss"));
+    }
     public void WriteBytes(ReadOnlyMemory<byte> bytes) => _writer.WriteBase64StringValue(bytes.Span);
 
     ITypeSerializer ISerializer.WriteCollection(ISerdeInfo info, int? size)
@@ -109,6 +117,8 @@ partial class JsonSerializer : ISerializer
         public void WriteU64(ISerdeInfo typeInfo, int index, ulong u64) => WriteEnumName(typeInfo, index);
         public void WriteDateTime(ISerdeInfo typeInfo, int index, DateTime dt) => ThrowInvalidEnum();
         public void WriteDateTimeOffset(ISerdeInfo typeInfo, int index, DateTimeOffset dt) => ThrowInvalidEnum();
+        public void WriteDateOnly(ISerdeInfo typeInfo, int index, DateOnly d) => ThrowInvalidEnum();
+        public void WriteTimeOnly(ISerdeInfo typeInfo, int index, TimeOnly t) => ThrowInvalidEnum();
         public void WriteBytes(ISerdeInfo typeInfo, int index, ReadOnlyMemory<byte> bytes) => ThrowInvalidEnum();
         private void ThrowInvalidEnum() => throw new InvalidOperationException("Invalid operation for enum serialization, expected integer value.");
     }
@@ -229,6 +239,16 @@ partial class JsonSerializer : ITypeSerializer
     {
         _writer.WritePropertyName(typeInfo.GetFieldName(index));
         WriteDateTimeOffset(dt);
+    }
+    void ITypeSerializer.WriteDateOnly(ISerdeInfo typeInfo, int index, DateOnly d)
+    {
+        _writer.WritePropertyName(typeInfo.GetFieldName(index));
+        WriteDateOnly(d);
+    }
+    void ITypeSerializer.WriteTimeOnly(ISerdeInfo typeInfo, int index, TimeOnly t)
+    {
+        _writer.WritePropertyName(typeInfo.GetFieldName(index));
+        WriteTimeOnly(t);
     }
     void ITypeSerializer.WriteBytes(ISerdeInfo typeInfo, int index, ReadOnlyMemory<byte> bytes)
     {

--- a/test/Serde.Generation.Test/test_output/AllInOneTest.GeneratorTest/Serde.Test.AllInOne.IDeserialize.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/AllInOneTest.GeneratorTest/Serde.Test.AllInOne.IDeserialize.g.verified.cs
@@ -28,6 +28,8 @@ partial record AllInOne
             string _l_stringfield = default!;
             System.DateTimeOffset _l_datetimeoffsetfield = default!;
             System.DateTime _l_datetimefield = default!;
+            System.DateOnly _l_dateonlyfield = default!;
+            System.TimeOnly _l_timeonlyfield = default!;
             System.Guid _l_guidfield = default!;
             string _l_escapedstringfield = default!;
             string? _l_nullstringfield = default!;
@@ -118,43 +120,53 @@ partial record AllInOne
                         break;
                     case 13:
                         Serde.DeserializeException.ThrowIfDuplicate(_r_assignedValid, 13, _l_serdeInfo);
-                        _l_guidfield = typeDeserialize.ReadBoxedValue<System.Guid, global::Serde.GuidProxy>(_l_serdeInfo, _l_index_);
+                        _l_dateonlyfield = typeDeserialize.ReadBoxedValue<System.DateOnly, global::Serde.DateOnlyProxy>(_l_serdeInfo, _l_index_);
                         _r_assignedValid |= ((uint)1) << 13;
                         break;
                     case 14:
                         Serde.DeserializeException.ThrowIfDuplicate(_r_assignedValid, 14, _l_serdeInfo);
-                        _l_escapedstringfield = typeDeserialize.ReadString(_l_serdeInfo, _l_index_);
+                        _l_timeonlyfield = typeDeserialize.ReadBoxedValue<System.TimeOnly, global::Serde.TimeOnlyProxy>(_l_serdeInfo, _l_index_);
                         _r_assignedValid |= ((uint)1) << 14;
                         break;
                     case 15:
                         Serde.DeserializeException.ThrowIfDuplicate(_r_assignedValid, 15, _l_serdeInfo);
-                        _l_nullstringfield = typeDeserialize.ReadValue<string?, Serde.NullableRefProxy.De<string, global::Serde.StringProxy>>(_l_serdeInfo, _l_index_);
+                        _l_guidfield = typeDeserialize.ReadBoxedValue<System.Guid, global::Serde.GuidProxy>(_l_serdeInfo, _l_index_);
                         _r_assignedValid |= ((uint)1) << 15;
                         break;
                     case 16:
                         Serde.DeserializeException.ThrowIfDuplicate(_r_assignedValid, 16, _l_serdeInfo);
-                        _l_uintarr = typeDeserialize.ReadValue<uint[], Serde.ArrayProxy.De<uint, global::Serde.U32Proxy>>(_l_serdeInfo, _l_index_);
+                        _l_escapedstringfield = typeDeserialize.ReadString(_l_serdeInfo, _l_index_);
                         _r_assignedValid |= ((uint)1) << 16;
                         break;
                     case 17:
                         Serde.DeserializeException.ThrowIfDuplicate(_r_assignedValid, 17, _l_serdeInfo);
-                        _l_nestedarr = typeDeserialize.ReadValue<int[][], Serde.ArrayProxy.De<int[], Serde.ArrayProxy.De<int, global::Serde.I32Proxy>>>(_l_serdeInfo, _l_index_);
+                        _l_nullstringfield = typeDeserialize.ReadValue<string?, Serde.NullableRefProxy.De<string, global::Serde.StringProxy>>(_l_serdeInfo, _l_index_);
                         _r_assignedValid |= ((uint)1) << 17;
                         break;
                     case 18:
                         Serde.DeserializeException.ThrowIfDuplicate(_r_assignedValid, 18, _l_serdeInfo);
-                        _l_bytearr = typeDeserialize.ReadValue<byte[], global::Serde.ByteArrayProxy>(_l_serdeInfo, _l_index_);
+                        _l_uintarr = typeDeserialize.ReadValue<uint[], Serde.ArrayProxy.De<uint, global::Serde.U32Proxy>>(_l_serdeInfo, _l_index_);
                         _r_assignedValid |= ((uint)1) << 18;
                         break;
                     case 19:
                         Serde.DeserializeException.ThrowIfDuplicate(_r_assignedValid, 19, _l_serdeInfo);
-                        _l_intimm = typeDeserialize.ReadBoxedValue<System.Collections.Immutable.ImmutableArray<int>, Serde.ImmutableArrayProxy.De<int, global::Serde.I32Proxy>>(_l_serdeInfo, _l_index_);
+                        _l_nestedarr = typeDeserialize.ReadValue<int[][], Serde.ArrayProxy.De<int[], Serde.ArrayProxy.De<int, global::Serde.I32Proxy>>>(_l_serdeInfo, _l_index_);
                         _r_assignedValid |= ((uint)1) << 19;
                         break;
                     case 20:
                         Serde.DeserializeException.ThrowIfDuplicate(_r_assignedValid, 20, _l_serdeInfo);
-                        _l_color = typeDeserialize.ReadBoxedValue<Serde.Test.AllInOne.ColorEnum, Serde.Test.AllInOne.ColorEnumProxy>(_l_serdeInfo, _l_index_);
+                        _l_bytearr = typeDeserialize.ReadValue<byte[], global::Serde.ByteArrayProxy>(_l_serdeInfo, _l_index_);
                         _r_assignedValid |= ((uint)1) << 20;
+                        break;
+                    case 21:
+                        Serde.DeserializeException.ThrowIfDuplicate(_r_assignedValid, 21, _l_serdeInfo);
+                        _l_intimm = typeDeserialize.ReadBoxedValue<System.Collections.Immutable.ImmutableArray<int>, Serde.ImmutableArrayProxy.De<int, global::Serde.I32Proxy>>(_l_serdeInfo, _l_index_);
+                        _r_assignedValid |= ((uint)1) << 21;
+                        break;
+                    case 22:
+                        Serde.DeserializeException.ThrowIfDuplicate(_r_assignedValid, 22, _l_serdeInfo);
+                        _l_color = typeDeserialize.ReadBoxedValue<Serde.Test.AllInOne.ColorEnum, Serde.Test.AllInOne.ColorEnumProxy>(_l_serdeInfo, _l_index_);
+                        _r_assignedValid |= ((uint)1) << 22;
                         break;
                     case Serde.ITypeDeserializer.IndexNotFound:
                         typeDeserialize.SkipValue(_l_serdeInfo, _l_index_);
@@ -163,7 +175,7 @@ partial record AllInOne
                         throw new InvalidOperationException("Unexpected index: " + _l_index_);
                 }
             }
-            if ((_r_assignedValid & 0b111110111111111111111) != 0b111110111111111111111)
+            if ((_r_assignedValid & 0b11111011111111111111111) != 0b11111011111111111111111)
             {
                 throw Serde.DeserializeException.UnassignedMember();
             }
@@ -181,6 +193,8 @@ partial record AllInOne
                 StringField = _l_stringfield,
                 DateTimeOffsetField = _l_datetimeoffsetfield,
                 DateTimeField = _l_datetimefield,
+                DateOnlyField = _l_dateonlyfield,
+                TimeOnlyField = _l_timeonlyfield,
                 GuidField = _l_guidfield,
                 EscapedStringField = _l_escapedstringfield,
                 NullStringField = _l_nullstringfield,

--- a/test/Serde.Generation.Test/test_output/AllInOneTest.GeneratorTest/Serde.Test.AllInOne.ISerdeInfoProvider.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/AllInOneTest.GeneratorTest/Serde.Test.AllInOne.ISerdeInfoProvider.g.verified.cs
@@ -23,6 +23,8 @@ partial record AllInOne
         ("stringField", global::Serde.SerdeInfoProvider.GetSerializeInfo<string, global::Serde.StringProxy>(), typeof(Serde.Test.AllInOne).GetField("StringField")),
         ("dateTimeOffsetField", global::Serde.SerdeInfoProvider.GetSerializeInfo<System.DateTimeOffset, global::Serde.DateTimeOffsetProxy>(), typeof(Serde.Test.AllInOne).GetField("DateTimeOffsetField")),
         ("dateTimeField", global::Serde.SerdeInfoProvider.GetSerializeInfo<System.DateTime, global::Serde.DateTimeProxy>(), typeof(Serde.Test.AllInOne).GetField("DateTimeField")),
+        ("dateOnlyField", global::Serde.SerdeInfoProvider.GetSerializeInfo<System.DateOnly, global::Serde.DateOnlyProxy>(), typeof(Serde.Test.AllInOne).GetField("DateOnlyField")),
+        ("timeOnlyField", global::Serde.SerdeInfoProvider.GetSerializeInfo<System.TimeOnly, global::Serde.TimeOnlyProxy>(), typeof(Serde.Test.AllInOne).GetField("TimeOnlyField")),
         ("guidField", global::Serde.SerdeInfoProvider.GetSerializeInfo<System.Guid, global::Serde.GuidProxy>(), typeof(Serde.Test.AllInOne).GetField("GuidField")),
         ("escapedStringField", global::Serde.SerdeInfoProvider.GetSerializeInfo<string, global::Serde.StringProxy>(), typeof(Serde.Test.AllInOne).GetField("EscapedStringField")),
         ("nullStringField", global::Serde.SerdeInfoProvider.GetSerializeInfo<string?, Serde.NullableRefProxy.Ser<string, global::Serde.StringProxy>>(), typeof(Serde.Test.AllInOne).GetField("NullStringField")),

--- a/test/Serde.Generation.Test/test_output/AllInOneTest.GeneratorTest/Serde.Test.AllInOne.ISerialize.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/AllInOneTest.GeneratorTest/Serde.Test.AllInOne.ISerialize.g.verified.cs
@@ -30,14 +30,16 @@ partial record AllInOne
             _l_type.WriteString(_l_info, 10, value.StringField);
             _l_type.WriteBoxedValue<global::System.DateTimeOffset, global::Serde.DateTimeOffsetProxy>(_l_info, 11, value.DateTimeOffsetField);
             _l_type.WriteDateTime(_l_info, 12, value.DateTimeField);
-            _l_type.WriteBoxedValue<global::System.Guid, global::Serde.GuidProxy>(_l_info, 13, value.GuidField);
-            _l_type.WriteString(_l_info, 14, value.EscapedStringField);
-            _l_type.WriteStringIfNotNull(_l_info, 15, value.NullStringField);
-            _l_type.WriteValue<uint[], Serde.ArrayProxy.Ser<uint, global::Serde.U32Proxy>>(_l_info, 16, value.UIntArr);
-            _l_type.WriteValue<int[][], Serde.ArrayProxy.Ser<int[], Serde.ArrayProxy.Ser<int, global::Serde.I32Proxy>>>(_l_info, 17, value.NestedArr);
-            _l_type.WriteValue<global::System.Byte[], global::Serde.ByteArrayProxy>(_l_info, 18, value.ByteArr);
-            _l_type.WriteBoxedValue<System.Collections.Immutable.ImmutableArray<int>, Serde.ImmutableArrayProxy.Ser<int, global::Serde.I32Proxy>>(_l_info, 19, value.IntImm);
-            _l_type.WriteBoxedValue<Serde.Test.AllInOne.ColorEnum, Serde.Test.AllInOne.ColorEnumProxy>(_l_info, 20, value.Color);
+            _l_type.WriteBoxedValue<global::System.DateOnly, global::Serde.DateOnlyProxy>(_l_info, 13, value.DateOnlyField);
+            _l_type.WriteBoxedValue<global::System.TimeOnly, global::Serde.TimeOnlyProxy>(_l_info, 14, value.TimeOnlyField);
+            _l_type.WriteBoxedValue<global::System.Guid, global::Serde.GuidProxy>(_l_info, 15, value.GuidField);
+            _l_type.WriteString(_l_info, 16, value.EscapedStringField);
+            _l_type.WriteStringIfNotNull(_l_info, 17, value.NullStringField);
+            _l_type.WriteValue<uint[], Serde.ArrayProxy.Ser<uint, global::Serde.U32Proxy>>(_l_info, 18, value.UIntArr);
+            _l_type.WriteValue<int[][], Serde.ArrayProxy.Ser<int[], Serde.ArrayProxy.Ser<int, global::Serde.I32Proxy>>>(_l_info, 19, value.NestedArr);
+            _l_type.WriteValue<global::System.Byte[], global::Serde.ByteArrayProxy>(_l_info, 20, value.ByteArr);
+            _l_type.WriteBoxedValue<System.Collections.Immutable.ImmutableArray<int>, Serde.ImmutableArrayProxy.Ser<int, global::Serde.I32Proxy>>(_l_info, 21, value.IntImm);
+            _l_type.WriteBoxedValue<Serde.Test.AllInOne.ColorEnum, Serde.Test.AllInOne.ColorEnumProxy>(_l_info, 22, value.Color);
             _l_type.End(_l_info);
         }
 

--- a/test/Serde.Test/AllInOneSrc.cs
+++ b/test/Serde.Test/AllInOneSrc.cs
@@ -30,6 +30,8 @@ namespace Serde.Test
         public string StringField = "StringValue";
         public DateTimeOffset DateTimeOffsetField;
         public DateTime DateTimeField;
+        public DateOnly DateOnlyField;
+        public TimeOnly TimeOnlyField;
         public Guid GuidField;
 
         public required string EscapedStringField;
@@ -69,6 +71,8 @@ namespace Serde.Test
                 StringField == other.StringField &&
                 DateTimeOffsetField == other.DateTimeOffsetField &&
                 DateTimeField == other.DateTimeField &&
+                DateOnlyField == other.DateOnlyField &&
+                TimeOnlyField == other.TimeOnlyField &&
                 EscapedStringField == other.EscapedStringField &&
                 GuidField.Equals(other.GuidField) &&
                 NullStringField == other.NullStringField &&
@@ -113,6 +117,8 @@ namespace Serde.Test
             StringField = "StringValue",
             DateTimeOffsetField = new DateTimeOffset(2040, 1, 1, 1, 1, 1, TimeSpan.FromHours(-7)),
             DateTimeField = new DateTime(2040, 1, 1, 1, 1, 1, DateTimeKind.Utc),
+            DateOnlyField = new DateOnly(2040, 6, 15),
+            TimeOnlyField = new TimeOnly(14, 30, 45),
             GuidField = new Guid(new byte[] {
                 0x01, 0x02, 0x03, 0x04,
                 0x05, 0x06, 0x07, 0x08,
@@ -146,6 +152,8 @@ namespace Serde.Test
   "stringField": "StringValue",
   "dateTimeOffsetField": "2040-01-01T01:01:01-07:00",
   "dateTimeField": "2040-01-01T01:01:01Z",
+  "dateOnlyField": "2040-06-15",
+  "timeOnlyField": "14:30:45",
   "guidField": "04030201-0605-0807-090a-0b0c0d0e0f10",
   "escapedStringField": "\u002B0 11 222 333 44",
   "uIntArr": [

--- a/test/Serde.Test/JsonFsCheck.cs
+++ b/test/Serde.Test/JsonFsCheck.cs
@@ -402,6 +402,20 @@ public static class DeepEquals
                 "new DateTimeOffset(2024, 1, 1, 1, 1, 1, TimeSpan.Zero)"
             );
         }
+        public sealed record TestDateOnly : TestType
+        {
+            public override TypeSyntax TypeSyntax(int typeIndex) => IdentifierName("DateOnly");
+            public override ExpressionSyntax Value(int typeIndex) => ParseExpression(
+                "new DateOnly(2024, 6, 15)"
+            );
+        }
+        public sealed record TestTimeOnly : TestType
+        {
+            public override TypeSyntax TypeSyntax(int typeIndex) => IdentifierName("TimeOnly");
+            public override ExpressionSyntax Value(int typeIndex) => ParseExpression(
+                "new TimeOnly(14, 30, 45)"
+            );
+        }
         public record TestTypeDef(ImmutableArray<TestType> FieldTypes) : TestType
         {
             public override TypeSyntax TypeSyntax(int typeIndex) => IdentifierName(TypeName(typeIndex));
@@ -504,6 +518,8 @@ public static class DeepEquals
                     Gen.Constant<TestType>(new TestDouble()),
                     Gen.Constant<TestType>(new TestDecimal()),
                     Gen.Constant<TestType>(new TestDateTimeOffset()),
+                    Gen.Constant<TestType>(new TestDateOnly()),
+                    Gen.Constant<TestType>(new TestTimeOnly()),
                 });
 
             public static Gen<TestType> GenType(int size)

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.AllInOne.IDeserialize.g.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.AllInOne.IDeserialize.g.cs
@@ -27,6 +27,8 @@ partial record AllInOne
             string _l_stringfield = default!;
             System.DateTimeOffset _l_datetimeoffsetfield = default!;
             System.DateTime _l_datetimefield = default!;
+            System.DateOnly _l_dateonlyfield = default!;
+            System.TimeOnly _l_timeonlyfield = default!;
             System.Guid _l_guidfield = default!;
             string _l_escapedstringfield = default!;
             string? _l_nullstringfield = default!;
@@ -117,43 +119,53 @@ partial record AllInOne
                         break;
                     case 13:
                         Serde.DeserializeException.ThrowIfDuplicate(_r_assignedValid, 13, _l_serdeInfo);
-                        _l_guidfield = typeDeserialize.ReadBoxedValue<System.Guid, global::Serde.GuidProxy>(_l_serdeInfo, _l_index_);
+                        _l_dateonlyfield = typeDeserialize.ReadBoxedValue<System.DateOnly, global::Serde.DateOnlyProxy>(_l_serdeInfo, _l_index_);
                         _r_assignedValid |= ((uint)1) << 13;
                         break;
                     case 14:
                         Serde.DeserializeException.ThrowIfDuplicate(_r_assignedValid, 14, _l_serdeInfo);
-                        _l_escapedstringfield = typeDeserialize.ReadString(_l_serdeInfo, _l_index_);
+                        _l_timeonlyfield = typeDeserialize.ReadBoxedValue<System.TimeOnly, global::Serde.TimeOnlyProxy>(_l_serdeInfo, _l_index_);
                         _r_assignedValid |= ((uint)1) << 14;
                         break;
                     case 15:
                         Serde.DeserializeException.ThrowIfDuplicate(_r_assignedValid, 15, _l_serdeInfo);
-                        _l_nullstringfield = typeDeserialize.ReadValue<string?, Serde.NullableRefProxy.De<string, global::Serde.StringProxy>>(_l_serdeInfo, _l_index_);
+                        _l_guidfield = typeDeserialize.ReadBoxedValue<System.Guid, global::Serde.GuidProxy>(_l_serdeInfo, _l_index_);
                         _r_assignedValid |= ((uint)1) << 15;
                         break;
                     case 16:
                         Serde.DeserializeException.ThrowIfDuplicate(_r_assignedValid, 16, _l_serdeInfo);
-                        _l_uintarr = typeDeserialize.ReadValue<uint[], Serde.ArrayProxy.De<uint, global::Serde.U32Proxy>>(_l_serdeInfo, _l_index_);
+                        _l_escapedstringfield = typeDeserialize.ReadString(_l_serdeInfo, _l_index_);
                         _r_assignedValid |= ((uint)1) << 16;
                         break;
                     case 17:
                         Serde.DeserializeException.ThrowIfDuplicate(_r_assignedValid, 17, _l_serdeInfo);
-                        _l_nestedarr = typeDeserialize.ReadValue<int[][], Serde.ArrayProxy.De<int[], Serde.ArrayProxy.De<int, global::Serde.I32Proxy>>>(_l_serdeInfo, _l_index_);
+                        _l_nullstringfield = typeDeserialize.ReadValue<string?, Serde.NullableRefProxy.De<string, global::Serde.StringProxy>>(_l_serdeInfo, _l_index_);
                         _r_assignedValid |= ((uint)1) << 17;
                         break;
                     case 18:
                         Serde.DeserializeException.ThrowIfDuplicate(_r_assignedValid, 18, _l_serdeInfo);
-                        _l_bytearr = typeDeserialize.ReadValue<byte[], global::Serde.ByteArrayProxy>(_l_serdeInfo, _l_index_);
+                        _l_uintarr = typeDeserialize.ReadValue<uint[], Serde.ArrayProxy.De<uint, global::Serde.U32Proxy>>(_l_serdeInfo, _l_index_);
                         _r_assignedValid |= ((uint)1) << 18;
                         break;
                     case 19:
                         Serde.DeserializeException.ThrowIfDuplicate(_r_assignedValid, 19, _l_serdeInfo);
-                        _l_intimm = typeDeserialize.ReadBoxedValue<System.Collections.Immutable.ImmutableArray<int>, Serde.ImmutableArrayProxy.De<int, global::Serde.I32Proxy>>(_l_serdeInfo, _l_index_);
+                        _l_nestedarr = typeDeserialize.ReadValue<int[][], Serde.ArrayProxy.De<int[], Serde.ArrayProxy.De<int, global::Serde.I32Proxy>>>(_l_serdeInfo, _l_index_);
                         _r_assignedValid |= ((uint)1) << 19;
                         break;
                     case 20:
                         Serde.DeserializeException.ThrowIfDuplicate(_r_assignedValid, 20, _l_serdeInfo);
-                        _l_color = typeDeserialize.ReadBoxedValue<Serde.Test.AllInOne.ColorEnum, Serde.Test.AllInOne.ColorEnumProxy>(_l_serdeInfo, _l_index_);
+                        _l_bytearr = typeDeserialize.ReadValue<byte[], global::Serde.ByteArrayProxy>(_l_serdeInfo, _l_index_);
                         _r_assignedValid |= ((uint)1) << 20;
+                        break;
+                    case 21:
+                        Serde.DeserializeException.ThrowIfDuplicate(_r_assignedValid, 21, _l_serdeInfo);
+                        _l_intimm = typeDeserialize.ReadBoxedValue<System.Collections.Immutable.ImmutableArray<int>, Serde.ImmutableArrayProxy.De<int, global::Serde.I32Proxy>>(_l_serdeInfo, _l_index_);
+                        _r_assignedValid |= ((uint)1) << 21;
+                        break;
+                    case 22:
+                        Serde.DeserializeException.ThrowIfDuplicate(_r_assignedValid, 22, _l_serdeInfo);
+                        _l_color = typeDeserialize.ReadBoxedValue<Serde.Test.AllInOne.ColorEnum, Serde.Test.AllInOne.ColorEnumProxy>(_l_serdeInfo, _l_index_);
+                        _r_assignedValid |= ((uint)1) << 22;
                         break;
                     case Serde.ITypeDeserializer.IndexNotFound:
                         typeDeserialize.SkipValue(_l_serdeInfo, _l_index_);
@@ -162,7 +174,7 @@ partial record AllInOne
                         throw new InvalidOperationException("Unexpected index: " + _l_index_);
                 }
             }
-            if ((_r_assignedValid & 0b111110111111111111111) != 0b111110111111111111111)
+            if ((_r_assignedValid & 0b11111011111111111111111) != 0b11111011111111111111111)
             {
                 throw Serde.DeserializeException.UnassignedMember();
             }
@@ -180,6 +192,8 @@ partial record AllInOne
                 StringField = _l_stringfield,
                 DateTimeOffsetField = _l_datetimeoffsetfield,
                 DateTimeField = _l_datetimefield,
+                DateOnlyField = _l_dateonlyfield,
+                TimeOnlyField = _l_timeonlyfield,
                 GuidField = _l_guidfield,
                 EscapedStringField = _l_escapedstringfield,
                 NullStringField = _l_nullstringfield,

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.AllInOne.ISerdeInfoProvider.g.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.AllInOne.ISerdeInfoProvider.g.cs
@@ -22,6 +22,8 @@ partial record AllInOne
         ("stringField", global::Serde.SerdeInfoProvider.GetSerializeInfo<string, global::Serde.StringProxy>(), typeof(Serde.Test.AllInOne).GetField("StringField")),
         ("dateTimeOffsetField", global::Serde.SerdeInfoProvider.GetSerializeInfo<System.DateTimeOffset, global::Serde.DateTimeOffsetProxy>(), typeof(Serde.Test.AllInOne).GetField("DateTimeOffsetField")),
         ("dateTimeField", global::Serde.SerdeInfoProvider.GetSerializeInfo<System.DateTime, global::Serde.DateTimeProxy>(), typeof(Serde.Test.AllInOne).GetField("DateTimeField")),
+        ("dateOnlyField", global::Serde.SerdeInfoProvider.GetSerializeInfo<System.DateOnly, global::Serde.DateOnlyProxy>(), typeof(Serde.Test.AllInOne).GetField("DateOnlyField")),
+        ("timeOnlyField", global::Serde.SerdeInfoProvider.GetSerializeInfo<System.TimeOnly, global::Serde.TimeOnlyProxy>(), typeof(Serde.Test.AllInOne).GetField("TimeOnlyField")),
         ("guidField", global::Serde.SerdeInfoProvider.GetSerializeInfo<System.Guid, global::Serde.GuidProxy>(), typeof(Serde.Test.AllInOne).GetField("GuidField")),
         ("escapedStringField", global::Serde.SerdeInfoProvider.GetSerializeInfo<string, global::Serde.StringProxy>(), typeof(Serde.Test.AllInOne).GetField("EscapedStringField")),
         ("nullStringField", global::Serde.SerdeInfoProvider.GetSerializeInfo<string?, Serde.NullableRefProxy.Ser<string, global::Serde.StringProxy>>(), typeof(Serde.Test.AllInOne).GetField("NullStringField")),

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.AllInOne.ISerialize.g.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.AllInOne.ISerialize.g.cs
@@ -29,14 +29,16 @@ partial record AllInOne
             _l_type.WriteString(_l_info, 10, value.StringField);
             _l_type.WriteBoxedValue<global::System.DateTimeOffset, global::Serde.DateTimeOffsetProxy>(_l_info, 11, value.DateTimeOffsetField);
             _l_type.WriteDateTime(_l_info, 12, value.DateTimeField);
-            _l_type.WriteBoxedValue<global::System.Guid, global::Serde.GuidProxy>(_l_info, 13, value.GuidField);
-            _l_type.WriteString(_l_info, 14, value.EscapedStringField);
-            _l_type.WriteStringIfNotNull(_l_info, 15, value.NullStringField);
-            _l_type.WriteValue<uint[], Serde.ArrayProxy.Ser<uint, global::Serde.U32Proxy>>(_l_info, 16, value.UIntArr);
-            _l_type.WriteValue<int[][], Serde.ArrayProxy.Ser<int[], Serde.ArrayProxy.Ser<int, global::Serde.I32Proxy>>>(_l_info, 17, value.NestedArr);
-            _l_type.WriteValue<global::System.Byte[], global::Serde.ByteArrayProxy>(_l_info, 18, value.ByteArr);
-            _l_type.WriteBoxedValue<System.Collections.Immutable.ImmutableArray<int>, Serde.ImmutableArrayProxy.Ser<int, global::Serde.I32Proxy>>(_l_info, 19, value.IntImm);
-            _l_type.WriteBoxedValue<Serde.Test.AllInOne.ColorEnum, Serde.Test.AllInOne.ColorEnumProxy>(_l_info, 20, value.Color);
+            _l_type.WriteBoxedValue<global::System.DateOnly, global::Serde.DateOnlyProxy>(_l_info, 13, value.DateOnlyField);
+            _l_type.WriteBoxedValue<global::System.TimeOnly, global::Serde.TimeOnlyProxy>(_l_info, 14, value.TimeOnlyField);
+            _l_type.WriteBoxedValue<global::System.Guid, global::Serde.GuidProxy>(_l_info, 15, value.GuidField);
+            _l_type.WriteString(_l_info, 16, value.EscapedStringField);
+            _l_type.WriteStringIfNotNull(_l_info, 17, value.NullStringField);
+            _l_type.WriteValue<uint[], Serde.ArrayProxy.Ser<uint, global::Serde.U32Proxy>>(_l_info, 18, value.UIntArr);
+            _l_type.WriteValue<int[][], Serde.ArrayProxy.Ser<int[], Serde.ArrayProxy.Ser<int, global::Serde.I32Proxy>>>(_l_info, 19, value.NestedArr);
+            _l_type.WriteValue<global::System.Byte[], global::Serde.ByteArrayProxy>(_l_info, 20, value.ByteArr);
+            _l_type.WriteBoxedValue<System.Collections.Immutable.ImmutableArray<int>, Serde.ImmutableArrayProxy.Ser<int, global::Serde.I32Proxy>>(_l_info, 21, value.IntImm);
+            _l_type.WriteBoxedValue<Serde.Test.AllInOne.ColorEnum, Serde.Test.AllInOne.ColorEnumProxy>(_l_info, 22, value.Color);
             _l_type.End(_l_info);
         }
 


### PR DESCRIPTION
I initially thought this could be done only with proxies, but it turns out some serialization formats (SQL, Parquet) have a date-specific representation. Format-level primitives require a new serialization method, so this PR adds corresponding methods.

Fixes https://github.com/serdedotnet/serde/issues/280