### PR TITLE
Introduce Read32/64/128 methods

### DIFF
--- a/perf/bench/DataGenerator.cs
+++ b/perf/bench/DataGenerator.cs
@@ -15,6 +15,8 @@ namespace Benchmarks
                 return (T)(object)Serde.Test.AllInOne.Sample;
             if (typeof(T) == typeof(Primitives))
                 return (T)(object)Primitives.Sample;
+            if (typeof(T) == typeof(Guids))
+                return (T)(object)Guids.Sample;
 
             throw new InvalidOperationException();
 
@@ -51,6 +53,8 @@ namespace Benchmarks
                 return Serde.Test.AllInOne.SampleSerialized;
             if (typeof(T) == typeof(Primitives))
                 return Primitives.SampleSerialized;
+            if (typeof(T) == typeof(Guids))
+                return Guids.SampleSerialized;
 
             throw new InvalidOperationException("Unexpected type");
         }

--- a/perf/bench/DeserializeFromString.cs
+++ b/perf/bench/DeserializeFromString.cs
@@ -13,6 +13,7 @@ namespace Benchmarks
     [GenericTypeArguments(typeof(LoginViewModel), typeof(LoginViewModel))]
     [GenericTypeArguments(typeof(Location), typeof(LocationWrap))]
     [GenericTypeArguments(typeof(Primitives), typeof(Primitives))]
+    [GenericTypeArguments(typeof(Guids), typeof(Guids))]
     [GenericTypeArguments(typeof(AllInOne), typeof(AllInOne))]
     public class DeserializeFromString<T, U>
         where T : Serde.IDeserializeProvider<T>

--- a/perf/bench/DeserializeFromString.cs
+++ b/perf/bench/DeserializeFromString.cs
@@ -6,6 +6,7 @@ using System.Text.Json;
 using BenchmarkDotNet.Attributes;
 using Serde;
 using Serde.Test;
+using STJ = System.Text.Json;
 
 namespace Benchmarks
 {
@@ -29,7 +30,11 @@ namespace Benchmarks
             _options = new JsonSerializerOptions()
             {
                 IncludeFields = true,
-                PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+                PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+                Converters =
+                {
+                    new STJ.Serialization.JsonStringEnumConverter(STJ.JsonNamingPolicy.CamelCase)
+                }
             };
             value = DataGenerator.GenerateDeserialize<T>();
         }

--- a/perf/bench/SampleTypes.cs
+++ b/perf/bench/SampleTypes.cs
@@ -209,6 +209,32 @@ public partial record Primitives(
 "longField": 9223372036854775807
 }
 """;
+}
 
-
+[GenerateSerde]
+public partial record Guids(
+    Guid GuidField,
+    Guid GuidField2
+)
+{
+    public static readonly Guids Sample = new Guids(
+        GuidField: new Guid(new byte[] {
+            0x01, 0x02, 0x03, 0x04,
+            0x05, 0x06, 0x07, 0x08,
+            0x09, 0x0A, 0x0B, 0x0C,
+            0x0D, 0x0E, 0x0F, 0x10,
+        }),
+        GuidField2: new Guid(new byte[] {
+            0x10, 0x0F, 0x0E, 0x0D,
+            0x0C, 0x0B, 0x0A, 0x09,
+            0x08, 0x07, 0x06, 0x05,
+            0x04, 0x03, 0x02, 0x01,
+        })
+    );
+    public const string SampleSerialized = """
+{
+"guidField": "04030201-0605-0807-090a-0b0c0d0e0f10",
+"guidField2": "0d0e0f10-0b0a-0908-0706-050403020101"
+}
+""";
 }

--- a/src/generator/DeserializeImplGen.cs
+++ b/src/generator/DeserializeImplGen.cs
@@ -281,7 +281,14 @@ namespace Serde
                     }
                     else if (Proxies.TryGetImplicitWrapper(m.Type, context, SerdeUsage.Deserialize, inProgress) is { Proxy: { } wrap })
                     {
-                        readValueCall = $"{readMethodName}<{memberType}, {wrap}>";
+                        if (wrap == "global::Serde.GuidProxy")
+                        {
+                            readValueCall = $"ReadGuid<{wrap}>";
+                        }
+                        else
+                        {
+                            readValueCall = $"{readMethodName}<{memberType}, {wrap}>";
+                        }
                     }
                     else
                     {

--- a/src/serde/IDeserializer.cs
+++ b/src/serde/IDeserializer.cs
@@ -191,12 +191,6 @@ public static class ITypeDeserializerExt
     {
         var u128 = deserializeType.ReadValue128(info, index, TProvider.Instance);
         Span<byte> bytes = stackalloc byte[16];
-#if NET10_0_OR_GREATER
-        if (!BitConverter.TryWriteBytes(bytes, u128))
-        {
-            throw new InvalidOperationException("Failed to convert UInt128 to Guid");
-        }
-#else
         if (BitConverter.IsLittleEndian)
         {
             BinaryPrimitives.WriteUInt128LittleEndian(bytes, u128);
@@ -205,7 +199,6 @@ public static class ITypeDeserializerExt
         {
             BinaryPrimitives.WriteUInt128BigEndian(bytes, u128);
         }
-#endif
         return new Guid(bytes, !BitConverter.IsLittleEndian);
     }
 }

--- a/src/serde/IDeserializer.cs
+++ b/src/serde/IDeserializer.cs
@@ -1,6 +1,7 @@
 
 using System;
 using System.Buffers;
+using System.Buffers.Binary;
 
 namespace Serde;
 
@@ -83,8 +84,50 @@ public interface ITypeDeserializer : IDisposable
     /// </summary>
     (int, string? errorName) TryReadIndexWithName(ISerdeInfo info);
 
+    /// <summary>
+    /// Read a value of type T using the provided deserializer.
+    /// </summary>
     T ReadValue<T>(ISerdeInfo info, int index, IDeserialize<T> deserialize)
         where T : class?;
+
+    /// <summary>
+    /// Read a value that can be represented as a 32-bit integer.
+    /// </summary>
+    /// <remarks>
+    /// Must be implemented by deserializers to avoid boxing.
+    ///
+    /// Useful for deserializing structs/enums without boxing. Unlike <see cref="ReadValue{T}"/> ,
+    /// this method does not require T to be a reference type. And unlike <see cref="ReadU32" />
+    /// there is no requirement that the serialized representation is exactly a 32-bit integer.
+    /// </remarks>
+    UInt32 ReadValue32(ISerdeInfo info, int index, IDeserialize<UInt32> deserialize)
+        => this.ReadBoxedValue(info, index, deserialize);
+
+    /// <summary>
+    /// Read a value that can be represented as a 64-bit integer.
+    /// </summary>
+    /// <remarks>
+    /// Must be implemented by deserializers to avoid boxing.
+    ///
+    /// Useful for deserializing structs/enums without boxing. Unlike <see cref="ReadValue{T}"/> ,
+    /// this method does not require T to be a reference type. And unlike <see cref="ReadU32" />
+    /// there is no requirement that the serialized representation is exactly a 32-bit integer.
+    /// </remarks>
+    UInt64 ReadValue64(ISerdeInfo info, int index, IDeserialize<UInt64> deserialize)
+        => this.ReadBoxedValue(info, index, deserialize);
+
+    /// <summary>
+    /// Read a value that can be represented as a 128-bit integer.
+    /// </summary>
+    /// <remarks>
+    /// Must be implemented by deserializers to avoid boxing.
+    ///
+    /// Useful for deserializing structs/enums without boxing. Unlike <see cref="ReadValue{T}"/> ,
+    /// this method does not require T to be a reference type. And unlike <see cref="ReadU32" />
+    /// there is no requirement that the serialized representation is exactly a 32-bit integer.
+    /// </remarks>
+    UInt128 ReadValue128(ISerdeInfo info, int index, IDeserialize<UInt128> deserialize)
+        => this.ReadBoxedValue(info, index, deserialize);
 
     void SkipValue(ISerdeInfo info, int index);
     bool ReadBool(ISerdeInfo info, int index);
@@ -131,9 +174,38 @@ public static class ITypeDeserializerExt
         return deserializeType.ReadValue(info, index, TProvider.Instance);
     }
 
+    public static T ReadBoxedValue<T>(this ITypeDeserializer deserializeType, ISerdeInfo info, int index, IDeserialize<T> d)
+        where T : struct
+    {
+        return (T)deserializeType.ReadValue(info, index, new BoxProxy.De<T>(d))!;
+    }
+
     public static T ReadBoxedValue<T, TProvider>(this ITypeDeserializer deserializeType, ISerdeInfo info, int index)
         where TProvider : IDeserializeProvider<T>
     {
         return (T)deserializeType.ReadValue(info, index, BoxProxy.De<T, TProvider>.Instance)!;
+    }
+
+    public static Guid ReadGuid<TProvider>(this ITypeDeserializer deserializeType, ISerdeInfo info, int index)
+        where TProvider : IDeserializeProvider<UInt128>
+    {
+        var u128 = deserializeType.ReadValue128(info, index, TProvider.Instance);
+        Span<byte> bytes = stackalloc byte[16];
+#if NET10_0_OR_GREATER
+        if (!BitConverter.TryWriteBytes(bytes, u128))
+        {
+            throw new InvalidOperationException("Failed to convert UInt128 to Guid");
+        }
+#else
+        if (BitConverter.IsLittleEndian)
+        {
+            BinaryPrimitives.WriteUInt128LittleEndian(bytes, u128);
+        }
+        else
+        {
+            BinaryPrimitives.WriteUInt128BigEndian(bytes, u128);
+        }
+#endif
+        return new Guid(bytes, !BitConverter.IsLittleEndian);
     }
 }

--- a/src/serde/Proxies.cs
+++ b/src/serde/Proxies.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Buffers;
+using System.Buffers.Binary;
 using System.Diagnostics;
 using System.Threading;
 
@@ -370,18 +371,18 @@ public static class BoxProxy
         }
     }
 
-    public sealed class De<T, TProvider> : IDeserialize<object?>, ITypeDeserialize<T>
-        where TProvider : IDeserializeProvider<T>
+    public sealed class De<T>(IDeserialize<T> _underlying) : IDeserialize<object?>, ITypeDeserialize<T>
     {
-        private IDeserialize<T> _underlying = TProvider.Instance;
-
-        public static readonly De<T, TProvider> Instance = new();
-        private De() {}
-
         public ISerdeInfo SerdeInfo => _underlying.SerdeInfo;
         public object? Deserialize(IDeserializer deserializer) => _underlying.Deserialize(deserializer);
         public T Deserialize(ITypeDeserializer deserializer, ISerdeInfo info, int index)
             => (T)deserializer.ReadValue(info, index, this)!;
+    }
+
+    public static class De<T, TProvider>
+        where TProvider : IDeserializeProvider<T>
+    {
+        public static readonly De<T> Instance = new De<T>(TProvider.Instance);
     }
 }
 
@@ -473,9 +474,13 @@ public static class NullableRefProxy
     }
 }
 
-public sealed class GuidProxy : ISerdePrimitive<GuidProxy, Guid>
+public sealed class GuidProxy
+    : ISerdePrimitive<GuidProxy, Guid>,
+    IDeserialize<UInt128>,
+    IDeserializeProvider<UInt128>
 {
     public static GuidProxy Instance { get; } = new();
+    static IDeserialize<UInt128> IDeserializeProvider<UInt128>.Instance => Instance;
     private GuidProxy() { }
 
     public static ISerdeInfo SerdeInfo { get; }
@@ -492,6 +497,20 @@ public sealed class GuidProxy : ISerdePrimitive<GuidProxy, Guid>
     {
         var bytes = deserializer.ReadString();
         return Guid.Parse(bytes);
+    }
+
+    UInt128 IDeserialize<UInt128>.Deserialize(IDeserializer deserializer)
+    {
+        var str = deserializer.ReadString();
+        var guid = Guid.Parse(str);
+        Span<byte> guidBytes = stackalloc byte[16];
+        if (!guid.TryWriteBytes(guidBytes, bigEndian: BitConverter.IsLittleEndian, out int written) || written != 16)
+        {
+            throw new InvalidOperationException("Couldn't write GUID bytes");
+        }
+        return BitConverter.IsLittleEndian
+            ? BinaryPrimitives.ReadUInt128LittleEndian(guidBytes)
+            : BinaryPrimitives.ReadUInt128BigEndian(guidBytes);
     }
 
     void ITypeSerialize<Guid>.Serialize(Guid value, ITypeSerializer serializer, ISerdeInfo info, int index)

--- a/src/serde/Proxies.cs
+++ b/src/serde/Proxies.cs
@@ -504,7 +504,7 @@ public sealed class GuidProxy
         var str = deserializer.ReadString();
         var guid = Guid.Parse(str);
         Span<byte> guidBytes = stackalloc byte[16];
-        if (!guid.TryWriteBytes(guidBytes, bigEndian: BitConverter.IsLittleEndian, out int written) || written != 16)
+        if (!guid.TryWriteBytes(guidBytes, bigEndian: !BitConverter.IsLittleEndian, out int written) || written != 16)
         {
             throw new InvalidOperationException("Couldn't write GUID bytes");
         }

--- a/src/serde/json/JsonDeserializer.Collection.cs
+++ b/src/serde/json/JsonDeserializer.Collection.cs
@@ -101,6 +101,27 @@ partial class JsonDeserializer<TReader>
             return next;
         }
 
+        public UInt32 ReadValue32(ISerdeInfo info, int index, IDeserialize<UInt32> d)
+        {
+            var next = d.Deserialize(_deserializer);
+            _index++;
+            return next;
+        }
+
+        public UInt64 ReadValue64(ISerdeInfo info, int index, IDeserialize<UInt64> d)
+        {
+            var next = d.Deserialize(_deserializer);
+            _index++;
+            return next;
+        }
+
+        public UInt128 ReadValue128(ISerdeInfo info, int index, IDeserialize<UInt128> d)
+        {
+            var next = d.Deserialize(_deserializer);
+            _index++;
+            return next;
+        }
+
         public void SkipValue(ISerdeInfo info, int index)
         {
             _deserializer.Reader.Skip();

--- a/src/serde/json/JsonDeserializer.Type.cs
+++ b/src/serde/json/JsonDeserializer.Type.cs
@@ -77,6 +77,24 @@ partial class JsonDeserializer<TReader>
             return d.Deserialize(_deserializer);
         }
 
+        uint ITypeDeserializer.ReadValue32(ISerdeInfo info, int index, IDeserialize<uint> d)
+        {
+            ReadColon();
+            return d.Deserialize(_deserializer);
+        }
+
+        ulong ITypeDeserializer.ReadValue64(ISerdeInfo info, int index, IDeserialize<ulong> d)
+        {
+            ReadColon();
+            return d.Deserialize(_deserializer);
+        }
+
+        UInt128 ITypeDeserializer.ReadValue128(ISerdeInfo info, int index, IDeserialize<UInt128> d)
+        {
+            ReadColon();
+            return d.Deserialize(_deserializer);
+        }
+
         private void ReadColon()
         {
             var peek = ThrowIfEos(_deserializer.Reader.SkipWhitespace());

--- a/test/Serde.Generation.Test/test_output/AllInOneTest.GeneratorTest/Serde.Test.AllInOne.IDeserialize.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/AllInOneTest.GeneratorTest/Serde.Test.AllInOne.IDeserialize.g.verified.cs
@@ -142,7 +142,7 @@ partial record AllInOne
                         break;
                     case 17:
                         Serde.DeserializeException.ThrowIfDuplicate(_r_assignedValid, 17, _l_serdeInfo);
-                        _l_guidfield = typeDeserialize.ReadBoxedValue<System.Guid, global::Serde.GuidProxy>(_l_serdeInfo, _l_index_);
+                        _l_guidfield = typeDeserialize.ReadGuid<global::Serde.GuidProxy>(_l_serdeInfo, _l_index_);
                         _r_assignedValid |= ((uint)1) << 17;
                         break;
                     case 18:

--- a/test/Serde.Test/AllInOneJsonTest.cs
+++ b/test/Serde.Test/AllInOneJsonTest.cs
@@ -1,5 +1,6 @@
 using Serde.Json;
 using Xunit;
+using STJ = System.Text.Json;
 
 namespace Serde.Test;
 
@@ -16,6 +17,22 @@ public class AllInOneJsonTest
     public void DeserializeTest()
     {
         var actual = JsonSerializer.Deserialize<AllInOne>(AllInOne.SampleSerialized);
+        Assert.Equal(AllInOne.Sample, actual);
+    }
+
+    [Fact]
+    public void StjDeserializeTest()
+    {
+        var options = new STJ.JsonSerializerOptions
+        {
+            IncludeFields = true,
+            PropertyNamingPolicy = STJ.JsonNamingPolicy.CamelCase,
+            Converters =
+            {
+                new STJ.Serialization.JsonStringEnumConverter(STJ.JsonNamingPolicy.CamelCase)
+            }
+        };
+        var actual = STJ.JsonSerializer.Deserialize<AllInOne>(AllInOne.SampleSerialized, options);
         Assert.Equal(AllInOne.Sample, actual);
     }
 }

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.AllInOne.IDeserialize.g.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.AllInOne.IDeserialize.g.cs
@@ -141,7 +141,7 @@ partial record AllInOne
                         break;
                     case 17:
                         Serde.DeserializeException.ThrowIfDuplicate(_r_assignedValid, 17, _l_serdeInfo);
-                        _l_guidfield = typeDeserialize.ReadBoxedValue<System.Guid, global::Serde.GuidProxy>(_l_serdeInfo, _l_index_);
+                        _l_guidfield = typeDeserialize.ReadGuid<global::Serde.GuidProxy>(_l_serdeInfo, _l_index_);
                         _r_assignedValid |= ((uint)1) << 17;
                         break;
                     case 18:


### PR DESCRIPTION
These methods allow reading arbitrary types that can be represented as
integers of the above sizes. This avoids boxing while deserializing.
Also adds support for Guid to use the 128 method by default.