### PR TITLE
Upgrade benchmark tfm to 10.0

### DIFF
--- a/perf/bench/bench.csproj
+++ b/perf/bench/bench.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <Deterministic>true</Deterministic>
     <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>


### PR DESCRIPTION
It looks like there are some significant wins across the board here. Every serializer got significantly faster. Note that STJ probably has different code in each of the TFMs, but Serde and Newtonsoft are identical, so this is just framework/runtime improvements.

NET8.0:

```
BenchmarkDotNet v0.13.12, macOS 15.6.1 (24G90) [Darwin 24.6.0]
Apple M2, 1 CPU, 8 logical and 8 physical cores
.NET SDK 10.0.101
  [Host]     : .NET 8.0.22 (8.0.2225.52707), Arm64 RyuJIT AdvSIMD
  DefaultJob : .NET 8.0.22 (8.0.2225.52707), Arm64 RyuJIT AdvSIMD


| Method      | Mean       | Error   | StdDev  | Gen0   | Gen1   | Allocated |
|------------ |-----------:|--------:|--------:|-------:|-------:|----------:|
| JsonNet     | 2,027.3 ns | 4.21 ns | 3.52 ns | 0.5798 | 0.0038 |    4864 B |
| SystemText  |   837.6 ns | 3.12 ns | 2.76 ns | 0.0429 |      - |     360 B |
| SerdeJson   |   872.7 ns | 1.46 ns | 1.29 ns | 0.0572 |      - |     480 B |
| SerdeManual |   873.2 ns | 1.33 ns | 1.11 ns | 0.0572 |      - |     480 B |
```

NET9.0:
```

BenchmarkDotNet v0.13.12, macOS 15.6.1 (24G90) [Darwin 24.6.0]
Apple M2, 1 CPU, 8 logical and 8 physical cores
.NET SDK 10.0.101
  [Host]     : .NET 9.0.10 (9.0.1025.47515), Arm64 RyuJIT AdvSIMD
  DefaultJob : .NET 9.0.10 (9.0.1025.47515), Arm64 RyuJIT AdvSIMD


| Method      | Mean       | Error   | StdDev  | Gen0   | Gen1   | Allocated |
|------------ |-----------:|--------:|--------:|-------:|-------:|----------:|
| JsonNet     | 1,853.9 ns | 3.44 ns | 2.87 ns | 0.5550 | 0.0057 |    4656 B |
| SystemText  |   782.5 ns | 3.45 ns | 2.88 ns | 0.0420 |      - |     352 B |
| SerdeJson   |   815.3 ns | 2.26 ns | 1.89 ns | 0.0572 |      - |     480 B |
| SerdeManual |   819.3 ns | 1.22 ns | 1.14 ns | 0.0572 |      - |     480 B |
```

NET10.0
```
BenchmarkDotNet v0.13.12, macOS 15.6.1 (24G90) [Darwin 24.6.0]
Apple M2, 1 CPU, 8 logical and 8 physical cores
.NET SDK 10.0.101
  [Host]     : .NET 10.0.1 (10.0.125.57005), Arm64 RyuJIT AdvSIMD
  DefaultJob : .NET 10.0.1 (10.0.125.57005), Arm64 RyuJIT AdvSIMD


| Method      | Mean       | Error   | StdDev  | Gen0   | Gen1   | Allocated |
|------------ |-----------:|--------:|--------:|-------:|-------:|----------:|
| JsonNet     | 1,582.6 ns | 6.73 ns | 5.62 ns | 0.5550 | 0.0057 |    4656 B |
| SystemText  |   719.5 ns | 2.57 ns | 2.28 ns | 0.0420 |      - |     352 B |
| SerdeJson   |   707.0 ns | 1.50 ns | 1.33 ns | 0.0572 |      - |     480 B |
| SerdeManual |   708.1 ns | 0.88 ns | 0.78 ns | 0.0572 |      - |     480 B |
```