### PR TITLE
Fix SerdeTypeOptions(Proxy =) and refactor

### DIFF
--- a/src/generator/Proxies.cs
+++ b/src/generator/Proxies.cs
@@ -231,7 +231,7 @@ sealed partial class {{proxyName}};
 
         foreach (var elemType in elemTypes)
         {
-            if (TryGetProxy(memberSymbol: null, elemType, context, usage, inProgress) is { } proxy)
+            if (TryGetProxyString(memberSymbol: null, elemType, context, usage, inProgress) is { } proxy)
             {
                 typeArgs.Add(proxy);
             }
@@ -252,7 +252,7 @@ sealed partial class {{proxyName}};
     /// 4. Implicit wrappers (primitives, enums, compound types)
     /// Returns null if none apply.
     /// </summary>
-    internal static string? TryGetProxy(
+    internal static string? TryGetProxyString(
         ISymbol? memberSymbol,
         ITypeSymbol type,
         GeneratorExecutionContext context,

--- a/src/generator/Proxies.cs
+++ b/src/generator/Proxies.cs
@@ -1,17 +1,10 @@
-
-using System;
 using System.Linq;
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
 using System.Collections.Immutable;
 using System.Collections.Generic;
-using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 using static Serde.Diagnostics;
 using static Serde.WellKnownTypes;
 using System.Diagnostics.CodeAnalysis;
-using Microsoft.CodeAnalysis.Text;
-using System.Reflection.Metadata;
 
 namespace Serde;
 
@@ -238,22 +231,13 @@ sealed partial class {{proxyName}};
 
         foreach (var elemType in elemTypes)
         {
-            // Check if the type directly implements the interface
-            if (SerdeImplRoslynGenerator.ImplementsSerde(elemType, elemType, context, usage))
+            if (TryGetProxy(memberSymbol: null, elemType, context, usage, inProgress) is { } proxy)
             {
-                typeArgs.Add(elemType.ToDisplayString(s_fqnFormat));
-                continue;
+                typeArgs.Add(proxy);
             }
-
-            // Otherwise we'll need to wrap the element type as well e.g.,
-            //      ArrayWrap<`elemType`, `elemTypeWrapper`>
-            switch (TryGetImplicitWrapper(elemType, context, usage, inProgress))
+            else
             {
-                case null:
-                    return null;
-                case var (_, wrapper):
-                    typeArgs.Add(wrapper);
-                    break;
+                return null;
             }
         }
 
@@ -261,10 +245,239 @@ sealed partial class {{proxyName}};
     }
 
     /// <summary>
+    /// Gets the proxy type string for a type, checking in order:
+    /// 1. Proxy attributes on the member (if provided)
+    /// 2. Proxy attributes on the type
+    /// 3. Whether the type directly implements ISerialize/IDeserialize
+    /// 4. Implicit wrappers (primitives, enums, compound types)
+    /// Returns null if none apply.
+    /// </summary>
+    internal static string? TryGetProxy(
+        ISymbol? memberSymbol,
+        ITypeSymbol type,
+        GeneratorExecutionContext context,
+        SerdeUsage usage,
+        ImmutableList<(ITypeSymbol Receiver, ITypeSymbol Containing)> inProgress)
+    {
+        // Check for explicit proxy (member first, then type)
+        if (TryGetExplicitProxy(memberSymbol, type, usage, context) is { } proxyType)
+        {
+            return ConstructProxyString(proxyType, type, context, usage, inProgress, memberSymbol);
+        }
+
+        // Then check if the type directly implements serde
+        if (SerdeImplRoslynGenerator.ImplementsSerde(type, type, context, usage))
+        {
+            return type.ToDisplayString(s_fqnFormat);
+        }
+
+        // Finally check implicit wrappers (primitives, enums, compound types)
+        if (TryGetImplicitWrapper(type, context, usage, inProgress) is { } wrapper)
+        {
+            return wrapper.Proxy;
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Constructs the proxy string from a proxy type symbol, handling generic types.
+    /// </summary>
+    private static string? ConstructProxyString(
+        ITypeSymbol proxyType,
+        ITypeSymbol targetType,
+        GeneratorExecutionContext context,
+        SerdeUsage usage,
+        ImmutableList<(ITypeSymbol Receiver, ITypeSymbol Containing)> inProgress,
+        ISymbol? memberSymbol)
+    {
+        // If the proxy is an unconstructed generic type, construct it with the target's type arguments
+        if (proxyType is INamedTypeSymbol { IsGenericType: true } namedProxy &&
+            namedProxy.Equals(namedProxy.OriginalDefinition, SymbolEqualityComparer.Default))
+        {
+            var baseName = proxyType.ToDisplayString(s_baseNameFormat);
+            var typeArgs = targetType switch
+            {
+                INamedTypeSymbol n => n.TypeArguments,
+                _ => ImmutableArray<ITypeSymbol>.Empty
+            };
+            return MakeProxyType(baseName, typeArgs, context, usage, inProgress);
+        }
+
+        // Validate that the proxy implements the required interface
+        if (memberSymbol != null && !SerdeImplRoslynGenerator.ImplementsSerde(proxyType, targetType, context, usage))
+        {
+            context.ReportDiagnostic(CreateDiagnostic(
+                DiagId.ERR_WrapperDoesntImplementInterface,
+                memberSymbol.Locations[0],
+                proxyType,
+                targetType,
+                usage.GetInterfaceName() + "Provider"));
+        }
+
+        return proxyType.ToDisplayString(s_fqnFormat);
+    }
+
+    /// <summary>
+    /// Looks for an explicit proxy type from member options or type options.
+    /// Returns the proxy type symbol (unconstructed for generics).
+    /// </summary>
+    private static ITypeSymbol? TryGetExplicitProxy(
+        ISymbol? memberSymbol,
+        ITypeSymbol type,
+        SerdeUsage usage,
+        GeneratorExecutionContext context)
+    {
+        // Check member first, then type
+        if (memberSymbol != null && TryGetProxyFromSymbol(memberSymbol, type, usage, context) is { } memberProxy)
+        {
+            return memberProxy;
+        }
+
+        return TryGetProxyFromSymbol(type, type, usage, context);
+    }
+
+    /// <summary>
+    /// Checks a symbol's attributes for proxy specifications (both SerdeMemberOptions and SerdeTypeOptions).
+    /// For generic types, returns the nested Ser/De type from the proxy.
+    /// </summary>
+    private static ITypeSymbol? TryGetProxyFromSymbol(
+        ISymbol symbol,
+        ITypeSymbol typeToWrap,
+        SerdeUsage usage,
+        GeneratorExecutionContext context)
+    {
+        foreach (var attr in symbol.GetAttributes())
+        {
+            if (attr is { AttributeClass.Name: nameof(SerdeMemberOptions) or nameof(SerdeTypeOptions), NamedArguments: { } named })
+            {
+                foreach (var arg in named)
+                {
+                    switch (arg)
+                    {
+                        // Proxy property (on both SerdeMemberOptions and SerdeTypeOptions)
+                        case { Key: nameof(SerdeTypeOptions.Proxy), Value.Value: INamedTypeSymbol proxyType }:
+                        {
+                            return ResolveProxyForGenericType(proxyType, typeToWrap, symbol, usage, context);
+                        }
+
+                        // SerdeMemberOptions-specific properties
+                        case
+                        {
+                            Key: nameof(SerdeMemberOptions.SerializeProxy),
+                            Value.Value: INamedTypeSymbol wrapperType
+                        } when usage.HasFlag(SerdeUsage.Serialize):
+                        {
+                            return wrapperType;
+                        }
+                        case
+                        {
+                            Key: nameof(SerdeMemberOptions.DeserializeProxy),
+                            Value.Value: INamedTypeSymbol wrapperType
+                        } when usage.HasFlag(SerdeUsage.Deserialize):
+                        {
+                            return wrapperType;
+                        }
+
+                        case
+                        {
+                            Key: nameof(SerdeMemberOptions.TypeParameterProxy),
+                            Value.Value: string typeParamName
+                        }:
+                        {
+                            return ResolveTypeParameterProxy(symbol, typeParamName, context);
+                        }
+
+                        case
+                        {
+                            Key: nameof(SerdeMemberOptions.SerializeTypeParameterProxy),
+                            Value.Value: string typeParamName
+                        } when usage.HasFlag(SerdeUsage.Serialize):
+                        {
+                            return ResolveTypeParameterProxy(symbol, typeParamName, context);
+                        }
+
+                        case
+                        {
+                            Key: nameof(SerdeMemberOptions.DeserializeTypeParameterProxy),
+                            Value.Value: string typeParamName
+                        } when usage.HasFlag(SerdeUsage.Deserialize):
+                        {
+                            return ResolveTypeParameterProxy(symbol, typeParamName, context);
+                        }
+                    }
+                }
+            }
+        }
+        return null;
+    }
+
+    /// <summary>
+    /// For generic types, finds the nested Ser/De type from the proxy container.
+    /// </summary>
+    private static INamedTypeSymbol? ResolveProxyForGenericType(
+        INamedTypeSymbol proxyType,
+        ITypeSymbol typeToWrap,
+        ISymbol symbol,
+        SerdeUsage usage,
+        GeneratorExecutionContext context)
+    {
+        // If the typeToWrap is a generic type, we should expect that the wrapper type
+        // is not listed directly, but instead a parent type is listed (possibly static) and
+        // the Serialize and Deserialize wrappers are nested below.
+        if (typeToWrap.OriginalDefinition is INamedTypeSymbol { Arity: > 0 } targetType)
+        {
+            var nestedName = GetSingletonImplName(usage);
+            var nestedTypes = proxyType.GetTypeMembers(nestedName);
+            if (nestedTypes is not [{ } elem])
+            {
+                context.ReportDiagnostic(CreateDiagnostic(
+                    DiagId.ERR_CantFindNestedWrapper,
+                    symbol.Locations[0],
+                    nestedName,
+                    proxyType,
+                    targetType));
+                return null;
+            }
+            return elem;
+        }
+        return proxyType;
+    }
+
+    /// <summary>
+    /// Resolves a type parameter proxy by looking up the containing type hierarchy.
+    /// </summary>
+    private static ITypeSymbol? ResolveTypeParameterProxy(
+        ISymbol symbol,
+        string typeParamName,
+        GeneratorExecutionContext context)
+    {
+        var containing = symbol.ContainingType;
+        while (containing is not null)
+        {
+            foreach (var t in containing.TypeParameters)
+            {
+                if (t.Name == typeParamName)
+                {
+                    return t;
+                }
+            }
+            containing = containing.ContainingType;
+        }
+
+        // If we didn't find the type parameter, report an error
+        context.ReportDiagnostic(CreateDiagnostic(
+            DiagId.ERR_CantFindTypeParameter,
+            symbol.Locations[0],
+            typeParamName));
+        return null;
+    }
+
+    /// <summary>
     /// Implicit wrappers are:
     ///     1. Wrappers for primitive types
     ///     2. Wrappers for enums
-    ///     3. Compound wrappers for primitive types (e.g. List, Dictionary)
+    ///     3. Compound wrappers for types (e.g. List, Dictionary)
     /// </summary>
     internal static TypeWithProxy? TryGetImplicitWrapper(
         ITypeSymbol elemType,
@@ -309,180 +522,12 @@ sealed partial class {{proxyName}};
         SerdeUsage usage,
         ImmutableList<(ITypeSymbol Receiver, ITypeSymbol Containing)> inProgress)
     {
-        if (TryGetExplicitProxyType(member, usage, context) is {} proxyType)
+        // Check for explicit proxy on member or type (but not ImplementsSerde - that's handled by the caller)
+        if (TryGetExplicitProxy(member.Symbol, member.Type, usage, context) is { } proxyType)
         {
-            var memberType = member.Type;
-            if (proxyType is INamedTypeSymbol { IsGenericType: true } && proxyType.Equals(proxyType.OriginalDefinition, SymbolEqualityComparer.Default))
-            {
-                // If the wrapper type is an unconstructed generic type which we need to construct
-                // with the appropriate wrappers for the member type's type arguments.
-                var baseName = proxyType.ToDisplayString(s_baseNameFormat);
-                var typeArgs = memberType switch
-                {
-                    INamedTypeSymbol n => n.TypeArguments,
-                    _ => ImmutableArray<ITypeSymbol>.Empty
-                };
-                return MakeProxyType(baseName, typeArgs, context, usage, inProgress);
-            }
-
-            if (!SerdeImplRoslynGenerator.ImplementsSerde(proxyType, memberType, context, usage))
-            {
-                context.ReportDiagnostic(CreateDiagnostic(
-                    DiagId.ERR_WrapperDoesntImplementInterface,
-                    member.Symbol.Locations[0],
-                    proxyType,
-                    memberType,
-                    usage.GetInterfaceName() + "Provider"));
-            }
-
-            return proxyType.ToDisplayString(s_fqnFormat);
+            return ConstructProxyString(proxyType, member.Type, context, usage, inProgress, member.Symbol);
         }
         return null;
-
-        // <summary>
-        // Looks to see if the given member or its type explicitly specifies a wrapper to use via
-        // the SerdeType or Member options. If so, returns the symbol of the wrapper type.
-        // </summary>
-        static ITypeSymbol? TryGetExplicitProxyType(DataMemberSymbol member, SerdeUsage usage, GeneratorExecutionContext context)
-        {
-            // Look first for a wrapper attribute on the member being serialized, and then for a
-            // wrapper attribute
-            var typeToWrap = member.Type;
-            return GetSerdeProxyType(member.Symbol, typeToWrap, usage, context)
-                ?? GetSerdeProxyType(member.Type, typeToWrap, usage, context);
-
-            static ITypeSymbol? GetSerdeProxyType(ISymbol symbol, ITypeSymbol typeToWrap, SerdeUsage usage, GeneratorExecutionContext context)
-            {
-                foreach (var attr in symbol.GetAttributes())
-                {
-                    if (attr is { AttributeClass.Name: nameof(SerdeMemberOptions) or nameof(SerdeTypeOptions), NamedArguments: { } named })
-                    {
-                        foreach (var arg in named)
-                        {
-                            switch (arg)
-                            {
-                                case { Key: nameof(SerdeTypeOptions.Proxy), Value.Value: INamedTypeSymbol proxyType }:
-                                {
-                                    // If the typeToWrap is a generic type, we should expect that the wrapper type
-                                    // is not listed directly, but instead a parent type is listed (possibly static) and
-                                    // the Serialize and Deserialize wrappers are nested below.
-                                    if (typeToWrap.OriginalDefinition is INamedTypeSymbol { Arity: > 0 } targetType)
-                                    {
-                                        var nestedName = GetSingletonImplName(usage);
-                                        var nestedTypes = proxyType.GetTypeMembers(nestedName);
-                                        if (nestedTypes is not [ {} elem ])
-                                        {
-                                            context.ReportDiagnostic(CreateDiagnostic(
-                                                DiagId.ERR_CantFindNestedWrapper,
-                                                symbol.Locations[0],
-                                                nestedName,
-                                                proxyType,
-                                                targetType));
-                                            return null;
-                                        }
-                                        return elem;
-                                    }
-                                    return proxyType;
-                                }
-                                case
-                                {
-                                    Key: nameof(SerdeMemberOptions.SerializeProxy),
-                                    Value.Value: INamedTypeSymbol wrapperType
-                                } when usage.HasFlag(SerdeUsage.Serialize):
-                                {
-                                    return wrapperType;
-                                }
-                                case
-                                {
-                                    Key: nameof(SerdeMemberOptions.DeserializeProxy),
-                                    Value.Value: INamedTypeSymbol wrapperType2
-                                } when usage.HasFlag(SerdeUsage.Deserialize):
-                                {
-                                    return wrapperType2;
-                                }
-
-                                case
-                                {
-                                    Key: nameof(SerdeMemberOptions.TypeParameterProxy),
-                                    Value.Value: string typeParamName
-                                }:
-                                {
-                                    var typeParam = FindContainingTypeParamWithName(symbol, typeParamName);
-                                    if (typeParam is not null)
-                                    {
-                                        return typeParam;
-                                    }
-                                    // If we didn't find the type parameter, report an error
-                                    context.ReportDiagnostic(CreateDiagnostic(
-                                        DiagId.ERR_CantFindTypeParameter,
-                                        symbol.Locations[0],
-                                        typeParamName));
-                                    break;
-                                }
-
-                                case
-                                {
-                                    Key: nameof(SerdeMemberOptions.SerializeTypeParameterProxy),
-                                    Value.Value: string typeParamName
-                                } when usage.HasFlag(SerdeUsage.Serialize):
-                                {
-                                    var typeParam = FindContainingTypeParamWithName(symbol, typeParamName);
-                                    if (typeParam is not null)
-                                    {
-                                        return typeParam;
-                                    }
-                                    // If we didn't find the type parameter, report an error
-                                    context.ReportDiagnostic(CreateDiagnostic(
-                                        DiagId.ERR_CantFindTypeParameter,
-                                        symbol.Locations[0],
-                                        typeParamName));
-                                    break;
-                                }
-
-                                case
-                                {
-                                    Key: nameof(SerdeMemberOptions.DeserializeTypeParameterProxy),
-                                    Value.Value: string typeParamName
-                                } when usage.HasFlag(SerdeUsage.Deserialize):
-                                {
-                                    var typeParam = FindContainingTypeParamWithName(symbol, typeParamName);
-                                    if (typeParam is not null)
-                                    {
-                                        return typeParam;
-                                    }
-                                    // If we didn't find the type parameter, report an error
-                                    context.ReportDiagnostic(CreateDiagnostic(
-                                        DiagId.ERR_CantFindTypeParameter,
-                                        symbol.Locations[0],
-                                        typeParamName));
-                                    break;
-                                }
-                            }
-
-                            // Walk up the containing types to find a type parameter with the given name.
-                            static ITypeSymbol? FindContainingTypeParamWithName(ISymbol current, string name)
-                            {
-                                var containing = current.ContainingType;
-                                while (containing is not null)
-                                {
-                                    var typeParams = containing.TypeParameters;
-                                    foreach (var t in typeParams)
-                                    {
-                                        if (t.Name == name)
-                                        {
-                                            return t;
-                                        }
-                                    }
-                                    containing = containing.ContainingType;
-                                }
-                                return null;
-                            }
-                        }
-                    }
-                }
-                return null;
-            }
-        }
     }
 
     [return: NotNullIfNotNull(nameof(wkOpt))]

--- a/src/generator/SerdeInfoGenerator.cs
+++ b/src/generator/SerdeInfoGenerator.cs
@@ -229,6 +229,6 @@ private static global::Serde.ISerdeInfo s_serdeInfo { get; } = Serde.SerdeInfo.M
         SerdeUsage usage,
         ImmutableList<(ITypeSymbol Receiver, ITypeSymbol Containing)> inProgress)
     {
-        return Proxies.TryGetProxy(m.Symbol, m.Type, context, usage, inProgress);
+        return Proxies.TryGetProxyString(m.Symbol, m.Type, context, usage, inProgress);
     }
 }

--- a/src/generator/SerdeInfoGenerator.cs
+++ b/src/generator/SerdeInfoGenerator.cs
@@ -229,23 +229,6 @@ private static global::Serde.ISerdeInfo s_serdeInfo { get; } = Serde.SerdeInfo.M
         SerdeUsage usage,
         ImmutableList<(ITypeSymbol Receiver, ITypeSymbol Containing)> inProgress)
     {
-        string? wrapperName;
-        if (Proxies.TryGetExplicitWrapper(m, context, usage, inProgress) is { } explicitWrap)
-        {
-            wrapperName = explicitWrap.ToString();
-        }
-        else if (SerdeImplRoslynGenerator.ImplementsSerde(m.Type, m.Type, context, usage))
-        {
-            wrapperName = m.Type.WithNullableAnnotation(m.NullableAnnotation).ToDisplayString();
-        }
-        else if (Proxies.TryGetImplicitWrapper(m.Type, context, usage, inProgress) is { Proxy: { } wrap })
-        {
-            wrapperName = wrap.ToString();
-        }
-        else
-        {
-            wrapperName = null;
-        }
-        return wrapperName;
+        return Proxies.TryGetProxy(m.Symbol, m.Type, context, usage, inProgress);
     }
 }

--- a/test/Serde.Generation.Test/test_output/SerdeTests.DictionaryWithEqArrayKey/Test.ISerde.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/SerdeTests.DictionaryWithEqArrayKey/Test.ISerde.g.verified.cs
@@ -1,0 +1,61 @@
+﻿//HintName: Test.ISerde.g.cs
+
+#nullable enable
+
+using System;
+using Serde;
+partial class Test
+{
+    sealed partial class _SerdeObj : global::Serde.ISerde<Test>
+    {
+        global::Serde.ISerdeInfo global::Serde.ISerdeInfoProvider.SerdeInfo => Test.s_serdeInfo;
+
+        void global::Serde.ISerialize<Test>.Serialize(Test value, global::Serde.ISerializer serializer)
+        {
+            var _l_info = global::Serde.SerdeInfoProvider.GetInfo(this);
+            var _l_type = serializer.WriteType(_l_info);
+            _l_type.WriteValue<System.Collections.Generic.Dictionary<EqArray<int>, int>, Serde.DictProxy.Ser<EqArray<int>, int, EqArrayProxy.Ser<int, global::Serde.I32Proxy>, global::Serde.I32Proxy>>(_l_info, 0, value.data);
+            _l_type.End(_l_info);
+        }
+        Test Serde.IDeserialize<Test>.Deserialize(IDeserializer deserializer)
+        {
+            System.Collections.Generic.Dictionary<EqArray<int>, int> _l_data = default!;
+
+            byte _r_assignedValid = 0;
+
+            var _l_serdeInfo = global::Serde.SerdeInfoProvider.GetInfo(this);
+            var typeDeserialize = deserializer.ReadType(_l_serdeInfo);
+            while (true)
+            {
+                var (_l_index_, _) = typeDeserialize.TryReadIndexWithName(_l_serdeInfo);
+                if (_l_index_ == Serde.ITypeDeserializer.EndOfType)
+                {
+                    break;
+                }
+
+                switch (_l_index_)
+                {
+                    case 0:
+                        Serde.DeserializeException.ThrowIfDuplicate(_r_assignedValid, 0, _l_serdeInfo);
+                        _l_data = typeDeserialize.ReadValue<System.Collections.Generic.Dictionary<EqArray<int>, int>, Serde.DictProxy.De<EqArray<int>, int, EqArrayProxy.De<int, global::Serde.I32Proxy>, global::Serde.I32Proxy>>(_l_serdeInfo, _l_index_);
+                        _r_assignedValid |= ((byte)1) << 0;
+                        break;
+                    case Serde.ITypeDeserializer.IndexNotFound:
+                        typeDeserialize.SkipValue(_l_serdeInfo, _l_index_);
+                        break;
+                    default:
+                        throw new InvalidOperationException("Unexpected index: " + _l_index_);
+                }
+            }
+            if ((_r_assignedValid & 0b1) != 0b1)
+            {
+                throw Serde.DeserializeException.UnassignedMember();
+            }
+            var newType = new Test() {
+                data = _l_data,
+            };
+
+            return newType;
+        }
+    }
+}

--- a/test/Serde.Generation.Test/test_output/SerdeTests.DictionaryWithEqArrayKey/Test.ISerdeInfoProvider.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/SerdeTests.DictionaryWithEqArrayKey/Test.ISerdeInfoProvider.g.verified.cs
@@ -1,0 +1,13 @@
+﻿//HintName: Test.ISerdeInfoProvider.g.cs
+
+#nullable enable
+partial class Test
+{
+    private static global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
+        "Test",
+    typeof(Test).GetCustomAttributesData(),
+    new (string, global::Serde.ISerdeInfo, System.Reflection.MemberInfo?)[] {
+        ("data", global::Serde.SerdeInfoProvider.GetSerializeInfo<System.Collections.Generic.Dictionary<EqArray<int>, int>, Serde.DictProxy.Ser<EqArray<int>, int, EqArrayProxy.Ser<int, global::Serde.I32Proxy>, global::Serde.I32Proxy>>(), typeof(Test).GetField("data"))
+    }
+    );
+}

--- a/test/Serde.Generation.Test/test_output/SerdeTests.DictionaryWithEqArrayKey/Test.ISerdeProvider.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/SerdeTests.DictionaryWithEqArrayKey/Test.ISerdeProvider.g.verified.cs
@@ -1,0 +1,6 @@
+﻿//HintName: Test.ISerdeProvider.g.cs
+partial class Test : Serde.ISerdeProvider<Test, Test._SerdeObj, Test>
+{
+    static Test._SerdeObj global::Serde.ISerdeProvider<Test, Test._SerdeObj, Test>.Instance { get; }
+        = new Test._SerdeObj();
+}


### PR DESCRIPTION
SerdeTypeOptions wasn't be handled in a nested case, resulting in proxies being dropped.
This change fixes that, and refactors the proxy handler to share more code, reducing the
likelihood of this in the future.

Fixes https://github.com/serdedotnet/serde/issues/300.