### PR TITLE
Preserve initializers in deserialization

### DIFF
--- a/src/generator/DataMemberSymbol.cs
+++ b/src/generator/DataMemberSymbol.cs
@@ -1,10 +1,12 @@
 
 using System;
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Linq;
 using System.Text;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace Serde
@@ -188,11 +190,10 @@ namespace Serde
         }
 
         /// <summary>
-        /// Returns the initializer expression text for the field/property, or null if there is none.
-        /// Only returns initializers that are safe to use without additional using directives
-        /// (literals, null, default, array creation with literals).
+        /// Returns the initializer expression text for the field/property with all symbols fully qualified,
+        /// or null if there is no initializer or the initializer cannot be safely preserved.
         /// </summary>
-        public string? GetInitializer()
+        public string? GetInitializer(Compilation compilation)
         {
             foreach (var syntaxRef in Symbol.DeclaringSyntaxReferences)
             {
@@ -203,37 +204,276 @@ namespace Serde
                     PropertyDeclarationSyntax p => p.Initializer,
                     _ => null
                 };
-                if (initializer is not null && IsSafeInitializer(initializer.Value))
+                if (initializer is not null)
                 {
-                    return initializer.Value.ToString();
+                    var semanticModel = compilation.GetSemanticModel(syntax.SyntaxTree);
+                    var qualifiedExpr = QualifyExpression(initializer.Value, semanticModel);
+                    // If the rewriter returned null, the expression can't be safely preserved
+                    if (qualifiedExpr is null)
+                    {
+                        return null;
+                    }
+                    return qualifiedExpr.ToFullString();
                 }
             }
             return null;
         }
 
         /// <summary>
-        /// Checks if an initializer expression is safe to copy without requiring additional context.
-        /// Safe expressions include: null, literals, default, and arrays of literals.
+        /// Rewrites an expression to fully qualify all type references.
+        /// Returns null if the expression cannot be safely preserved.
         /// </summary>
-        private static bool IsSafeInitializer(ExpressionSyntax expr)
+        private static ExpressionSyntax? QualifyExpression(ExpressionSyntax expr, SemanticModel semanticModel)
         {
-            return expr switch
+            var rewriter = new FullyQualifyingRewriter(semanticModel);
+            var result = rewriter.Visit(expr);
+            if (rewriter.Failed)
             {
-                // null, numeric literals, string literals, etc.
-                LiteralExpressionSyntax => true,
-                // null!, "string"!, etc.
-                PostfixUnaryExpressionSyntax { Operand: LiteralExpressionSyntax } => true,
-                // default or default(T) where T is a predefined type
-                DefaultExpressionSyntax def => def.Type is null or PredefinedTypeSyntax,
-                // default!, default(int)!
-                PostfixUnaryExpressionSyntax { Operand: DefaultExpressionSyntax def } => def.Type is null or PredefinedTypeSyntax,
-                // new[] { ... } with safe elements
-                ImplicitArrayCreationExpressionSyntax arr => arr.Initializer.Expressions.All(IsSafeInitializer),
-                // new T[] { ... } with keyword type and safe elements
-                ArrayCreationExpressionSyntax { Type.ElementType: PredefinedTypeSyntax } arr
-                    => arr.Initializer?.Expressions.All(IsSafeInitializer) ?? true,
-                _ => false
-            };
+                return null;
+            }
+            return (ExpressionSyntax?)result;
+        }
+
+        /// <summary>
+        /// Format for fully qualified symbol names with global:: prefix.
+        /// </summary>
+        private static readonly SymbolDisplayFormat s_fullyQualifiedFormat = SymbolDisplayFormat.FullyQualifiedFormat
+            .WithMemberOptions(SymbolDisplayMemberOptions.IncludeContainingType);
+
+        /// <summary>
+        /// A syntax rewriter that fully qualifies all type and member references.
+        /// Sets Failed to true if the expression cannot be safely preserved.
+        /// </summary>
+        private sealed class FullyQualifyingRewriter : CSharpSyntaxRewriter
+        {
+            private readonly SemanticModel _semanticModel;
+
+            public bool Failed { get; private set; }
+
+            public FullyQualifyingRewriter(SemanticModel semanticModel)
+            {
+                _semanticModel = semanticModel;
+            }
+
+            public override SyntaxNode? VisitIdentifierName(IdentifierNameSyntax node)
+            {
+                var symbolInfo = _semanticModel.GetSymbolInfo(node);
+                if (symbolInfo.Symbol is ITypeSymbol typeSymbol)
+                {
+                    var fqn = typeSymbol.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
+                    return SyntaxFactory.ParseTypeName(fqn).WithTriviaFrom(node);
+                }
+                return base.VisitIdentifierName(node);
+            }
+
+            public override SyntaxNode? VisitPredefinedType(PredefinedTypeSyntax node)
+            {
+                // Predefined types like 'string', 'int' are always in scope - no need to qualify
+                return base.VisitPredefinedType(node);
+            }
+
+            public override SyntaxNode? VisitMemberAccessExpression(MemberAccessExpressionSyntax node)
+            {
+                var symbolInfo = _semanticModel.GetSymbolInfo(node);
+                var symbol = symbolInfo.Symbol;
+
+                // Handle static field/property/method access like string.Empty or Console.WriteLine
+                if (symbol is IFieldSymbol { IsStatic: true } or
+                    IPropertySymbol { IsStatic: true } or
+                    IMethodSymbol { IsStatic: true })
+                {
+                    // Use ToDisplayString to get fully qualified member access
+                    var fqn = symbol.ToDisplayString(s_fullyQualifiedFormat);
+                    return SyntaxFactory.ParseExpression(fqn).WithTriviaFrom(node);
+                }
+
+                // For instance member access, just qualify the expression part
+                return base.VisitMemberAccessExpression(node);
+            }
+
+            public override SyntaxNode? VisitInvocationExpression(InvocationExpressionSyntax node)
+            {
+                var symbolInfo = _semanticModel.GetSymbolInfo(node);
+
+                // Check if this is an extension method call
+                if (symbolInfo.Symbol is IMethodSymbol { IsExtensionMethod: true } method)
+                {
+                    // Rewrite extension method call to explicit static call
+                    // e.g., list.ToImmutableArray() -> ImmutableArray.ToImmutableArray(list)
+                    var containingType = method.ContainingType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
+                    var methodName = method.Name;
+
+                    // Get the receiver (the 'this' argument) from the member access
+                    ExpressionSyntax? receiver = null;
+                    if (node.Expression is MemberAccessExpressionSyntax memberAccess)
+                    {
+                        receiver = (ExpressionSyntax?)Visit(memberAccess.Expression);
+                    }
+
+                    // Build the argument list: receiver + original arguments
+                    var arguments = new List<ArgumentSyntax>();
+                    if (receiver is not null)
+                    {
+                        arguments.Add(SyntaxFactory.Argument(receiver));
+                    }
+                    foreach (var arg in node.ArgumentList.Arguments)
+                    {
+                        var visitedArg = (ArgumentSyntax?)Visit(arg) ?? arg;
+                        arguments.Add(visitedArg);
+                    }
+
+                    // Handle generic method type arguments
+                    SimpleNameSyntax methodNameSyntax;
+                    if (method.TypeArguments.Length > 0)
+                    {
+                        var typeArgs = method.TypeArguments
+                            .Select(t => SyntaxFactory.ParseTypeName(t.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat)))
+                            .ToArray();
+                        methodNameSyntax = SyntaxFactory.GenericName(
+                            SyntaxFactory.Identifier(methodName),
+                            SyntaxFactory.TypeArgumentList(SyntaxFactory.SeparatedList(typeArgs)));
+                    }
+                    else
+                    {
+                        methodNameSyntax = SyntaxFactory.IdentifierName(methodName);
+                    }
+
+                    // Build: ContainingType.MethodName(receiver, args...)
+                    var qualifiedMethod = SyntaxFactory.MemberAccessExpression(
+                        SyntaxKind.SimpleMemberAccessExpression,
+                        SyntaxFactory.ParseTypeName(containingType),
+                        methodNameSyntax);
+
+                    return SyntaxFactory.InvocationExpression(
+                        qualifiedMethod,
+                        SyntaxFactory.ArgumentList(SyntaxFactory.SeparatedList(arguments)))
+                        .WithTriviaFrom(node);
+                }
+
+                return base.VisitInvocationExpression(node);
+            }
+
+            public override SyntaxNode? VisitObjectCreationExpression(ObjectCreationExpressionSyntax node)
+            {
+                // If there's a complex initializer (collection init, etc.), don't preserve
+                if (node.Initializer is not null)
+                {
+                    Failed = true;
+                    return node;
+                }
+
+                var typeInfo = _semanticModel.GetTypeInfo(node);
+                if (typeInfo.Type is INamedTypeSymbol namedType)
+                {
+                    // Only preserve object creation if:
+                    // 1. It has arguments (constructor with params)
+                    // 2. It's a value type (structs always have parameterless constructors)
+                    // 3. It has a parameterless constructor
+                    bool hasArgs = node.ArgumentList?.Arguments.Count > 0;
+                    bool isValueType = namedType.IsValueType;
+                    bool hasParameterlessCtor = namedType.InstanceConstructors
+                        .Any(c => c.Parameters.Length == 0 && c.DeclaredAccessibility == Accessibility.Public);
+
+                    if (!hasArgs && !isValueType && !hasParameterlessCtor)
+                    {
+                        // Can't safely preserve this - the type doesn't have a parameterless constructor
+                        Failed = true;
+                        return node;
+                    }
+
+                    var fqn = namedType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
+                    var qualifiedType = SyntaxFactory.ParseTypeName(fqn)
+                        .WithLeadingTrivia(node.Type.GetLeadingTrivia());
+
+                    var newArgs = node.ArgumentList is not null
+                        ? (ArgumentListSyntax?)Visit(node.ArgumentList)
+                        : null;
+
+                    return SyntaxFactory.ObjectCreationExpression(
+                        node.NewKeyword,
+                        qualifiedType,
+                        newArgs,
+                        null);
+                }
+                return base.VisitObjectCreationExpression(node);
+            }
+
+            public override SyntaxNode? VisitImplicitObjectCreationExpression(ImplicitObjectCreationExpressionSyntax node)
+            {
+                // Target-typed new like: new() { ... } or new(args)
+                // These are complex to handle correctly - fail for now
+                Failed = true;
+                return node;
+            }
+
+            public override SyntaxNode? VisitImplicitArrayCreationExpression(ImplicitArrayCreationExpressionSyntax node)
+            {
+                // Implicit array like: new[] { 1, 2, 3 } is complex - don't preserve
+                Failed = true;
+                return node;
+            }
+
+            public override SyntaxNode? VisitGenericName(GenericNameSyntax node)
+            {
+                var symbolInfo = _semanticModel.GetSymbolInfo(node);
+                if (symbolInfo.Symbol is ITypeSymbol typeSymbol)
+                {
+                    var fqn = typeSymbol.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
+                    return SyntaxFactory.ParseTypeName(fqn).WithTriviaFrom(node);
+                }
+                return base.VisitGenericName(node);
+            }
+
+            public override SyntaxNode? VisitArrayCreationExpression(ArrayCreationExpressionSyntax node)
+            {
+                // Array creation with initializer is complex - don't preserve
+                if (node.Initializer is not null)
+                {
+                    Failed = true;
+                    return node;
+                }
+                return base.VisitArrayCreationExpression(node);
+            }
+
+            public override SyntaxNode? VisitTypeOfExpression(TypeOfExpressionSyntax node)
+            {
+                var typeInfo = _semanticModel.GetTypeInfo(node.Type);
+                if (typeInfo.Type is not null)
+                {
+                    var fqn = typeInfo.Type.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
+                    return SyntaxFactory.TypeOfExpression(SyntaxFactory.ParseTypeName(fqn))
+                        .WithTriviaFrom(node);
+                }
+                return base.VisitTypeOfExpression(node);
+            }
+
+            public override SyntaxNode? VisitDefaultExpression(DefaultExpressionSyntax node)
+            {
+                if (node.Type is not null)
+                {
+                    var typeInfo = _semanticModel.GetTypeInfo(node.Type);
+                    if (typeInfo.Type is not null)
+                    {
+                        var fqn = typeInfo.Type.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
+                        return SyntaxFactory.DefaultExpression(SyntaxFactory.ParseTypeName(fqn))
+                            .WithTriviaFrom(node);
+                    }
+                }
+                return base.VisitDefaultExpression(node);
+            }
+
+            public override SyntaxNode? VisitCastExpression(CastExpressionSyntax node)
+            {
+                var typeInfo = _semanticModel.GetTypeInfo(node.Type);
+                if (typeInfo.Type is not null)
+                {
+                    var fqn = typeInfo.Type.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
+                    var newExpr = (ExpressionSyntax?)Visit(node.Expression) ?? node.Expression;
+                    return SyntaxFactory.CastExpression(SyntaxFactory.ParseTypeName(fqn), newExpr)
+                        .WithTriviaFrom(node);
+                }
+                return base.VisitCastExpression(node);
+            }
         }
     }
 }

--- a/src/generator/DeserializeImplGen.cs
+++ b/src/generator/DeserializeImplGen.cs
@@ -302,7 +302,8 @@ namespace Serde
                         readValueCall = $"ReadValue<{memberType}, {memberType}>";
                     }
                     var localName = GetLocalName(m);
-                    localsBuilder.AppendLine($"{memberType} {localName} = default!;");
+                    var initializer = m.GetInitializer() ?? "default!";
+                    localsBuilder.AppendLine($"{memberType} {localName} = {initializer};");
 
                     var typeOptions = SymbolUtilities.GetTypeOptions(type);
                     var duplicateKeyCheck = !typeOptions.AllowDuplicateKeys

--- a/src/generator/DeserializeImplGen.cs
+++ b/src/generator/DeserializeImplGen.cs
@@ -302,7 +302,7 @@ namespace Serde
                         readValueCall = $"ReadValue<{memberType}, {memberType}>";
                     }
                     var localName = GetLocalName(m);
-                    var initializer = m.GetInitializer() ?? "default!";
+                    var initializer = m.GetInitializer(context.Compilation) ?? "default!";
                     localsBuilder.AppendLine($"{memberType} {localName} = {initializer};");
 
                     var typeOptions = SymbolUtilities.GetTypeOptions(type);

--- a/test/Serde.Generation.Test/DeserializeTests.cs
+++ b/test/Serde.Generation.Test/DeserializeTests.cs
@@ -192,6 +192,27 @@ partial class ArrayField
         }
 
         [Fact]
+        public Task FieldInitializers()
+        {
+            var src = """
+using Serde;
+[GenerateDeserialize]
+partial class C
+{
+    // Safe initializers - should be preserved
+    public string Str = "hello";
+    public int Num = 42;
+    public bool Flag = true;
+    public string? Nullable = null;
+
+    // Unsafe initializers - should fall back to default!
+    public string FromMethod = string.Empty;
+}
+""";
+            return VerifyDeserialize(src);
+        }
+
+        [Fact]
         public Task EnumMember()
         {
             var src = @"

--- a/test/Serde.Generation.Test/DeserializeTests.cs
+++ b/test/Serde.Generation.Test/DeserializeTests.cs
@@ -205,8 +205,26 @@ partial class C
     public bool Flag = true;
     public string? Nullable = null;
 
-    // Unsafe initializers - should fall back to default!
+    // Initializers with predefined type static members
     public string FromMethod = string.Empty;
+}
+""";
+            return VerifyDeserialize(src);
+        }
+
+        [Fact]
+        public Task ExtensionMethodInitializer()
+        {
+            var src = """
+using Serde;
+using System.Collections.Immutable;
+using System.Linq;
+
+[GenerateDeserialize]
+partial class C
+{
+    // Extension method - should be rewritten to static call
+    public ImmutableArray<int> Arr = new[] { 1, 2, 3 }.ToImmutableArray();
 }
 """;
             return VerifyDeserialize(src);

--- a/test/Serde.Generation.Test/test_output/AllInOneTest.GeneratorTest/Serde.Test.AllInOne.IDeserialize.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/AllInOneTest.GeneratorTest/Serde.Test.AllInOne.IDeserialize.g.verified.cs
@@ -27,17 +27,17 @@ partial record AllInOne
             int _l_intfield = default!;
             long _l_longfield = default!;
             System.Int128 _l_int128field = default!;
-            string _l_stringfield = default!;
+            string _l_stringfield = "StringValue";
             System.DateTimeOffset _l_datetimeoffsetfield = default!;
             System.DateTime _l_datetimefield = default!;
             System.DateOnly _l_dateonlyfield = default!;
             System.TimeOnly _l_timeonlyfield = default!;
             System.Guid _l_guidfield = default!;
             string _l_escapedstringfield = default!;
-            string? _l_nullstringfield = default!;
-            uint[] _l_uintarr = default!;
-            int[][] _l_nestedarr = default!;
-            byte[] _l_bytearr = default!;
+            string? _l_nullstringfield = null;
+            uint[] _l_uintarr = null!;
+            int[][] _l_nestedarr = null!;
+            byte[] _l_bytearr = null!;
             System.Collections.Immutable.ImmutableArray<int> _l_intimm = default!;
             Serde.Test.AllInOne.ColorEnum _l_color = default!;
 

--- a/test/Serde.Generation.Test/test_output/DeserializeTests/Array#ArrayField.IDeserialize.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/DeserializeTests/Array#ArrayField.IDeserialize.g.verified.cs
@@ -12,7 +12,7 @@ partial class ArrayField
 
         ArrayField Serde.IDeserialize<ArrayField>.Deserialize(IDeserializer deserializer)
         {
-            int[] _l_intarr = default!;
+            int[] _l_intarr = new[] { 1, 2, 3 };
 
             byte _r_assignedValid = 0;
 

--- a/test/Serde.Generation.Test/test_output/DeserializeTests/ExtensionMethodInitializer#C.IDeserialize.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/DeserializeTests/ExtensionMethodInitializer#C.IDeserialize.g.verified.cs
@@ -1,18 +1,18 @@
-﻿//HintName: ArrayField.IDeserialize.g.cs
+﻿//HintName: C.IDeserialize.g.cs
 
 #nullable enable
 
 using System;
 using Serde;
-partial class ArrayField
+partial class C
 {
-    sealed partial class _DeObj : Serde.IDeserialize<ArrayField>
+    sealed partial class _DeObj : Serde.IDeserialize<C>
     {
-        global::Serde.ISerdeInfo global::Serde.ISerdeInfoProvider.SerdeInfo => ArrayField.s_serdeInfo;
+        global::Serde.ISerdeInfo global::Serde.ISerdeInfoProvider.SerdeInfo => C.s_serdeInfo;
 
-        ArrayField Serde.IDeserialize<ArrayField>.Deserialize(IDeserializer deserializer)
+        C Serde.IDeserialize<C>.Deserialize(IDeserializer deserializer)
         {
-            int[] _l_intarr = default!;
+            System.Collections.Immutable.ImmutableArray<int> _l_arr = default!;
 
             byte _r_assignedValid = 0;
 
@@ -30,7 +30,7 @@ partial class ArrayField
                 {
                     case 0:
                         Serde.DeserializeException.ThrowIfDuplicate(_r_assignedValid, 0, _l_serdeInfo);
-                        _l_intarr = typeDeserialize.ReadValue<int[], Serde.ArrayProxy.De<int, global::Serde.I32Proxy>>(_l_serdeInfo, _l_index_);
+                        _l_arr = typeDeserialize.ReadBoxedValue<System.Collections.Immutable.ImmutableArray<int>, Serde.ImmutableArrayProxy.De<int, global::Serde.I32Proxy>>(_l_serdeInfo, _l_index_);
                         _r_assignedValid |= ((byte)1) << 0;
                         break;
                     case Serde.ITypeDeserializer.IndexNotFound:
@@ -44,8 +44,8 @@ partial class ArrayField
             {
                 throw Serde.DeserializeException.UnassignedMember();
             }
-            var newType = new ArrayField() {
-                IntArr = _l_intarr,
+            var newType = new C() {
+                Arr = _l_arr,
             };
 
             return newType;

--- a/test/Serde.Generation.Test/test_output/DeserializeTests/ExtensionMethodInitializer#C.IDeserializeProvider.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/DeserializeTests/ExtensionMethodInitializer#C.IDeserializeProvider.g.verified.cs
@@ -1,0 +1,6 @@
+﻿//HintName: C.IDeserializeProvider.g.cs
+partial class C : Serde.IDeserializeProvider<C>
+{
+    static global::Serde.IDeserialize<C> global::Serde.IDeserializeProvider<C>.Instance { get; }
+        = new C._DeObj();
+}

--- a/test/Serde.Generation.Test/test_output/DeserializeTests/ExtensionMethodInitializer#C.ISerdeInfoProvider.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/DeserializeTests/ExtensionMethodInitializer#C.ISerdeInfoProvider.g.verified.cs
@@ -1,0 +1,13 @@
+﻿//HintName: C.ISerdeInfoProvider.g.cs
+
+#nullable enable
+partial class C
+{
+    private static global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
+        "C",
+    typeof(C).GetCustomAttributesData(),
+    new (string, global::Serde.ISerdeInfo, System.Reflection.MemberInfo?)[] {
+        ("arr", global::Serde.SerdeInfoProvider.GetDeserializeInfo<System.Collections.Immutable.ImmutableArray<int>, Serde.ImmutableArrayProxy.De<int, global::Serde.I32Proxy>>(), typeof(C).GetField("Arr"))
+    }
+    );
+}

--- a/test/Serde.Generation.Test/test_output/DeserializeTests/FieldInitializers#C.IDeserialize.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/DeserializeTests/FieldInitializers#C.IDeserialize.g.verified.cs
@@ -1,0 +1,82 @@
+﻿//HintName: C.IDeserialize.g.cs
+
+#nullable enable
+
+using System;
+using Serde;
+partial class C
+{
+    sealed partial class _DeObj : Serde.IDeserialize<C>
+    {
+        global::Serde.ISerdeInfo global::Serde.ISerdeInfoProvider.SerdeInfo => C.s_serdeInfo;
+
+        C Serde.IDeserialize<C>.Deserialize(IDeserializer deserializer)
+        {
+            string _l_str = "hello";
+            int _l_num = 42;
+            bool _l_flag = true;
+            string? _l_nullable = null;
+            string _l_frommethod = default!;
+
+            byte _r_assignedValid = 0;
+
+            var _l_serdeInfo = global::Serde.SerdeInfoProvider.GetInfo(this);
+            var typeDeserialize = deserializer.ReadType(_l_serdeInfo);
+            while (true)
+            {
+                var (_l_index_, _) = typeDeserialize.TryReadIndexWithName(_l_serdeInfo);
+                if (_l_index_ == Serde.ITypeDeserializer.EndOfType)
+                {
+                    break;
+                }
+
+                switch (_l_index_)
+                {
+                    case 0:
+                        Serde.DeserializeException.ThrowIfDuplicate(_r_assignedValid, 0, _l_serdeInfo);
+                        _l_str = typeDeserialize.ReadString(_l_serdeInfo, _l_index_);
+                        _r_assignedValid |= ((byte)1) << 0;
+                        break;
+                    case 1:
+                        Serde.DeserializeException.ThrowIfDuplicate(_r_assignedValid, 1, _l_serdeInfo);
+                        _l_num = typeDeserialize.ReadI32(_l_serdeInfo, _l_index_);
+                        _r_assignedValid |= ((byte)1) << 1;
+                        break;
+                    case 2:
+                        Serde.DeserializeException.ThrowIfDuplicate(_r_assignedValid, 2, _l_serdeInfo);
+                        _l_flag = typeDeserialize.ReadBool(_l_serdeInfo, _l_index_);
+                        _r_assignedValid |= ((byte)1) << 2;
+                        break;
+                    case 3:
+                        Serde.DeserializeException.ThrowIfDuplicate(_r_assignedValid, 3, _l_serdeInfo);
+                        _l_nullable = typeDeserialize.ReadValue<string?, Serde.NullableRefProxy.De<string, global::Serde.StringProxy>>(_l_serdeInfo, _l_index_);
+                        _r_assignedValid |= ((byte)1) << 3;
+                        break;
+                    case 4:
+                        Serde.DeserializeException.ThrowIfDuplicate(_r_assignedValid, 4, _l_serdeInfo);
+                        _l_frommethod = typeDeserialize.ReadString(_l_serdeInfo, _l_index_);
+                        _r_assignedValid |= ((byte)1) << 4;
+                        break;
+                    case Serde.ITypeDeserializer.IndexNotFound:
+                        typeDeserialize.SkipValue(_l_serdeInfo, _l_index_);
+                        break;
+                    default:
+                        throw new InvalidOperationException("Unexpected index: " + _l_index_);
+                }
+            }
+            if ((_r_assignedValid & 0b10111) != 0b10111)
+            {
+                throw Serde.DeserializeException.UnassignedMember();
+            }
+            var newType = new C() {
+                Str = _l_str,
+                Num = _l_num,
+                Flag = _l_flag,
+                Nullable = _l_nullable,
+                FromMethod = _l_frommethod,
+            };
+
+            return newType;
+        }
+    }
+}

--- a/test/Serde.Generation.Test/test_output/DeserializeTests/FieldInitializers#C.IDeserialize.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/DeserializeTests/FieldInitializers#C.IDeserialize.g.verified.cs
@@ -16,7 +16,7 @@ partial class C
             int _l_num = 42;
             bool _l_flag = true;
             string? _l_nullable = null;
-            string _l_frommethod = default!;
+            string _l_frommethod = string.Empty;
 
             byte _r_assignedValid = 0;
 

--- a/test/Serde.Generation.Test/test_output/DeserializeTests/FieldInitializers#C.IDeserializeProvider.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/DeserializeTests/FieldInitializers#C.IDeserializeProvider.g.verified.cs
@@ -1,0 +1,6 @@
+﻿//HintName: C.IDeserializeProvider.g.cs
+partial class C : Serde.IDeserializeProvider<C>
+{
+    static global::Serde.IDeserialize<C> global::Serde.IDeserializeProvider<C>.Instance { get; }
+        = new C._DeObj();
+}

--- a/test/Serde.Generation.Test/test_output/DeserializeTests/FieldInitializers#C.ISerdeInfoProvider.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/DeserializeTests/FieldInitializers#C.ISerdeInfoProvider.g.verified.cs
@@ -1,0 +1,17 @@
+﻿//HintName: C.ISerdeInfoProvider.g.cs
+
+#nullable enable
+partial class C
+{
+    private static global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
+        "C",
+    typeof(C).GetCustomAttributesData(),
+    new (string, global::Serde.ISerdeInfo, System.Reflection.MemberInfo?)[] {
+        ("str", global::Serde.SerdeInfoProvider.GetDeserializeInfo<string, global::Serde.StringProxy>(), typeof(C).GetField("Str")),
+        ("num", global::Serde.SerdeInfoProvider.GetDeserializeInfo<int, global::Serde.I32Proxy>(), typeof(C).GetField("Num")),
+        ("flag", global::Serde.SerdeInfoProvider.GetDeserializeInfo<bool, global::Serde.BoolProxy>(), typeof(C).GetField("Flag")),
+        ("nullable", global::Serde.SerdeInfoProvider.GetDeserializeInfo<string?, Serde.NullableRefProxy.De<string, global::Serde.StringProxy>>(), typeof(C).GetField("Nullable")),
+        ("fromMethod", global::Serde.SerdeInfoProvider.GetDeserializeInfo<string, global::Serde.StringProxy>(), typeof(C).GetField("FromMethod"))
+    }
+    );
+}

--- a/test/Serde.Generation.Test/test_output/ProxyTests.ExplicitInvalidGenericWrapper/Container.IDeserialize.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/ProxyTests.ExplicitInvalidGenericWrapper/Container.IDeserialize.g.verified.cs
@@ -12,7 +12,7 @@ partial record Container
 
         Container Serde.IDeserialize<Container>.Deserialize(IDeserializer deserializer)
         {
-            Original? _l_sdkdir = default!;
+            Original? _l_sdkdir = null;
 
             byte _r_assignedValid = 0;
 

--- a/test/Serde.Generation.Test/test_output/ProxyTests.ExplicitNullableProxy/Container.IDeserialize.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/ProxyTests.ExplicitNullableProxy/Container.IDeserialize.g.verified.cs
@@ -12,7 +12,7 @@ partial record Container
 
         Container Serde.IDeserialize<Container>.Deserialize(IDeserializer deserializer)
         {
-            Original? _l_sdkdir = default!;
+            Original? _l_sdkdir = null;
 
             byte _r_assignedValid = 0;
 

--- a/test/Serde.Generation.Test/test_output/ProxyTests.NestedDeserializeWrap/C.IDeserialize.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/ProxyTests.NestedDeserializeWrap/C.IDeserialize.g.verified.cs
@@ -12,7 +12,7 @@ partial class C
 
         C Serde.IDeserialize<C>.Deserialize(IDeserializer deserializer)
         {
-            System.Runtime.InteropServices.ComTypes.BIND_OPTS _l_s = default!;
+            System.Runtime.InteropServices.ComTypes.BIND_OPTS _l_s = new global::System.Runtime.InteropServices.ComTypes.BIND_OPTS();
 
             byte _r_assignedValid = 0;
 

--- a/test/Serde.Generation.Test/test_output/SerdeTests.CommandResponseTest/ArgumentInfo.ISerde.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/SerdeTests.CommandResponseTest/ArgumentInfo.ISerde.g.verified.cs
@@ -20,8 +20,8 @@ partial class ArgumentInfo
         }
         ArgumentInfo Serde.IDeserialize<ArgumentInfo>.Deserialize(IDeserializer deserializer)
         {
-            string _l_name = default!;
-            string _l_value = default!;
+            string _l_name = string.Empty;
+            string _l_value = string.Empty;
 
             byte _r_assignedValid = 0;
 

--- a/test/Serde.Generation.Test/test_output/SerdeTests.CommandResponseTest/CommandResponse.ISerde.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/SerdeTests.CommandResponseTest/CommandResponse.ISerde.g.verified.cs
@@ -24,7 +24,7 @@ partial class CommandResponse<TResult, TProxy>
         CommandResponse<TResult, TProxy> Serde.IDeserialize<CommandResponse<TResult, TProxy>>.Deserialize(IDeserializer deserializer)
         {
             int _l_status = default!;
-            string _l_message = default!;
+            string _l_message = string.Empty;
             System.Collections.Generic.List<ArgumentInfo>? _l_arguments = default!;
             TResult _l_results = default!;
             long _l_duration = default!;

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.AllInOne.IDeserialize.g.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.AllInOne.IDeserialize.g.cs
@@ -26,17 +26,17 @@ partial record AllInOne
             int _l_intfield = default!;
             long _l_longfield = default!;
             System.Int128 _l_int128field = default!;
-            string _l_stringfield = default!;
+            string _l_stringfield = "StringValue";
             System.DateTimeOffset _l_datetimeoffsetfield = default!;
             System.DateTime _l_datetimefield = default!;
             System.DateOnly _l_dateonlyfield = default!;
             System.TimeOnly _l_timeonlyfield = default!;
             System.Guid _l_guidfield = default!;
             string _l_escapedstringfield = default!;
-            string? _l_nullstringfield = default!;
-            uint[] _l_uintarr = default!;
-            int[][] _l_nestedarr = default!;
-            byte[] _l_bytearr = default!;
+            string? _l_nullstringfield = null;
+            uint[] _l_uintarr = null!;
+            int[][] _l_nestedarr = null!;
+            byte[] _l_bytearr = null!;
             System.Collections.Immutable.ImmutableArray<int> _l_intimm = default!;
             Serde.Test.AllInOne.ColorEnum _l_color = default!;
 

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonDeserializeTests.NullableFields.IDeserialize.g.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonDeserializeTests.NullableFields.IDeserialize.g.cs
@@ -16,7 +16,7 @@ partial class JsonDeserializeTests
 
             Serde.Test.JsonDeserializeTests.NullableFields Serde.IDeserialize<Serde.Test.JsonDeserializeTests.NullableFields>.Deserialize(IDeserializer deserializer)
             {
-                string? _l_s = default!;
+                string? _l_s = null;
                 System.Collections.Generic.Dictionary<string, string?> _l_dict = default!;
 
                 byte _r_assignedValid = 0;

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonDeserializeTests.ThrowMissingFalse.IDeserialize.g.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonDeserializeTests.ThrowMissingFalse.IDeserialize.g.cs
@@ -17,7 +17,7 @@ partial class JsonDeserializeTests
             Serde.Test.JsonDeserializeTests.ThrowMissingFalse Serde.IDeserialize<Serde.Test.JsonDeserializeTests.ThrowMissingFalse>.Deserialize(IDeserializer deserializer)
             {
                 string _l_present = default!;
-                bool _l_missing = default!;
+                bool _l_missing = false;
 
                 byte _r_assignedValid = 0;
 


### PR DESCRIPTION
Right now initializers are effectively overwritten. For required members this doesn't matter much as they will have to be initialized anyway. But for optional members, or when DenyMissingMembers is false, this is problematic.

The current behavior is conservative -- if an initializer isn't known to be "invariant" across initialization, we fall back to default value. This is probably not the right long-term plan, but it is a fine first step.