### PR TITLE
Add an easy way to register proxies

### DIFF
--- a/src/generator/DeserializeImplGen.cs
+++ b/src/generator/DeserializeImplGen.cs
@@ -1,13 +1,13 @@
 
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Linq;
 using System.Text;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
 using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 using static Serde.Diagnostics;
 using static Serde.SerdeImplRoslynGenerator;
@@ -200,6 +200,8 @@ namespace Serde
         {
             Debug.Assert(type.TypeKind != TypeKind.Enum);
 
+            var classScopeProxyMap = new ProxyMap(type);
+
             var members = SymbolUtilities.GetDataMembers(type, SerdeUsage.Both);
             var typeFqn = typeSyntax.ToString();
             var assignedVarType = members.Count switch {
@@ -267,7 +269,14 @@ namespace Serde
                         ? "ReadValue"
                         : "ReadBoxedValue";
                     string readValueCall;
-                    if (Proxies.TryGetExplicitWrapper(m, context, SerdeUsage.Deserialize, inProgress) is { } explicitWrap)
+
+                    var proxyContext = new ProxyContext()
+                    {
+                        ClassScopeMap = classScopeProxyMap,
+                        MemberScopeMap = new ProxyMap(m.Symbol)
+                    };
+
+                    if (Proxies.TryGetExplicitWrapper(m, context, SerdeUsage.Deserialize, inProgress, proxyContext) is { } explicitWrap)
                     {
                         readValueCall = $"{readMethodName}<{memberType}, {explicitWrap}>";
                     }
@@ -279,7 +288,7 @@ namespace Serde
                     {
                         readValueCall = $"Read{primitiveName}";
                     }
-                    else if (Proxies.TryGetImplicitWrapper(m.Type, context, SerdeUsage.Deserialize, inProgress) is { Proxy: { } wrap })
+                    else if (Proxies.TryGetImplicitWrapper(m.Type, context, SerdeUsage.Deserialize, inProgress, proxyContext) is { Proxy: { } wrap })
                     {
                         if (wrap == "global::Serde.GuidProxy")
                         {

--- a/src/generator/DeserializeImplGen.cs
+++ b/src/generator/DeserializeImplGen.cs
@@ -200,7 +200,7 @@ namespace Serde
         {
             Debug.Assert(type.TypeKind != TypeKind.Enum);
 
-            var classScopeProxyMap = new ProxyMap(type);
+            var classScopeProxyMap = ProxyMap.FromSymbol(type);
 
             var members = SymbolUtilities.GetDataMembers(type, SerdeUsage.Both);
             var typeFqn = typeSyntax.ToString();
@@ -270,11 +270,7 @@ namespace Serde
                         : "ReadBoxedValue";
                     string readValueCall;
 
-                    var proxyContext = new ProxyContext()
-                    {
-                        ClassScopeMap = classScopeProxyMap,
-                        MemberScopeMap = new ProxyMap(m.Symbol)
-                    };
+                    var proxyContext = ProxyContext.Create(classScopeProxyMap, ProxyMap.FromSymbol(m.Symbol));
 
                     if (Proxies.TryGetExplicitWrapper(m, context, SerdeUsage.Deserialize, inProgress, proxyContext) is { } explicitWrap)
                     {

--- a/src/generator/Diagnostics.cs
+++ b/src/generator/Diagnostics.cs
@@ -19,7 +19,6 @@ namespace Serde
         ERR_WrapperDoesntImplementInterface = 6,
         ERR_CantImplementAbstract = 7,
         ERR_CantFindTypeParameter = 8,
-        WARN_UseProxyIgnored = 9,
     }
 
     internal static class Diagnostics
@@ -34,7 +33,6 @@ namespace Serde
             ERR_WrapperDoesntImplementInterface => nameof(ERR_WrapperDoesntImplementInterface),
             ERR_CantImplementAbstract => nameof(ERR_CantImplementAbstract),
             ERR_CantFindTypeParameter => nameof(ERR_CantFindTypeParameter),
-            WARN_UseProxyIgnored => nameof(WARN_UseProxyIgnored),
         };
 
         public static Diagnostic CreateDiagnostic(DiagId id, Location location, params object[] args)

--- a/src/generator/Diagnostics.cs
+++ b/src/generator/Diagnostics.cs
@@ -19,6 +19,7 @@ namespace Serde
         ERR_WrapperDoesntImplementInterface = 6,
         ERR_CantImplementAbstract = 7,
         ERR_CantFindTypeParameter = 8,
+        WARN_UseProxyIgnored = 9,
     }
 
     internal static class Diagnostics
@@ -33,6 +34,7 @@ namespace Serde
             ERR_WrapperDoesntImplementInterface => nameof(ERR_WrapperDoesntImplementInterface),
             ERR_CantImplementAbstract => nameof(ERR_CantImplementAbstract),
             ERR_CantFindTypeParameter => nameof(ERR_CantFindTypeParameter),
+            WARN_UseProxyIgnored => nameof(WARN_UseProxyIgnored),
         };
 
         public static Diagnostic CreateDiagnostic(DiagId id, Location location, params object[] args)

--- a/src/generator/Proxies.cs
+++ b/src/generator/Proxies.cs
@@ -1,10 +1,11 @@
-using System.Linq;
 using Microsoft.CodeAnalysis;
-using System.Collections.Immutable;
+using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 using static Serde.Diagnostics;
 using static Serde.WellKnownTypes;
-using System.Diagnostics.CodeAnalysis;
 
 namespace Serde;
 
@@ -135,7 +136,8 @@ sealed partial class {{proxyName}};
         ITypeSymbol type,
         GeneratorExecutionContext context,
         SerdeUsage usage,
-        ImmutableList<(ITypeSymbol Receiver, ITypeSymbol Containing)> inProgress)
+        ImmutableList<(ITypeSymbol Receiver, ITypeSymbol Containing)> inProgress,
+        ProxyContext proxyContext)
     {
         (string?, string?)? valueTypeAndProxy = type switch
         {
@@ -145,7 +147,8 @@ sealed partial class {{proxyName}};
                     ImmutableArray.Create(((INamedTypeSymbol)type).TypeArguments[0]),
                     context,
                     usage,
-                    inProgress)),
+                    inProgress,
+                    proxyContext)),
 
             // This is rather subtle. One might think that we would want to use a
             // NullableRefWrapper for any reference type that could contain null. In fact, we
@@ -163,7 +166,8 @@ sealed partial class {{proxyName}};
                     ImmutableArray.Create(type.WithNullableAnnotation(NullableAnnotation.NotAnnotated)),
                     context,
                     usage,
-                    inProgress)),
+                    inProgress,
+                    proxyContext)),
 
             IArrayTypeSymbol and { IsSZArray: true, Rank: 1, ElementType: { } elemType } =>
                 (type.ToDisplayString(s_fqnFormat), MakeProxyString(
@@ -171,10 +175,11 @@ sealed partial class {{proxyName}};
                     ImmutableArray.Create(elemType),
                     context,
                     usage,
-                    inProgress)),
+                    inProgress,
+                    proxyContext)),
 
             INamedTypeSymbol t when TryGetWrapperComponents(t, context, usage) is (var ConvertedType, var WrapperType, var Args)
-                => (ConvertedType, MakeProxyString(WrapperType, Args, context, usage, inProgress)),
+                => (ConvertedType, MakeProxyString(WrapperType, Args, context, usage, inProgress, proxyContext)),
 
             _ => null,
         };
@@ -219,7 +224,8 @@ sealed partial class {{proxyName}};
         ImmutableArray<ITypeSymbol> elemTypes,
         GeneratorExecutionContext context,
         SerdeUsage usage,
-        ImmutableList<(ITypeSymbol Receiver, ITypeSymbol Containing)> inProgress)
+        ImmutableList<(ITypeSymbol Receiver, ITypeSymbol Containing)> inProgress,
+        ProxyContext proxyContext)
     {
         if (elemTypes.Length == 0)
         {
@@ -235,7 +241,7 @@ sealed partial class {{proxyName}};
 
         foreach (var elemType in elemTypes)
         {
-            if (TryGetProxyString(memberSymbol: null, elemType, context, usage, inProgress) is { } proxy)
+            if (TryGetProxyString(memberSymbol: null, elemType, context, usage, inProgress, proxyContext) is { } proxy)
             {
                 typeArgs.Add(proxy);
             }
@@ -261,12 +267,13 @@ sealed partial class {{proxyName}};
         ITypeSymbol type,
         GeneratorExecutionContext context,
         SerdeUsage usage,
-        ImmutableList<(ITypeSymbol Receiver, ITypeSymbol Containing)> inProgress)
+        ImmutableList<(ITypeSymbol Receiver, ITypeSymbol Containing)> inProgress,
+        ProxyContext proxyContext)
     {
         // Check for explicit proxy (member first, then type)
-        if (TryGetExplicitProxy(memberSymbol, type, usage, context) is { } proxyType)
+        if (TryGetExplicitProxy(memberSymbol, type, usage, context, proxyContext) is { } proxyType)
         {
-            return ResolveProxyString(proxyType, type, context, usage, inProgress, memberSymbol);
+            return ResolveProxyString(proxyType, type, context, usage, inProgress, memberSymbol, proxyContext);
         }
 
         // Then check if the type directly implements serde
@@ -276,7 +283,7 @@ sealed partial class {{proxyName}};
         }
 
         // Finally check implicit wrappers (primitives, enums, compound types)
-        if (TryGetImplicitWrapper(type, context, usage, inProgress) is { } wrapper)
+        if (TryGetImplicitWrapper(type, context, usage, inProgress, proxyContext) is { } wrapper)
         {
             return wrapper.Proxy;
         }
@@ -294,7 +301,8 @@ sealed partial class {{proxyName}};
         GeneratorExecutionContext context,
         SerdeUsage usage,
         ImmutableList<(ITypeSymbol Receiver, ITypeSymbol Containing)> inProgress,
-        ISymbol? memberSymbol)
+        ISymbol? memberSymbol,
+        ProxyContext proxyContext)
     {
         // If the proxy is an unconstructed generic type, construct it with the target's type arguments
         if (proxyType is INamedTypeSymbol { IsGenericType: true } namedProxy &&
@@ -306,7 +314,7 @@ sealed partial class {{proxyName}};
                 INamedTypeSymbol n => n.TypeArguments,
                 _ => ImmutableArray<ITypeSymbol>.Empty
             };
-            return MakeProxyString(baseName, typeArgs, context, usage, inProgress);
+            return MakeProxyString(baseName, typeArgs, context, usage, inProgress, proxyContext);
         }
 
         // Validate that the proxy implements the required interface
@@ -331,15 +339,16 @@ sealed partial class {{proxyName}};
         ISymbol? memberSymbol,
         ITypeSymbol type,
         SerdeUsage usage,
-        GeneratorExecutionContext context)
+        GeneratorExecutionContext context,
+        ProxyContext proxyContext)
     {
         // Check member first, then type
-        if (memberSymbol != null && TryGetProxyFromSymbol(memberSymbol, type, usage, context) is { } memberProxy)
+        if (memberSymbol != null && TryGetProxyFromSymbol(memberSymbol, type, usage, context, proxyContext) is { } memberProxy)
         {
             return memberProxy;
         }
 
-        return TryGetProxyFromSymbol(type, type, usage, context);
+        return TryGetProxyFromSymbol(type, type, usage, context, proxyContext);
     }
 
     /// <summary>
@@ -350,8 +359,13 @@ sealed partial class {{proxyName}};
         ISymbol symbol,
         ITypeSymbol typeToWrap,
         SerdeUsage usage,
-        GeneratorExecutionContext context)
+        GeneratorExecutionContext context,
+        ProxyContext proxyContext)
     {
+        if (proxyContext.TryResolve(typeToWrap, usage, out var specifiedProxyType))
+        {
+            return ResolveProxyForGenericType(specifiedProxyType, typeToWrap, symbol, usage, context);
+        }
         foreach (var attr in symbol.GetAttributes())
         {
             if (attr is { AttributeClass.Name: nameof(SerdeMemberOptions) or nameof(SerdeTypeOptions), NamedArguments: { } named })
@@ -488,7 +502,8 @@ sealed partial class {{proxyName}};
         ITypeSymbol elemType,
         GeneratorExecutionContext context,
         SerdeUsage usage,
-        ImmutableList<(ITypeSymbol Receiver, ITypeSymbol Containing)> inProgress)
+        ImmutableList<(ITypeSymbol Receiver, ITypeSymbol Containing)> inProgress,
+        ProxyContext proxyContext)
     {
         // If we're in the process of generating a proxy type for the given underlying, return
         // the proxy type we're currently generating. This is to avoid infinite recursion.
@@ -504,7 +519,7 @@ sealed partial class {{proxyName}};
         }
         return TryGetPrimitiveProxy(elemType)
             ?? TryGetEnumProxy(elemType, usage)
-            ?? TryGetCompoundWrapper(elemType, context, usage, inProgress);
+            ?? TryGetCompoundWrapper(elemType, context, usage, inProgress, proxyContext);
     }
 
     private static readonly SymbolDisplayFormat s_baseNameFormat = new(
@@ -525,12 +540,13 @@ sealed partial class {{proxyName}};
         DataMemberSymbol member,
         GeneratorExecutionContext context,
         SerdeUsage usage,
-        ImmutableList<(ITypeSymbol Receiver, ITypeSymbol Containing)> inProgress)
+        ImmutableList<(ITypeSymbol Receiver, ITypeSymbol Containing)> inProgress,
+        ProxyContext proxyContext)
     {
         // Check for explicit proxy on member or type (but not ImplementsSerde - that's handled by the caller)
-        if (TryGetExplicitProxy(member.Symbol, member.Type, usage, context) is { } proxyType)
+        if (TryGetExplicitProxy(member.Symbol, member.Type, usage, context, proxyContext) is { } proxyType)
         {
-            return ResolveProxyString(proxyType, member.Type, context, usage, inProgress, member.Symbol);
+            return ResolveProxyString(proxyType, member.Type, context, usage, inProgress, member.Symbol, proxyContext);
         }
         return null;
     }
@@ -589,4 +605,134 @@ internal static class SerdeUsageExt
         SerdeUsage.Both => "_SerdeObj",
         _ => throw ExceptionUtilities.Unreachable
     };
+}
+
+internal class ProxyMap
+{
+    public readonly Dictionary<SerdeUsage, Dictionary<INamedTypeSymbol, INamedTypeSymbol>> map = new()
+    {   
+        { SerdeUsage.Serialize, [] },
+        { SerdeUsage.Deserialize, [] },
+    };
+
+    private readonly bool isEmpty;
+
+    public ProxyMap()
+    {
+        isEmpty = true;
+    }
+
+    public ProxyMap(ISymbol symbol)
+    {
+        isEmpty = false;
+        foreach (var attr in symbol.GetAttributes())
+        {
+            if (attr.AttributeClass is null)
+            {
+                continue;
+            }
+            if (attr is { AttributeClass.Name: nameof(UseProxy), NamedArguments: { } namedArgs })
+            {
+                INamedTypeSymbol target = default!;
+                INamedTypeSymbol proxy = default!;
+                var usage = SerdeUsage.Both;
+                foreach (var arg in namedArgs)
+                {
+                    switch (arg)
+                    {
+                        case
+                        {
+                            Key: nameof(UseProxy.ForType),
+                            Value.Value: INamedTypeSymbol targetType
+                        }:
+                            {
+                                target = targetType.OriginalDefinition;
+                                break;
+                            }
+                        case
+                        {
+                            Key: nameof(UseProxy.Proxy),
+                            Value.Value: INamedTypeSymbol proxyType
+                        }:
+                            {
+                                proxy = proxyType;
+                                break;
+                            }
+                        case
+                        {
+                            Key: nameof(UseProxy.Usage),
+                            Value:
+                            {
+                                Kind: TypedConstantKind.Enum,
+                                Value: var rawUsage
+                            }
+                        } when rawUsage is not null:
+                            {
+                                var usageValue = Convert.ToUInt64(rawUsage);
+                                if ((usageValue & (byte)SerdeUsage.Both) == (byte)SerdeUsage.Both)
+                                {
+                                    usage = SerdeUsage.Both;
+                                }
+                                else if ((usageValue & (byte)SerdeUsage.Serialize) == (byte)SerdeUsage.Serialize)
+                                {
+                                    usage = SerdeUsage.Serialize; 
+                                }
+                                else if ((usageValue & (byte)SerdeUsage.Deserialize) == (byte)SerdeUsage.Deserialize)
+                                {
+                                    usage = SerdeUsage.Deserialize;
+                                }
+                                break;
+                            }
+                    }
+                }
+                if (usage.HasFlag(SerdeUsage.Serialize))
+                {
+                    map[SerdeUsage.Serialize][target] = proxy;
+                }
+                if (usage.HasFlag(SerdeUsage.Deserialize))
+                {
+                    map[SerdeUsage.Deserialize][target] = proxy;
+                }
+            }
+        }
+    }
+
+    public bool TryResolve(INamedTypeSymbol typeToWrap, SerdeUsage usage, out INamedTypeSymbol proxyType)
+    {
+        if (isEmpty)
+        {
+            proxyType = default!;
+            return false;
+        }
+        if (usage.HasFlag(SerdeUsage.Serialize))
+        {
+            return map[SerdeUsage.Serialize].TryGetValue(typeToWrap.OriginalDefinition, out proxyType);
+        }
+        if (usage.HasFlag(SerdeUsage.Deserialize))
+        {
+            return map[SerdeUsage.Deserialize].TryGetValue(typeToWrap.OriginalDefinition, out proxyType);
+        }
+        proxyType = default!;
+        return false;
+    }
+}
+
+internal class ProxyContext
+{
+    public required ProxyMap ClassScopeMap { get; init; }
+    public required ProxyMap MemberScopeMap { get; init; }
+
+    public bool TryResolve(ITypeSymbol typeToWrap, SerdeUsage usage, out INamedTypeSymbol proxyType)
+    {
+        if (typeToWrap is not INamedTypeSymbol namedType)
+        {
+            proxyType = default!;
+            return false;
+        }
+        if (MemberScopeMap.TryResolve(namedType, usage, out proxyType))
+        {
+            return true;
+        }
+        return ClassScopeMap.TryResolve(namedType, usage, out proxyType);
+    }
 }

--- a/src/generator/Proxies.cs
+++ b/src/generator/Proxies.cs
@@ -352,8 +352,9 @@ sealed partial class {{proxyName}};
     }
 
     /// <summary>
-    /// Checks a symbol's attributes for proxy specifications (both SerdeMemberOptions and SerdeTypeOptions).
+    /// Checks a symbol's attributes for proxy specifications (SerdeMemberOptions, SerdeTypeOptions, and UseProxy).
     /// For generic types, returns the nested Ser/De type from the proxy.
+    /// SerdeMember/TypeOptions takes precedence over UseProxy.
     /// </summary>
     private static ITypeSymbol? TryGetProxyFromSymbol(
         ISymbol symbol,
@@ -362,10 +363,6 @@ sealed partial class {{proxyName}};
         GeneratorExecutionContext context,
         ProxyContext proxyContext)
     {
-        if (proxyContext.TryResolve(typeToWrap, usage, out var specifiedProxyType))
-        {
-            return ResolveProxyForGenericType(specifiedProxyType, typeToWrap, symbol, usage, context);
-        }
         foreach (var attr in symbol.GetAttributes())
         {
             if (attr is { AttributeClass.Name: nameof(SerdeMemberOptions) or nameof(SerdeTypeOptions), NamedArguments: { } named })
@@ -428,6 +425,14 @@ sealed partial class {{proxyName}};
                 }
             }
         }
+
+        // Check if UseProxy also specifies a proxy for this type
+        if (proxyContext.TryGetProxy(typeToWrap, usage) is { } useProxyType)
+        {
+            // No SerdeMemberOptions proxy, use the UseProxy one
+            return ResolveProxyForGenericType(useProxyType, typeToWrap, symbol, usage, context);
+        }
+
         return null;
     }
 
@@ -607,24 +612,38 @@ internal static class SerdeUsageExt
     };
 }
 
-internal class ProxyMap
+internal readonly struct ProxyMap
 {
-    public readonly Dictionary<SerdeUsage, Dictionary<INamedTypeSymbol, INamedTypeSymbol>> map = new()
-    {   
-        { SerdeUsage.Serialize, [] },
-        { SerdeUsage.Deserialize, [] },
-    };
+    private readonly ImmutableDictionary<INamedTypeSymbol, INamedTypeSymbol> _serializeMap;
+    private readonly ImmutableDictionary<INamedTypeSymbol, INamedTypeSymbol> _deserializeMap;
 
-    private readonly bool isEmpty;
-
+    [Obsolete($"Use {nameof(Empty)} instead", error: true)]
     public ProxyMap()
     {
-        isEmpty = true;
+        _serializeMap = ImmutableDictionary<INamedTypeSymbol, INamedTypeSymbol>.Empty;
+        _deserializeMap = ImmutableDictionary<INamedTypeSymbol, INamedTypeSymbol>.Empty;
     }
 
-    public ProxyMap(ISymbol symbol)
+    private ProxyMap(
+        ImmutableDictionary<INamedTypeSymbol, INamedTypeSymbol> serializeMap,
+        ImmutableDictionary<INamedTypeSymbol, INamedTypeSymbol> deserializeMap)
     {
-        isEmpty = false;
+        _serializeMap = serializeMap;
+        _deserializeMap = deserializeMap;
+    }
+
+    public static readonly ProxyMap Empty =
+        new(
+            ImmutableDictionary<INamedTypeSymbol, INamedTypeSymbol>.Empty,
+            ImmutableDictionary<INamedTypeSymbol, INamedTypeSymbol>.Empty
+        );
+
+    public bool IsEmpty => _serializeMap.IsEmpty && _deserializeMap.IsEmpty;
+
+    public static ProxyMap FromSymbol(ISymbol symbol)
+    {
+        var serializeBuilder = ImmutableDictionary.CreateBuilder<INamedTypeSymbol, INamedTypeSymbol>(SymbolEqualityComparer.IncludeNullability);
+        var deserializeBuilder = ImmutableDictionary.CreateBuilder<INamedTypeSymbol, INamedTypeSymbol>(SymbolEqualityComparer.IncludeNullability);
         foreach (var attr in symbol.GetAttributes())
         {
             if (attr.AttributeClass is null)
@@ -633,9 +652,10 @@ internal class ProxyMap
             }
             if (attr is { AttributeClass.Name: nameof(UseProxy), NamedArguments: { } namedArgs })
             {
-                INamedTypeSymbol target = default!;
-                INamedTypeSymbol proxy = default!;
-                var usage = SerdeUsage.Both;
+                INamedTypeSymbol? target = null;
+                INamedTypeSymbol? proxy = null;
+                INamedTypeSymbol? serializeProxy = null;
+                INamedTypeSymbol? deserializeProxy = null;
                 foreach (var arg in namedArgs)
                 {
                     switch (arg)
@@ -660,79 +680,94 @@ internal class ProxyMap
                             }
                         case
                         {
-                            Key: nameof(UseProxy.Usage),
-                            Value:
+                            Key: nameof(UseProxy.SerializeProxy),
+                            Value.Value: INamedTypeSymbol proxyType
+                        }:
                             {
-                                Kind: TypedConstantKind.Enum,
-                                Value: var rawUsage
+                                serializeProxy = proxyType;
+                                break;
                             }
-                        } when rawUsage is not null:
+                        case
+                        {
+                            Key: nameof(UseProxy.DeserializeProxy),
+                            Value.Value: INamedTypeSymbol proxyType
+                        }:
                             {
-                                var usageValue = Convert.ToUInt64(rawUsage);
-                                if ((usageValue & (byte)SerdeUsage.Both) == (byte)SerdeUsage.Both)
-                                {
-                                    usage = SerdeUsage.Both;
-                                }
-                                else if ((usageValue & (byte)SerdeUsage.Serialize) == (byte)SerdeUsage.Serialize)
-                                {
-                                    usage = SerdeUsage.Serialize; 
-                                }
-                                else if ((usageValue & (byte)SerdeUsage.Deserialize) == (byte)SerdeUsage.Deserialize)
-                                {
-                                    usage = SerdeUsage.Deserialize;
-                                }
+                                deserializeProxy = proxyType;
                                 break;
                             }
                     }
                 }
-                if (usage.HasFlag(SerdeUsage.Serialize))
+                if (target is null)
                 {
-                    map[SerdeUsage.Serialize][target] = proxy;
+                    // TODO: report diagnostic for missing target
+                    continue;
                 }
-                if (usage.HasFlag(SerdeUsage.Deserialize))
+                if ((serializeProxy ?? proxy) is { } serProxy)
                 {
-                    map[SerdeUsage.Deserialize][target] = proxy;
+                    serializeBuilder[target] = serProxy;
+                }
+                if ((deserializeProxy ?? proxy) is { } deProxy)
+                {
+                    deserializeBuilder[target] = deProxy;
                 }
             }
         }
+        return new ProxyMap(serializeBuilder.ToImmutable(), deserializeBuilder.ToImmutable());
     }
 
-    public bool TryResolve(INamedTypeSymbol typeToWrap, SerdeUsage usage, out INamedTypeSymbol proxyType)
+    public INamedTypeSymbol? TryGetProxy(INamedTypeSymbol typeToWrap, SerdeUsage usage)
     {
-        if (isEmpty)
-        {
-            proxyType = default!;
-            return false;
-        }
         if (usage.HasFlag(SerdeUsage.Serialize))
         {
-            return map[SerdeUsage.Serialize].TryGetValue(typeToWrap.OriginalDefinition, out proxyType);
+            if (_serializeMap.TryGetValue(typeToWrap.OriginalDefinition, out var proxyType))
+            {
+                return proxyType;
+            }
         }
         if (usage.HasFlag(SerdeUsage.Deserialize))
         {
-            return map[SerdeUsage.Deserialize].TryGetValue(typeToWrap.OriginalDefinition, out proxyType);
+            if (_deserializeMap.TryGetValue(typeToWrap.OriginalDefinition, out var proxyType))
+            {
+                return proxyType;
+            }
         }
-        proxyType = default!;
-        return false;
+        return null;
     }
 }
 
-internal class ProxyContext
+internal sealed class ProxyContext
 {
-    public required ProxyMap ClassScopeMap { get; init; }
-    public required ProxyMap MemberScopeMap { get; init; }
+    public ProxyMap ClassScopeMap { get; }
+    public ProxyMap MemberScopeMap { get; }
 
-    public bool TryResolve(ITypeSymbol typeToWrap, SerdeUsage usage, out INamedTypeSymbol proxyType)
+    private ProxyContext(ProxyMap classScopeMap, ProxyMap memberScopeMap)
+    {
+        ClassScopeMap = classScopeMap;
+        MemberScopeMap = memberScopeMap;
+    }
+
+    public static ProxyContext Empty { get; } = new ProxyContext(ProxyMap.Empty, ProxyMap.Empty);
+
+    public static ProxyContext Create(ProxyMap classScopeMap, ProxyMap memberScopeMap)
+    {
+        if (classScopeMap.IsEmpty && memberScopeMap.IsEmpty)
+        {
+            return Empty;
+        }
+        return new ProxyContext(classScopeMap, memberScopeMap);
+    }
+
+    public INamedTypeSymbol? TryGetProxy(ITypeSymbol typeToWrap, SerdeUsage usage)
     {
         if (typeToWrap is not INamedTypeSymbol namedType)
         {
-            proxyType = default!;
-            return false;
+            return null;
         }
-        if (MemberScopeMap.TryResolve(namedType, usage, out proxyType))
+        if (MemberScopeMap.TryGetProxy(namedType, usage) is { } proxyType)
         {
-            return true;
+            return proxyType;
         }
-        return ClassScopeMap.TryResolve(namedType, usage, out proxyType);
+        return ClassScopeMap.TryGetProxy(namedType, usage);
     }
 }

--- a/src/generator/Resources.resx
+++ b/src/generator/Resources.resx
@@ -145,7 +145,4 @@
   <data name="ERR_CantFindTypeParameter" xml:space="preserve">
     <value>Could not find type parameter named '{0}' in the current context.</value>
   </data>
-  <data name="WARN_UseProxyIgnored" xml:space="preserve">
-    <value>The UseProxy attribute specifying '{0}' for type '{1}' will be ignored because a more specific proxy '{2}' is specified via SerdeMemberOptions.</value>
-  </data>
 </root>

--- a/src/generator/Resources.resx
+++ b/src/generator/Resources.resx
@@ -145,4 +145,7 @@
   <data name="ERR_CantFindTypeParameter" xml:space="preserve">
     <value>Could not find type parameter named '{0}' in the current context.</value>
   </data>
+  <data name="WARN_UseProxyIgnored" xml:space="preserve">
+    <value>The UseProxy attribute specifying '{0}' for type '{1}' will be ignored because a more specific proxy '{2}' is specified via SerdeMemberOptions.</value>
+  </data>
 </root>

--- a/src/generator/SerdeImplRoslynGenerator.cs
+++ b/src/generator/SerdeImplRoslynGenerator.cs
@@ -508,13 +508,3 @@ public class SerdeImplRoslynGenerator : IIncrementalGenerator
         return type.Name;
     }
 }
-
-[Flags]
-[Closed]
-internal enum SerdeUsage : byte
-{
-    Serialize = 0b01,
-    Deserialize = 0b10,
-
-    Both = Serialize | Deserialize,
-}

--- a/src/generator/SerdeImplRoslynGenerator.cs
+++ b/src/generator/SerdeImplRoslynGenerator.cs
@@ -508,3 +508,13 @@ public class SerdeImplRoslynGenerator : IIncrementalGenerator
         return type.Name;
     }
 }
+
+[Flags]
+[Closed]
+internal enum SerdeUsage : byte
+{
+    Serialize = 0b01,
+    Deserialize = 0b10,
+
+    Both = Serialize | Deserialize,
+}

--- a/src/generator/SerdeInfoGenerator.cs
+++ b/src/generator/SerdeInfoGenerator.cs
@@ -1,14 +1,12 @@
 
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
-using System.Net.Http.Headers;
 using System.Text;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 
 namespace Serde;
 
@@ -71,6 +69,8 @@ internal static class SerdeInfoGenerator
             typeString = typeString + "<" + new string(',', receiverType.TypeParameters.Length - 1) + ">";
         }
 
+        var classScopeProxyMap = new ProxyMap(receiverType);
+
         var membersString = string.Join("," + Utilities.NewLine,
             SymbolUtilities.GetDataMembers(receiverType, SerdeUsage.Both).SelectNotNull(GetMemberEntry));
 
@@ -78,8 +78,14 @@ internal static class SerdeInfoGenerator
 
         if (isEnum)
         {
+            var proxyContext = new ProxyContext()
+            {
+                ClassScopeMap = classScopeProxyMap,
+                MemberScopeMap = new ProxyMap()
+            };
+
             string underlyingInfo;
-            if (Proxies.TryGetImplicitWrapper(receiverType.EnumUnderlyingType!, context, usage, inProgress) is { Proxy: { } wrap })
+            if (Proxies.TryGetImplicitWrapper(receiverType.EnumUnderlyingType!, context, usage, inProgress, proxyContext) is { Proxy: { } wrap })
             {
                 underlyingInfo = wrap.ToString();
             }
@@ -126,7 +132,13 @@ private static global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.Make{{make
 
             if (!isEnum)
             {
-                string? wrapperName = GetWrapperName(m, context, usage, inProgress);
+                var proxyContext = new ProxyContext()
+                {
+                    ClassScopeMap = classScopeProxyMap,
+                    MemberScopeMap = new ProxyMap(m.Symbol)
+                };
+
+                string? wrapperName = GetWrapperName(m, context, usage, inProgress, proxyContext);
                 if (wrapperName is null)
                 {
                     // This is an error, but it should have already been produced by the serialization
@@ -227,8 +239,9 @@ private static global::Serde.ISerdeInfo s_serdeInfo { get; } = Serde.SerdeInfo.M
         DataMemberSymbol m,
         GeneratorExecutionContext context,
         SerdeUsage usage,
-        ImmutableList<(ITypeSymbol Receiver, ITypeSymbol Containing)> inProgress)
+        ImmutableList<(ITypeSymbol Receiver, ITypeSymbol Containing)> inProgress,
+        ProxyContext proxyContext)
     {
-        return Proxies.TryGetProxyString(m.Symbol, m.Type, context, usage, inProgress);
+        return Proxies.TryGetProxyString(m.Symbol, m.Type, context, usage, inProgress, proxyContext);
     }
 }

--- a/src/generator/SerdeInfoGenerator.cs
+++ b/src/generator/SerdeInfoGenerator.cs
@@ -69,7 +69,7 @@ internal static class SerdeInfoGenerator
             typeString = typeString + "<" + new string(',', receiverType.TypeParameters.Length - 1) + ">";
         }
 
-        var classScopeProxyMap = new ProxyMap(receiverType);
+        var classScopeProxyMap = ProxyMap.FromSymbol(receiverType);
 
         var membersString = string.Join("," + Utilities.NewLine,
             SymbolUtilities.GetDataMembers(receiverType, SerdeUsage.Both).SelectNotNull(GetMemberEntry));
@@ -78,11 +78,7 @@ internal static class SerdeInfoGenerator
 
         if (isEnum)
         {
-            var proxyContext = new ProxyContext()
-            {
-                ClassScopeMap = classScopeProxyMap,
-                MemberScopeMap = new ProxyMap()
-            };
+            var proxyContext = ProxyContext.Create(classScopeProxyMap, ProxyMap.Empty);
 
             string underlyingInfo;
             if (Proxies.TryGetImplicitWrapper(receiverType.EnumUnderlyingType!, context, usage, inProgress, proxyContext) is { Proxy: { } wrap })
@@ -132,11 +128,7 @@ private static global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.Make{{make
 
             if (!isEnum)
             {
-                var proxyContext = new ProxyContext()
-                {
-                    ClassScopeMap = classScopeProxyMap,
-                    MemberScopeMap = new ProxyMap(m.Symbol)
-                };
+                var proxyContext = ProxyContext.Create(classScopeProxyMap, ProxyMap.FromSymbol(m.Symbol));
 
                 string? wrapperName = GetWrapperName(m, context, usage, inProgress, proxyContext);
                 if (wrapperName is null)

--- a/src/generator/SerializeImplGen.cs
+++ b/src/generator/SerializeImplGen.cs
@@ -1,12 +1,9 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Linq;
-using System.Text;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 using static Serde.Diagnostics;
 
 namespace Serde;
@@ -64,6 +61,8 @@ public partial class SerializeImplGen
         }
         else
         {
+            var classScopeProxyMap = new ProxyMap(receiverType);
+
             // `var _l_info = GetInfo(this);`
             statements.AppendLine($"var _l_info = global::Serde.SerdeInfoProvider.GetInfo(this);");
 
@@ -74,8 +73,14 @@ public partial class SerializeImplGen
             {
                 var m = fieldsAndProps[i];
 
+                var proxyContext = new ProxyContext()
+                {
+                    ClassScopeMap = classScopeProxyMap,
+                    MemberScopeMap = new ProxyMap(m.Symbol)
+                };
+
                 // 1. Check if this member has an explicit proxy. If so, we'll use it.
-                if (Proxies.TryGetExplicitWrapper(m, context, SerdeUsage.Serialize, inProgress) is { } proxy)
+                if (Proxies.TryGetExplicitWrapper(m, context, SerdeUsage.Serialize, inProgress, proxyContext) is { } proxy)
                 {
                     statements.AppendLine(MakeWriteValueStmt(m, m.Type.ToDisplayString(), proxy, i));
                 }
@@ -97,7 +102,7 @@ public partial class SerializeImplGen
                     statements.AppendLine($"_l_type.Write{primName}(_l_info, {i}, value.{m.Name});");
                 }
                 // 4. A wrapper that implements ISerialize
-                else if (Proxies.TryGetImplicitWrapper(m.Type, context, SerdeUsage.Serialize, inProgress) is { } wrapper)
+                else if (Proxies.TryGetImplicitWrapper(m.Type, context, SerdeUsage.Serialize, inProgress, proxyContext) is { } wrapper)
                 {
                     statements.AppendLine(MakeWriteValueStmt(m, wrapper.Type, wrapper.Proxy, i));
                 }

--- a/src/generator/SerializeImplGen.cs
+++ b/src/generator/SerializeImplGen.cs
@@ -61,7 +61,7 @@ public partial class SerializeImplGen
         }
         else
         {
-            var classScopeProxyMap = new ProxyMap(receiverType);
+            var classScopeProxyMap = ProxyMap.FromSymbol(receiverType);
 
             // `var _l_info = GetInfo(this);`
             statements.AppendLine($"var _l_info = global::Serde.SerdeInfoProvider.GetInfo(this);");
@@ -73,11 +73,7 @@ public partial class SerializeImplGen
             {
                 var m = fieldsAndProps[i];
 
-                var proxyContext = new ProxyContext()
-                {
-                    ClassScopeMap = classScopeProxyMap,
-                    MemberScopeMap = new ProxyMap(m.Symbol)
-                };
+                var proxyContext = ProxyContext.Create(classScopeProxyMap, ProxyMap.FromSymbol(m.Symbol));
 
                 // 1. Check if this member has an explicit proxy. If so, we'll use it.
                 if (Proxies.TryGetExplicitWrapper(m, context, SerdeUsage.Serialize, inProgress, proxyContext) is { } proxy)

--- a/src/serde/Attributes.cs
+++ b/src/serde/Attributes.cs
@@ -1,4 +1,3 @@
-using StaticCs;
 using System;
 using System.Diagnostics;
 
@@ -240,21 +239,19 @@ internal
 sealed class UseProxy : Attribute
 {
     public required Type ForType { get; init; }
-    public required Type Proxy { get; init; }
-    public SerdeUsage Usage { get; init; } = SerdeUsage.Both;
-}
 
-[Flags]
-[Closed]
-#if !SRCGEN
-public
-#else
-internal
-#endif
-enum SerdeUsage : byte
-{
-    Serialize = 0b01,
-    Deserialize = 0b10,
+    /// <summary>
+    /// Proxy type for both ISerialize and IDeserialize implementations.
+    /// </summary>
+    public Type? Proxy { get; init; }
 
-    Both = Serialize | Deserialize,
+    /// <summary>
+    /// Proxy type for the ISerialize implementation.
+    /// </summary>
+    public Type? SerializeProxy { get; init; }
+
+    /// <summary>
+    /// Proxy type for the IDeserialize implementation.
+    /// </summary>
+    public Type? DeserializeProxy { get; init; }
 }

--- a/src/serde/Attributes.cs
+++ b/src/serde/Attributes.cs
@@ -1,4 +1,4 @@
-
+using StaticCs;
 using System;
 using System.Diagnostics;
 
@@ -229,4 +229,32 @@ enum MemberFormat : byte
     /// "kebab-case"
     /// </summary>
     KebabCase,
+}
+
+[AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct | AttributeTargets.Property | AttributeTargets.Field, AllowMultiple = true, Inherited = false)]
+#if !SRCGEN
+public
+#else
+internal
+#endif
+sealed class UseProxy : Attribute
+{
+    public required Type ForType { get; init; }
+    public required Type Proxy { get; init; }
+    public SerdeUsage Usage { get; init; } = SerdeUsage.Both;
+}
+
+[Flags]
+[Closed]
+#if !SRCGEN
+public
+#else
+internal
+#endif
+enum SerdeUsage : byte
+{
+    Serialize = 0b01,
+    Deserialize = 0b10,
+
+    Both = Serialize | Deserialize,
 }

--- a/src/serde/json/newreader/Utf8JsonLexer.cs
+++ b/src/serde/json/newreader/Utf8JsonLexer.cs
@@ -254,14 +254,14 @@ internal struct Utf8JsonLexer<TReader>(TReader byteReader)
             Advance();
 
             peek = Peek();
-            if (peek is >= (short)'0' and <= (short)'9')
+            if (peek is (>= (short)'0' and <= (short)'9'))
             {
                 throw new JsonException("Leading zero not allowed");
             }
         }
         else
         {
-            if (b is not >= (byte)'1' and <= (byte)'9')
+            if (b is not (>= (byte)'1' and <= (byte)'9'))
             {
                 throw new InvalidOperationException("expected 1-9");
             }
@@ -287,7 +287,7 @@ internal struct Utf8JsonLexer<TReader>(TReader byteReader)
                 Advance();
 
                 b = PeekOrThrow();
-                if (b is not >= (byte)'0' and <= (byte)'9')
+                if (b is not (>= (byte)'0' and <= (byte)'9'))
                 {
                     throw new InvalidOperationException("expected 0-9");
                 }
@@ -317,7 +317,7 @@ internal struct Utf8JsonLexer<TReader>(TReader byteReader)
                 Advance();
                 b = PeekOrThrow();
             }
-            if (b is not >= (byte)'0' and <= (byte)'9')
+            if (b is not (>= (byte)'0' and <= (byte)'9'))
             {
                 throw new InvalidOperationException("expected 0-9");
             }

--- a/test/Serde.Generation.Test/ProxyTests.cs
+++ b/test/Serde.Generation.Test/ProxyTests.cs
@@ -379,5 +379,30 @@ public partial record Parent
 """;
             await VerifyMultiFile(src, new[] { comp.EmitToImageReference() });
         }
+
+        [Fact]
+        public Task SerdeMemberOptionsTakesPrecedenceOverUseProxy()
+        {
+            var src = """
+using System.Runtime.InteropServices.ComTypes;
+using Serde;
+
+[GenerateSerde(ForType = typeof(BIND_OPTS))]
+internal sealed partial class Proxy1 {}
+
+[GenerateSerde(ForType = typeof(BIND_OPTS))]
+internal sealed partial class Proxy2 {}
+
+[GenerateSerde]
+partial class C
+{
+    // SerdeMemberOptions takes precedence
+    [UseProxy(ForType = typeof(BIND_OPTS), Proxy = typeof(Proxy1))]
+    [SerdeMemberOptions(Proxy = typeof(Proxy2))]
+    public BIND_OPTS S = new BIND_OPTS();
+}
+""";
+            return VerifyMultiFile(src);
+        }
     }
 }

--- a/test/Serde.Generation.Test/test_output/ProxyTests.SerdeMemberOptionsTakesPrecedenceOverUseProxy/C.ISerde.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/ProxyTests.SerdeMemberOptionsTakesPrecedenceOverUseProxy/C.ISerde.g.verified.cs
@@ -1,29 +1,25 @@
+﻿//HintName: C.ISerde.g.cs
 
 #nullable enable
 
 using System;
 using Serde;
-
-namespace Serde.Json.Test;
-
-partial class Vector2Proxy
+partial class C
 {
-    sealed partial class _SerdeObj : global::Serde.ISerde<System.Numerics.Vector2>
+    sealed partial class _SerdeObj : global::Serde.ISerde<C>
     {
-        global::Serde.ISerdeInfo global::Serde.ISerdeInfoProvider.SerdeInfo => Serde.Json.Test.Vector2Proxy.s_serdeInfo;
+        global::Serde.ISerdeInfo global::Serde.ISerdeInfoProvider.SerdeInfo => C.s_serdeInfo;
 
-        void global::Serde.ISerialize<System.Numerics.Vector2>.Serialize(System.Numerics.Vector2 value, global::Serde.ISerializer serializer)
+        void global::Serde.ISerialize<C>.Serialize(C value, global::Serde.ISerializer serializer)
         {
             var _l_info = global::Serde.SerdeInfoProvider.GetInfo(this);
             var _l_type = serializer.WriteType(_l_info);
-            _l_type.WriteF32(_l_info, 0, value.X);
-            _l_type.WriteF32(_l_info, 1, value.Y);
+            _l_type.WriteBoxedValue<System.Runtime.InteropServices.ComTypes.BIND_OPTS, Proxy2>(_l_info, 0, value.S);
             _l_type.End(_l_info);
         }
-        System.Numerics.Vector2 Serde.IDeserialize<System.Numerics.Vector2>.Deserialize(IDeserializer deserializer)
+        C Serde.IDeserialize<C>.Deserialize(IDeserializer deserializer)
         {
-            float _l_x = default!;
-            float _l_y = default!;
+            System.Runtime.InteropServices.ComTypes.BIND_OPTS _l_s = default!;
 
             byte _r_assignedValid = 0;
 
@@ -41,13 +37,8 @@ partial class Vector2Proxy
                 {
                     case 0:
                         Serde.DeserializeException.ThrowIfDuplicate(_r_assignedValid, 0, _l_serdeInfo);
-                        _l_x = typeDeserialize.ReadF32(_l_serdeInfo, _l_index_);
+                        _l_s = typeDeserialize.ReadBoxedValue<System.Runtime.InteropServices.ComTypes.BIND_OPTS, Proxy2>(_l_serdeInfo, _l_index_);
                         _r_assignedValid |= ((byte)1) << 0;
-                        break;
-                    case 1:
-                        Serde.DeserializeException.ThrowIfDuplicate(_r_assignedValid, 1, _l_serdeInfo);
-                        _l_y = typeDeserialize.ReadF32(_l_serdeInfo, _l_index_);
-                        _r_assignedValid |= ((byte)1) << 1;
                         break;
                     case Serde.ITypeDeserializer.IndexNotFound:
                         typeDeserialize.SkipValue(_l_serdeInfo, _l_index_);
@@ -56,13 +47,12 @@ partial class Vector2Proxy
                         throw new InvalidOperationException("Unexpected index: " + _l_index_);
                 }
             }
-            if ((_r_assignedValid & 0b11) != 0b11)
+            if ((_r_assignedValid & 0b1) != 0b1)
             {
                 throw Serde.DeserializeException.UnassignedMember();
             }
-            var newType = new System.Numerics.Vector2() {
-                X = _l_x,
-                Y = _l_y,
+            var newType = new C() {
+                S = _l_s,
             };
 
             return newType;

--- a/test/Serde.Generation.Test/test_output/ProxyTests.SerdeMemberOptionsTakesPrecedenceOverUseProxy/C.ISerdeInfoProvider.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/ProxyTests.SerdeMemberOptionsTakesPrecedenceOverUseProxy/C.ISerdeInfoProvider.g.verified.cs
@@ -1,0 +1,13 @@
+﻿//HintName: C.ISerdeInfoProvider.g.cs
+
+#nullable enable
+partial class C
+{
+    private static global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
+        "C",
+    typeof(C).GetCustomAttributesData(),
+    new (string, global::Serde.ISerdeInfo, System.Reflection.MemberInfo?)[] {
+        ("s", global::Serde.SerdeInfoProvider.GetSerializeInfo<System.Runtime.InteropServices.ComTypes.BIND_OPTS, Proxy2>(), typeof(C).GetField("S"))
+    }
+    );
+}

--- a/test/Serde.Generation.Test/test_output/ProxyTests.SerdeMemberOptionsTakesPrecedenceOverUseProxy/C.ISerdeProvider.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/ProxyTests.SerdeMemberOptionsTakesPrecedenceOverUseProxy/C.ISerdeProvider.g.verified.cs
@@ -1,0 +1,6 @@
+﻿//HintName: C.ISerdeProvider.g.cs
+partial class C : Serde.ISerdeProvider<C, C._SerdeObj, C>
+{
+    static C._SerdeObj global::Serde.ISerdeProvider<C, C._SerdeObj, C>.Instance { get; }
+        = new C._SerdeObj();
+}

--- a/test/Serde.Generation.Test/test_output/ProxyTests.SerdeMemberOptionsTakesPrecedenceOverUseProxy/Proxy1.ISerde.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/ProxyTests.SerdeMemberOptionsTakesPrecedenceOverUseProxy/Proxy1.ISerde.g.verified.cs
@@ -1,0 +1,85 @@
+﻿//HintName: Proxy1.ISerde.g.cs
+
+#nullable enable
+
+using System;
+using Serde;
+partial class Proxy1
+{
+    sealed partial class _SerdeObj : global::Serde.ISerde<System.Runtime.InteropServices.ComTypes.BIND_OPTS>
+    {
+        global::Serde.ISerdeInfo global::Serde.ISerdeInfoProvider.SerdeInfo => Proxy1.s_serdeInfo;
+
+        void global::Serde.ISerialize<System.Runtime.InteropServices.ComTypes.BIND_OPTS>.Serialize(System.Runtime.InteropServices.ComTypes.BIND_OPTS value, global::Serde.ISerializer serializer)
+        {
+            var _l_info = global::Serde.SerdeInfoProvider.GetInfo(this);
+            var _l_type = serializer.WriteType(_l_info);
+            _l_type.WriteI32(_l_info, 0, value.cbStruct);
+            _l_type.WriteI32(_l_info, 1, value.dwTickCountDeadline);
+            _l_type.WriteI32(_l_info, 2, value.grfFlags);
+            _l_type.WriteI32(_l_info, 3, value.grfMode);
+            _l_type.End(_l_info);
+        }
+        System.Runtime.InteropServices.ComTypes.BIND_OPTS Serde.IDeserialize<System.Runtime.InteropServices.ComTypes.BIND_OPTS>.Deserialize(IDeserializer deserializer)
+        {
+            int _l_cbstruct = default!;
+            int _l_dwtickcountdeadline = default!;
+            int _l_grfflags = default!;
+            int _l_grfmode = default!;
+
+            byte _r_assignedValid = 0;
+
+            var _l_serdeInfo = global::Serde.SerdeInfoProvider.GetInfo(this);
+            var typeDeserialize = deserializer.ReadType(_l_serdeInfo);
+            while (true)
+            {
+                var (_l_index_, _) = typeDeserialize.TryReadIndexWithName(_l_serdeInfo);
+                if (_l_index_ == Serde.ITypeDeserializer.EndOfType)
+                {
+                    break;
+                }
+
+                switch (_l_index_)
+                {
+                    case 0:
+                        Serde.DeserializeException.ThrowIfDuplicate(_r_assignedValid, 0, _l_serdeInfo);
+                        _l_cbstruct = typeDeserialize.ReadI32(_l_serdeInfo, _l_index_);
+                        _r_assignedValid |= ((byte)1) << 0;
+                        break;
+                    case 1:
+                        Serde.DeserializeException.ThrowIfDuplicate(_r_assignedValid, 1, _l_serdeInfo);
+                        _l_dwtickcountdeadline = typeDeserialize.ReadI32(_l_serdeInfo, _l_index_);
+                        _r_assignedValid |= ((byte)1) << 1;
+                        break;
+                    case 2:
+                        Serde.DeserializeException.ThrowIfDuplicate(_r_assignedValid, 2, _l_serdeInfo);
+                        _l_grfflags = typeDeserialize.ReadI32(_l_serdeInfo, _l_index_);
+                        _r_assignedValid |= ((byte)1) << 2;
+                        break;
+                    case 3:
+                        Serde.DeserializeException.ThrowIfDuplicate(_r_assignedValid, 3, _l_serdeInfo);
+                        _l_grfmode = typeDeserialize.ReadI32(_l_serdeInfo, _l_index_);
+                        _r_assignedValid |= ((byte)1) << 3;
+                        break;
+                    case Serde.ITypeDeserializer.IndexNotFound:
+                        typeDeserialize.SkipValue(_l_serdeInfo, _l_index_);
+                        break;
+                    default:
+                        throw new InvalidOperationException("Unexpected index: " + _l_index_);
+                }
+            }
+            if ((_r_assignedValid & 0b1111) != 0b1111)
+            {
+                throw Serde.DeserializeException.UnassignedMember();
+            }
+            var newType = new System.Runtime.InteropServices.ComTypes.BIND_OPTS() {
+                cbStruct = _l_cbstruct,
+                dwTickCountDeadline = _l_dwtickcountdeadline,
+                grfFlags = _l_grfflags,
+                grfMode = _l_grfmode,
+            };
+
+            return newType;
+        }
+    }
+}

--- a/test/Serde.Generation.Test/test_output/ProxyTests.SerdeMemberOptionsTakesPrecedenceOverUseProxy/Proxy1.ISerdeInfoProvider.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/ProxyTests.SerdeMemberOptionsTakesPrecedenceOverUseProxy/Proxy1.ISerdeInfoProvider.g.verified.cs
@@ -1,0 +1,16 @@
+﻿//HintName: Proxy1.ISerdeInfoProvider.g.cs
+
+#nullable enable
+partial class Proxy1
+{
+    private static global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
+        "BIND_OPTS",
+    typeof(System.Runtime.InteropServices.ComTypes.BIND_OPTS).GetCustomAttributesData(),
+    new (string, global::Serde.ISerdeInfo, System.Reflection.MemberInfo?)[] {
+        ("cbStruct", global::Serde.SerdeInfoProvider.GetSerializeInfo<int, global::Serde.I32Proxy>(), typeof(System.Runtime.InteropServices.ComTypes.BIND_OPTS).GetField("cbStruct")),
+        ("dwTickCountDeadline", global::Serde.SerdeInfoProvider.GetSerializeInfo<int, global::Serde.I32Proxy>(), typeof(System.Runtime.InteropServices.ComTypes.BIND_OPTS).GetField("dwTickCountDeadline")),
+        ("grfFlags", global::Serde.SerdeInfoProvider.GetSerializeInfo<int, global::Serde.I32Proxy>(), typeof(System.Runtime.InteropServices.ComTypes.BIND_OPTS).GetField("grfFlags")),
+        ("grfMode", global::Serde.SerdeInfoProvider.GetSerializeInfo<int, global::Serde.I32Proxy>(), typeof(System.Runtime.InteropServices.ComTypes.BIND_OPTS).GetField("grfMode"))
+    }
+    );
+}

--- a/test/Serde.Generation.Test/test_output/ProxyTests.SerdeMemberOptionsTakesPrecedenceOverUseProxy/Proxy1.ISerdeProvider.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/ProxyTests.SerdeMemberOptionsTakesPrecedenceOverUseProxy/Proxy1.ISerdeProvider.g.verified.cs
@@ -1,0 +1,6 @@
+﻿//HintName: Proxy1.ISerdeProvider.g.cs
+partial class Proxy1 : Serde.ISerdeProvider<Proxy1, Proxy1._SerdeObj, System.Runtime.InteropServices.ComTypes.BIND_OPTS>
+{
+    static Proxy1._SerdeObj global::Serde.ISerdeProvider<Proxy1, Proxy1._SerdeObj, System.Runtime.InteropServices.ComTypes.BIND_OPTS>.Instance { get; }
+        = new Proxy1._SerdeObj();
+}

--- a/test/Serde.Generation.Test/test_output/ProxyTests.SerdeMemberOptionsTakesPrecedenceOverUseProxy/Proxy2.ISerde.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/ProxyTests.SerdeMemberOptionsTakesPrecedenceOverUseProxy/Proxy2.ISerde.g.verified.cs
@@ -1,0 +1,85 @@
+﻿//HintName: Proxy2.ISerde.g.cs
+
+#nullable enable
+
+using System;
+using Serde;
+partial class Proxy2
+{
+    sealed partial class _SerdeObj : global::Serde.ISerde<System.Runtime.InteropServices.ComTypes.BIND_OPTS>
+    {
+        global::Serde.ISerdeInfo global::Serde.ISerdeInfoProvider.SerdeInfo => Proxy2.s_serdeInfo;
+
+        void global::Serde.ISerialize<System.Runtime.InteropServices.ComTypes.BIND_OPTS>.Serialize(System.Runtime.InteropServices.ComTypes.BIND_OPTS value, global::Serde.ISerializer serializer)
+        {
+            var _l_info = global::Serde.SerdeInfoProvider.GetInfo(this);
+            var _l_type = serializer.WriteType(_l_info);
+            _l_type.WriteI32(_l_info, 0, value.cbStruct);
+            _l_type.WriteI32(_l_info, 1, value.dwTickCountDeadline);
+            _l_type.WriteI32(_l_info, 2, value.grfFlags);
+            _l_type.WriteI32(_l_info, 3, value.grfMode);
+            _l_type.End(_l_info);
+        }
+        System.Runtime.InteropServices.ComTypes.BIND_OPTS Serde.IDeserialize<System.Runtime.InteropServices.ComTypes.BIND_OPTS>.Deserialize(IDeserializer deserializer)
+        {
+            int _l_cbstruct = default!;
+            int _l_dwtickcountdeadline = default!;
+            int _l_grfflags = default!;
+            int _l_grfmode = default!;
+
+            byte _r_assignedValid = 0;
+
+            var _l_serdeInfo = global::Serde.SerdeInfoProvider.GetInfo(this);
+            var typeDeserialize = deserializer.ReadType(_l_serdeInfo);
+            while (true)
+            {
+                var (_l_index_, _) = typeDeserialize.TryReadIndexWithName(_l_serdeInfo);
+                if (_l_index_ == Serde.ITypeDeserializer.EndOfType)
+                {
+                    break;
+                }
+
+                switch (_l_index_)
+                {
+                    case 0:
+                        Serde.DeserializeException.ThrowIfDuplicate(_r_assignedValid, 0, _l_serdeInfo);
+                        _l_cbstruct = typeDeserialize.ReadI32(_l_serdeInfo, _l_index_);
+                        _r_assignedValid |= ((byte)1) << 0;
+                        break;
+                    case 1:
+                        Serde.DeserializeException.ThrowIfDuplicate(_r_assignedValid, 1, _l_serdeInfo);
+                        _l_dwtickcountdeadline = typeDeserialize.ReadI32(_l_serdeInfo, _l_index_);
+                        _r_assignedValid |= ((byte)1) << 1;
+                        break;
+                    case 2:
+                        Serde.DeserializeException.ThrowIfDuplicate(_r_assignedValid, 2, _l_serdeInfo);
+                        _l_grfflags = typeDeserialize.ReadI32(_l_serdeInfo, _l_index_);
+                        _r_assignedValid |= ((byte)1) << 2;
+                        break;
+                    case 3:
+                        Serde.DeserializeException.ThrowIfDuplicate(_r_assignedValid, 3, _l_serdeInfo);
+                        _l_grfmode = typeDeserialize.ReadI32(_l_serdeInfo, _l_index_);
+                        _r_assignedValid |= ((byte)1) << 3;
+                        break;
+                    case Serde.ITypeDeserializer.IndexNotFound:
+                        typeDeserialize.SkipValue(_l_serdeInfo, _l_index_);
+                        break;
+                    default:
+                        throw new InvalidOperationException("Unexpected index: " + _l_index_);
+                }
+            }
+            if ((_r_assignedValid & 0b1111) != 0b1111)
+            {
+                throw Serde.DeserializeException.UnassignedMember();
+            }
+            var newType = new System.Runtime.InteropServices.ComTypes.BIND_OPTS() {
+                cbStruct = _l_cbstruct,
+                dwTickCountDeadline = _l_dwtickcountdeadline,
+                grfFlags = _l_grfflags,
+                grfMode = _l_grfmode,
+            };
+
+            return newType;
+        }
+    }
+}

--- a/test/Serde.Generation.Test/test_output/ProxyTests.SerdeMemberOptionsTakesPrecedenceOverUseProxy/Proxy2.ISerdeInfoProvider.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/ProxyTests.SerdeMemberOptionsTakesPrecedenceOverUseProxy/Proxy2.ISerdeInfoProvider.g.verified.cs
@@ -1,0 +1,16 @@
+﻿//HintName: Proxy2.ISerdeInfoProvider.g.cs
+
+#nullable enable
+partial class Proxy2
+{
+    private static global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
+        "BIND_OPTS",
+    typeof(System.Runtime.InteropServices.ComTypes.BIND_OPTS).GetCustomAttributesData(),
+    new (string, global::Serde.ISerdeInfo, System.Reflection.MemberInfo?)[] {
+        ("cbStruct", global::Serde.SerdeInfoProvider.GetSerializeInfo<int, global::Serde.I32Proxy>(), typeof(System.Runtime.InteropServices.ComTypes.BIND_OPTS).GetField("cbStruct")),
+        ("dwTickCountDeadline", global::Serde.SerdeInfoProvider.GetSerializeInfo<int, global::Serde.I32Proxy>(), typeof(System.Runtime.InteropServices.ComTypes.BIND_OPTS).GetField("dwTickCountDeadline")),
+        ("grfFlags", global::Serde.SerdeInfoProvider.GetSerializeInfo<int, global::Serde.I32Proxy>(), typeof(System.Runtime.InteropServices.ComTypes.BIND_OPTS).GetField("grfFlags")),
+        ("grfMode", global::Serde.SerdeInfoProvider.GetSerializeInfo<int, global::Serde.I32Proxy>(), typeof(System.Runtime.InteropServices.ComTypes.BIND_OPTS).GetField("grfMode"))
+    }
+    );
+}

--- a/test/Serde.Generation.Test/test_output/ProxyTests.SerdeMemberOptionsTakesPrecedenceOverUseProxy/Proxy2.ISerdeProvider.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/ProxyTests.SerdeMemberOptionsTakesPrecedenceOverUseProxy/Proxy2.ISerdeProvider.g.verified.cs
@@ -1,0 +1,6 @@
+﻿//HintName: Proxy2.ISerdeProvider.g.cs
+partial class Proxy2 : Serde.ISerdeProvider<Proxy2, Proxy2._SerdeObj, System.Runtime.InteropServices.ComTypes.BIND_OPTS>
+{
+    static Proxy2._SerdeObj global::Serde.ISerdeProvider<Proxy2, Proxy2._SerdeObj, System.Runtime.InteropServices.ComTypes.BIND_OPTS>.Instance { get; }
+        = new Proxy2._SerdeObj();
+}

--- a/test/Serde.Test/TestClasses.cs
+++ b/test/Serde.Test/TestClasses.cs
@@ -24,12 +24,21 @@ public partial class Vector2Proxy;
 [GenerateSerde(ForType = typeof(Vector2))]
 public partial class Vector2Proxy2;
 
+[GenerateSerde(ForType = typeof(Vector3))]
+public partial class Vector3Proxy;
+
+[GenerateSerde(ForType = typeof(Vector4))]
+public partial class Vector4Proxy;
+
 [GenerateSerde]
 [UseProxy(ForType = typeof(Vector2), Proxy = typeof(Vector2Proxy))]
+[UseProxy(ForType = typeof(Vector3), Proxy = typeof(Vector3Proxy))]
 public partial class Test
 {
     public required Vector2 v2;
     public required Vector2[][] vertices;
-    [UseProxy(ForType = typeof(Vector2), Proxy = typeof(Vector2Proxy2), Usage = SerdeUsage.Serialize)]
+    [UseProxy(ForType = typeof(Vector2), SerializeProxy = typeof(Vector2Proxy2))]
     public required Vector2[][] weights;
+    [UseProxy(ForType = typeof(Vector2), DeserializeProxy = typeof(Vector2Proxy2))]
+    public required Dictionary<Vector3, Vector2[][]> points;
 }

--- a/test/Serde.Test/TestClasses.cs
+++ b/test/Serde.Test/TestClasses.cs
@@ -1,15 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-using System.Collections;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Collections.Immutable;
-using System.Collections.ObjectModel;
-using System.Linq;
-using System.Text;
-using Xunit;
+using System.Numerics;
 
 namespace Serde.Json.Test;
 
@@ -23,4 +16,20 @@ public partial class PocoDictionary
 public partial class Poco
 {
     public int Id { get; set; }
+}
+
+[GenerateSerde(ForType = typeof(Vector2))]
+public partial class Vector2Proxy;
+
+[GenerateSerde(ForType = typeof(Vector2))]
+public partial class Vector2Proxy2;
+
+[GenerateSerde]
+[UseProxy(ForType = typeof(Vector2), Proxy = typeof(Vector2Proxy))]
+public partial class Test
+{
+    public required Vector2 v2;
+    public required Vector2[][] vertices;
+    [UseProxy(ForType = typeof(Vector2), Proxy = typeof(Vector2Proxy2), Usage = SerdeUsage.Serialize)]
+    public required Vector2[][] weights;
 }

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Json.Test.Test.ISerde.g.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Json.Test.Test.ISerde.g.cs
@@ -19,6 +19,7 @@ partial class Test
             _l_type.WriteBoxedValue<System.Numerics.Vector2, Serde.Json.Test.Vector2Proxy>(_l_info, 0, value.v2);
             _l_type.WriteValue<System.Numerics.Vector2[][], Serde.ArrayProxy.Ser<System.Numerics.Vector2[], Serde.ArrayProxy.Ser<System.Numerics.Vector2, Serde.Json.Test.Vector2Proxy>>>(_l_info, 1, value.vertices);
             _l_type.WriteValue<System.Numerics.Vector2[][], Serde.ArrayProxy.Ser<System.Numerics.Vector2[], Serde.ArrayProxy.Ser<System.Numerics.Vector2, Serde.Json.Test.Vector2Proxy2>>>(_l_info, 2, value.weights);
+            _l_type.WriteValue<System.Collections.Generic.Dictionary<System.Numerics.Vector3, System.Numerics.Vector2[][]>, Serde.DictProxy.Ser<System.Numerics.Vector3, System.Numerics.Vector2[][], Serde.Json.Test.Vector3Proxy, Serde.ArrayProxy.Ser<System.Numerics.Vector2[], Serde.ArrayProxy.Ser<System.Numerics.Vector2, Serde.Json.Test.Vector2Proxy>>>>(_l_info, 3, value.points);
             _l_type.End(_l_info);
         }
         Serde.Json.Test.Test Serde.IDeserialize<Serde.Json.Test.Test>.Deserialize(IDeserializer deserializer)
@@ -26,6 +27,7 @@ partial class Test
             System.Numerics.Vector2 _l_v2 = default!;
             System.Numerics.Vector2[][] _l_vertices = default!;
             System.Numerics.Vector2[][] _l_weights = default!;
+            System.Collections.Generic.Dictionary<System.Numerics.Vector3, System.Numerics.Vector2[][]> _l_points = default!;
 
             byte _r_assignedValid = 0;
 
@@ -56,6 +58,11 @@ partial class Test
                         _l_weights = typeDeserialize.ReadValue<System.Numerics.Vector2[][], Serde.ArrayProxy.De<System.Numerics.Vector2[], Serde.ArrayProxy.De<System.Numerics.Vector2, Serde.Json.Test.Vector2Proxy>>>(_l_serdeInfo, _l_index_);
                         _r_assignedValid |= ((byte)1) << 2;
                         break;
+                    case 3:
+                        Serde.DeserializeException.ThrowIfDuplicate(_r_assignedValid, 3, _l_serdeInfo);
+                        _l_points = typeDeserialize.ReadValue<System.Collections.Generic.Dictionary<System.Numerics.Vector3, System.Numerics.Vector2[][]>, Serde.DictProxy.De<System.Numerics.Vector3, System.Numerics.Vector2[][], Serde.Json.Test.Vector3Proxy, Serde.ArrayProxy.De<System.Numerics.Vector2[], Serde.ArrayProxy.De<System.Numerics.Vector2, Serde.Json.Test.Vector2Proxy2>>>>(_l_serdeInfo, _l_index_);
+                        _r_assignedValid |= ((byte)1) << 3;
+                        break;
                     case Serde.ITypeDeserializer.IndexNotFound:
                         typeDeserialize.SkipValue(_l_serdeInfo, _l_index_);
                         break;
@@ -63,7 +70,7 @@ partial class Test
                         throw new InvalidOperationException("Unexpected index: " + _l_index_);
                 }
             }
-            if ((_r_assignedValid & 0b111) != 0b111)
+            if ((_r_assignedValid & 0b1111) != 0b1111)
             {
                 throw Serde.DeserializeException.UnassignedMember();
             }
@@ -71,10 +78,8 @@ partial class Test
                 v2 = _l_v2,
                 vertices = _l_vertices,
                 weights = _l_weights,
+                points = _l_points,
             };
-
-
-            typeDeserialize.End(_l_serdeInfo);
 
             return newType;
         }

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Json.Test.Test.ISerde.g.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Json.Test.Test.ISerde.g.cs
@@ -1,0 +1,82 @@
+
+#nullable enable
+
+using System;
+using Serde;
+
+namespace Serde.Json.Test;
+
+partial class Test
+{
+    sealed partial class _SerdeObj : global::Serde.ISerde<Serde.Json.Test.Test>
+    {
+        global::Serde.ISerdeInfo global::Serde.ISerdeInfoProvider.SerdeInfo => Serde.Json.Test.Test.s_serdeInfo;
+
+        void global::Serde.ISerialize<Serde.Json.Test.Test>.Serialize(Serde.Json.Test.Test value, global::Serde.ISerializer serializer)
+        {
+            var _l_info = global::Serde.SerdeInfoProvider.GetInfo(this);
+            var _l_type = serializer.WriteType(_l_info);
+            _l_type.WriteBoxedValue<System.Numerics.Vector2, Serde.Json.Test.Vector2Proxy>(_l_info, 0, value.v2);
+            _l_type.WriteValue<System.Numerics.Vector2[][], Serde.ArrayProxy.Ser<System.Numerics.Vector2[], Serde.ArrayProxy.Ser<System.Numerics.Vector2, Serde.Json.Test.Vector2Proxy>>>(_l_info, 1, value.vertices);
+            _l_type.WriteValue<System.Numerics.Vector2[][], Serde.ArrayProxy.Ser<System.Numerics.Vector2[], Serde.ArrayProxy.Ser<System.Numerics.Vector2, Serde.Json.Test.Vector2Proxy2>>>(_l_info, 2, value.weights);
+            _l_type.End(_l_info);
+        }
+        Serde.Json.Test.Test Serde.IDeserialize<Serde.Json.Test.Test>.Deserialize(IDeserializer deserializer)
+        {
+            System.Numerics.Vector2 _l_v2 = default!;
+            System.Numerics.Vector2[][] _l_vertices = default!;
+            System.Numerics.Vector2[][] _l_weights = default!;
+
+            byte _r_assignedValid = 0;
+
+            var _l_serdeInfo = global::Serde.SerdeInfoProvider.GetInfo(this);
+            var typeDeserialize = deserializer.ReadType(_l_serdeInfo);
+            while (true)
+            {
+                var (_l_index_, _) = typeDeserialize.TryReadIndexWithName(_l_serdeInfo);
+                if (_l_index_ == Serde.ITypeDeserializer.EndOfType)
+                {
+                    break;
+                }
+
+                switch (_l_index_)
+                {
+                    case 0:
+                        Serde.DeserializeException.ThrowIfDuplicate(_r_assignedValid, 0, _l_serdeInfo);
+                        _l_v2 = typeDeserialize.ReadBoxedValue<System.Numerics.Vector2, Serde.Json.Test.Vector2Proxy>(_l_serdeInfo, _l_index_);
+                        _r_assignedValid |= ((byte)1) << 0;
+                        break;
+                    case 1:
+                        Serde.DeserializeException.ThrowIfDuplicate(_r_assignedValid, 1, _l_serdeInfo);
+                        _l_vertices = typeDeserialize.ReadValue<System.Numerics.Vector2[][], Serde.ArrayProxy.De<System.Numerics.Vector2[], Serde.ArrayProxy.De<System.Numerics.Vector2, Serde.Json.Test.Vector2Proxy>>>(_l_serdeInfo, _l_index_);
+                        _r_assignedValid |= ((byte)1) << 1;
+                        break;
+                    case 2:
+                        Serde.DeserializeException.ThrowIfDuplicate(_r_assignedValid, 2, _l_serdeInfo);
+                        _l_weights = typeDeserialize.ReadValue<System.Numerics.Vector2[][], Serde.ArrayProxy.De<System.Numerics.Vector2[], Serde.ArrayProxy.De<System.Numerics.Vector2, Serde.Json.Test.Vector2Proxy>>>(_l_serdeInfo, _l_index_);
+                        _r_assignedValid |= ((byte)1) << 2;
+                        break;
+                    case Serde.ITypeDeserializer.IndexNotFound:
+                        typeDeserialize.SkipValue(_l_serdeInfo, _l_index_);
+                        break;
+                    default:
+                        throw new InvalidOperationException("Unexpected index: " + _l_index_);
+                }
+            }
+            if ((_r_assignedValid & 0b111) != 0b111)
+            {
+                throw Serde.DeserializeException.UnassignedMember();
+            }
+            var newType = new Serde.Json.Test.Test() {
+                v2 = _l_v2,
+                vertices = _l_vertices,
+                weights = _l_weights,
+            };
+
+
+            typeDeserialize.End(_l_serdeInfo);
+
+            return newType;
+        }
+    }
+}

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Json.Test.Test.ISerdeInfoProvider.g.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Json.Test.Test.ISerdeInfoProvider.g.cs
@@ -1,0 +1,17 @@
+
+#nullable enable
+
+namespace Serde.Json.Test;
+
+partial class Test
+{
+    private static global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
+        "Test",
+    typeof(Serde.Json.Test.Test).GetCustomAttributesData(),
+    new (string, global::Serde.ISerdeInfo, System.Reflection.MemberInfo?)[] {
+        ("v2", global::Serde.SerdeInfoProvider.GetSerializeInfo<System.Numerics.Vector2, Serde.Json.Test.Vector2Proxy>(), typeof(Serde.Json.Test.Test).GetField("v2")),
+        ("vertices", global::Serde.SerdeInfoProvider.GetSerializeInfo<System.Numerics.Vector2[][], Serde.ArrayProxy.Ser<System.Numerics.Vector2[], Serde.ArrayProxy.Ser<System.Numerics.Vector2, Serde.Json.Test.Vector2Proxy>>>(), typeof(Serde.Json.Test.Test).GetField("vertices")),
+        ("weights", global::Serde.SerdeInfoProvider.GetSerializeInfo<System.Numerics.Vector2[][], Serde.ArrayProxy.Ser<System.Numerics.Vector2[], Serde.ArrayProxy.Ser<System.Numerics.Vector2, Serde.Json.Test.Vector2Proxy2>>>(), typeof(Serde.Json.Test.Test).GetField("weights"))
+    }
+    );
+}

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Json.Test.Test.ISerdeInfoProvider.g.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Json.Test.Test.ISerdeInfoProvider.g.cs
@@ -11,7 +11,8 @@ partial class Test
     new (string, global::Serde.ISerdeInfo, System.Reflection.MemberInfo?)[] {
         ("v2", global::Serde.SerdeInfoProvider.GetSerializeInfo<System.Numerics.Vector2, Serde.Json.Test.Vector2Proxy>(), typeof(Serde.Json.Test.Test).GetField("v2")),
         ("vertices", global::Serde.SerdeInfoProvider.GetSerializeInfo<System.Numerics.Vector2[][], Serde.ArrayProxy.Ser<System.Numerics.Vector2[], Serde.ArrayProxy.Ser<System.Numerics.Vector2, Serde.Json.Test.Vector2Proxy>>>(), typeof(Serde.Json.Test.Test).GetField("vertices")),
-        ("weights", global::Serde.SerdeInfoProvider.GetSerializeInfo<System.Numerics.Vector2[][], Serde.ArrayProxy.Ser<System.Numerics.Vector2[], Serde.ArrayProxy.Ser<System.Numerics.Vector2, Serde.Json.Test.Vector2Proxy2>>>(), typeof(Serde.Json.Test.Test).GetField("weights"))
+        ("weights", global::Serde.SerdeInfoProvider.GetSerializeInfo<System.Numerics.Vector2[][], Serde.ArrayProxy.Ser<System.Numerics.Vector2[], Serde.ArrayProxy.Ser<System.Numerics.Vector2, Serde.Json.Test.Vector2Proxy2>>>(), typeof(Serde.Json.Test.Test).GetField("weights")),
+        ("points", global::Serde.SerdeInfoProvider.GetSerializeInfo<System.Collections.Generic.Dictionary<System.Numerics.Vector3, System.Numerics.Vector2[][]>, Serde.DictProxy.Ser<System.Numerics.Vector3, System.Numerics.Vector2[][], Serde.Json.Test.Vector3Proxy, Serde.ArrayProxy.Ser<System.Numerics.Vector2[], Serde.ArrayProxy.Ser<System.Numerics.Vector2, Serde.Json.Test.Vector2Proxy>>>>(), typeof(Serde.Json.Test.Test).GetField("points"))
     }
     );
 }

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Json.Test.Test.ISerdeProvider.g.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Json.Test.Test.ISerdeProvider.g.cs
@@ -1,0 +1,8 @@
+
+namespace Serde.Json.Test;
+
+partial class Test : Serde.ISerdeProvider<Serde.Json.Test.Test, Serde.Json.Test.Test._SerdeObj, Serde.Json.Test.Test>
+{
+    static Serde.Json.Test.Test._SerdeObj global::Serde.ISerdeProvider<Serde.Json.Test.Test, Serde.Json.Test.Test._SerdeObj, Serde.Json.Test.Test>.Instance { get; }
+        = new Serde.Json.Test.Test._SerdeObj();
+}

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Json.Test.Vector2Proxy.ISerde.g.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Json.Test.Vector2Proxy.ISerde.g.cs
@@ -1,0 +1,74 @@
+
+#nullable enable
+
+using System;
+using Serde;
+
+namespace Serde.Json.Test;
+
+partial class Vector2Proxy
+{
+    sealed partial class _SerdeObj : global::Serde.ISerde<System.Numerics.Vector2>
+    {
+        global::Serde.ISerdeInfo global::Serde.ISerdeInfoProvider.SerdeInfo => Serde.Json.Test.Vector2Proxy.s_serdeInfo;
+
+        void global::Serde.ISerialize<System.Numerics.Vector2>.Serialize(System.Numerics.Vector2 value, global::Serde.ISerializer serializer)
+        {
+            var _l_info = global::Serde.SerdeInfoProvider.GetInfo(this);
+            var _l_type = serializer.WriteType(_l_info);
+            _l_type.WriteF32(_l_info, 0, value.X);
+            _l_type.WriteF32(_l_info, 1, value.Y);
+            _l_type.End(_l_info);
+        }
+        System.Numerics.Vector2 Serde.IDeserialize<System.Numerics.Vector2>.Deserialize(IDeserializer deserializer)
+        {
+            float _l_x = default!;
+            float _l_y = default!;
+
+            byte _r_assignedValid = 0;
+
+            var _l_serdeInfo = global::Serde.SerdeInfoProvider.GetInfo(this);
+            var typeDeserialize = deserializer.ReadType(_l_serdeInfo);
+            while (true)
+            {
+                var (_l_index_, _) = typeDeserialize.TryReadIndexWithName(_l_serdeInfo);
+                if (_l_index_ == Serde.ITypeDeserializer.EndOfType)
+                {
+                    break;
+                }
+
+                switch (_l_index_)
+                {
+                    case 0:
+                        Serde.DeserializeException.ThrowIfDuplicate(_r_assignedValid, 0, _l_serdeInfo);
+                        _l_x = typeDeserialize.ReadF32(_l_serdeInfo, _l_index_);
+                        _r_assignedValid |= ((byte)1) << 0;
+                        break;
+                    case 1:
+                        Serde.DeserializeException.ThrowIfDuplicate(_r_assignedValid, 1, _l_serdeInfo);
+                        _l_y = typeDeserialize.ReadF32(_l_serdeInfo, _l_index_);
+                        _r_assignedValid |= ((byte)1) << 1;
+                        break;
+                    case Serde.ITypeDeserializer.IndexNotFound:
+                        typeDeserialize.SkipValue(_l_serdeInfo, _l_index_);
+                        break;
+                    default:
+                        throw new InvalidOperationException("Unexpected index: " + _l_index_);
+                }
+            }
+            if ((_r_assignedValid & 0b11) != 0b11)
+            {
+                throw Serde.DeserializeException.UnassignedMember();
+            }
+            var newType = new System.Numerics.Vector2() {
+                X = _l_x,
+                Y = _l_y,
+            };
+
+
+            typeDeserialize.End(_l_serdeInfo);
+
+            return newType;
+        }
+    }
+}

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Json.Test.Vector2Proxy.ISerdeInfoProvider.g.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Json.Test.Vector2Proxy.ISerdeInfoProvider.g.cs
@@ -1,0 +1,16 @@
+
+#nullable enable
+
+namespace Serde.Json.Test;
+
+partial class Vector2Proxy
+{
+    private static global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
+        "Vector2",
+    typeof(System.Numerics.Vector2).GetCustomAttributesData(),
+    new (string, global::Serde.ISerdeInfo, System.Reflection.MemberInfo?)[] {
+        ("X", global::Serde.SerdeInfoProvider.GetSerializeInfo<float, global::Serde.F32Proxy>(), typeof(System.Numerics.Vector2).GetField("X")),
+        ("Y", global::Serde.SerdeInfoProvider.GetSerializeInfo<float, global::Serde.F32Proxy>(), typeof(System.Numerics.Vector2).GetField("Y"))
+    }
+    );
+}

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Json.Test.Vector2Proxy.ISerdeInfoProvider.g.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Json.Test.Vector2Proxy.ISerdeInfoProvider.g.cs
@@ -9,8 +9,8 @@ partial class Vector2Proxy
         "Vector2",
     typeof(System.Numerics.Vector2).GetCustomAttributesData(),
     new (string, global::Serde.ISerdeInfo, System.Reflection.MemberInfo?)[] {
-        ("X", global::Serde.SerdeInfoProvider.GetSerializeInfo<float, global::Serde.F32Proxy>(), typeof(System.Numerics.Vector2).GetField("X")),
-        ("Y", global::Serde.SerdeInfoProvider.GetSerializeInfo<float, global::Serde.F32Proxy>(), typeof(System.Numerics.Vector2).GetField("Y"))
+        ("x", global::Serde.SerdeInfoProvider.GetSerializeInfo<float, global::Serde.F32Proxy>(), typeof(System.Numerics.Vector2).GetField("X")),
+        ("y", global::Serde.SerdeInfoProvider.GetSerializeInfo<float, global::Serde.F32Proxy>(), typeof(System.Numerics.Vector2).GetField("Y"))
     }
     );
 }

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Json.Test.Vector2Proxy.ISerdeProvider.g.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Json.Test.Vector2Proxy.ISerdeProvider.g.cs
@@ -1,0 +1,8 @@
+
+namespace Serde.Json.Test;
+
+partial class Vector2Proxy : Serde.ISerdeProvider<Serde.Json.Test.Vector2Proxy, Serde.Json.Test.Vector2Proxy._SerdeObj, System.Numerics.Vector2>
+{
+    static Serde.Json.Test.Vector2Proxy._SerdeObj global::Serde.ISerdeProvider<Serde.Json.Test.Vector2Proxy, Serde.Json.Test.Vector2Proxy._SerdeObj, System.Numerics.Vector2>.Instance { get; }
+        = new Serde.Json.Test.Vector2Proxy._SerdeObj();
+}

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Json.Test.Vector2Proxy2.ISerde.g.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Json.Test.Vector2Proxy2.ISerde.g.cs
@@ -65,9 +65,6 @@ partial class Vector2Proxy2
                 Y = _l_y,
             };
 
-
-            typeDeserialize.End(_l_serdeInfo);
-
             return newType;
         }
     }

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Json.Test.Vector2Proxy2.ISerde.g.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Json.Test.Vector2Proxy2.ISerde.g.cs
@@ -1,0 +1,74 @@
+
+#nullable enable
+
+using System;
+using Serde;
+
+namespace Serde.Json.Test;
+
+partial class Vector2Proxy2
+{
+    sealed partial class _SerdeObj : global::Serde.ISerde<System.Numerics.Vector2>
+    {
+        global::Serde.ISerdeInfo global::Serde.ISerdeInfoProvider.SerdeInfo => Serde.Json.Test.Vector2Proxy2.s_serdeInfo;
+
+        void global::Serde.ISerialize<System.Numerics.Vector2>.Serialize(System.Numerics.Vector2 value, global::Serde.ISerializer serializer)
+        {
+            var _l_info = global::Serde.SerdeInfoProvider.GetInfo(this);
+            var _l_type = serializer.WriteType(_l_info);
+            _l_type.WriteF32(_l_info, 0, value.X);
+            _l_type.WriteF32(_l_info, 1, value.Y);
+            _l_type.End(_l_info);
+        }
+        System.Numerics.Vector2 Serde.IDeserialize<System.Numerics.Vector2>.Deserialize(IDeserializer deserializer)
+        {
+            float _l_x = default!;
+            float _l_y = default!;
+
+            byte _r_assignedValid = 0;
+
+            var _l_serdeInfo = global::Serde.SerdeInfoProvider.GetInfo(this);
+            var typeDeserialize = deserializer.ReadType(_l_serdeInfo);
+            while (true)
+            {
+                var (_l_index_, _) = typeDeserialize.TryReadIndexWithName(_l_serdeInfo);
+                if (_l_index_ == Serde.ITypeDeserializer.EndOfType)
+                {
+                    break;
+                }
+
+                switch (_l_index_)
+                {
+                    case 0:
+                        Serde.DeserializeException.ThrowIfDuplicate(_r_assignedValid, 0, _l_serdeInfo);
+                        _l_x = typeDeserialize.ReadF32(_l_serdeInfo, _l_index_);
+                        _r_assignedValid |= ((byte)1) << 0;
+                        break;
+                    case 1:
+                        Serde.DeserializeException.ThrowIfDuplicate(_r_assignedValid, 1, _l_serdeInfo);
+                        _l_y = typeDeserialize.ReadF32(_l_serdeInfo, _l_index_);
+                        _r_assignedValid |= ((byte)1) << 1;
+                        break;
+                    case Serde.ITypeDeserializer.IndexNotFound:
+                        typeDeserialize.SkipValue(_l_serdeInfo, _l_index_);
+                        break;
+                    default:
+                        throw new InvalidOperationException("Unexpected index: " + _l_index_);
+                }
+            }
+            if ((_r_assignedValid & 0b11) != 0b11)
+            {
+                throw Serde.DeserializeException.UnassignedMember();
+            }
+            var newType = new System.Numerics.Vector2() {
+                X = _l_x,
+                Y = _l_y,
+            };
+
+
+            typeDeserialize.End(_l_serdeInfo);
+
+            return newType;
+        }
+    }
+}

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Json.Test.Vector2Proxy2.ISerdeInfoProvider.g.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Json.Test.Vector2Proxy2.ISerdeInfoProvider.g.cs
@@ -1,0 +1,16 @@
+
+#nullable enable
+
+namespace Serde.Json.Test;
+
+partial class Vector2Proxy2
+{
+    private static global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
+        "Vector2",
+    typeof(System.Numerics.Vector2).GetCustomAttributesData(),
+    new (string, global::Serde.ISerdeInfo, System.Reflection.MemberInfo?)[] {
+        ("X", global::Serde.SerdeInfoProvider.GetSerializeInfo<float, global::Serde.F32Proxy>(), typeof(System.Numerics.Vector2).GetField("X")),
+        ("Y", global::Serde.SerdeInfoProvider.GetSerializeInfo<float, global::Serde.F32Proxy>(), typeof(System.Numerics.Vector2).GetField("Y"))
+    }
+    );
+}

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Json.Test.Vector2Proxy2.ISerdeInfoProvider.g.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Json.Test.Vector2Proxy2.ISerdeInfoProvider.g.cs
@@ -9,8 +9,8 @@ partial class Vector2Proxy2
         "Vector2",
     typeof(System.Numerics.Vector2).GetCustomAttributesData(),
     new (string, global::Serde.ISerdeInfo, System.Reflection.MemberInfo?)[] {
-        ("X", global::Serde.SerdeInfoProvider.GetSerializeInfo<float, global::Serde.F32Proxy>(), typeof(System.Numerics.Vector2).GetField("X")),
-        ("Y", global::Serde.SerdeInfoProvider.GetSerializeInfo<float, global::Serde.F32Proxy>(), typeof(System.Numerics.Vector2).GetField("Y"))
+        ("x", global::Serde.SerdeInfoProvider.GetSerializeInfo<float, global::Serde.F32Proxy>(), typeof(System.Numerics.Vector2).GetField("X")),
+        ("y", global::Serde.SerdeInfoProvider.GetSerializeInfo<float, global::Serde.F32Proxy>(), typeof(System.Numerics.Vector2).GetField("Y"))
     }
     );
 }

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Json.Test.Vector2Proxy2.ISerdeProvider.g.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Json.Test.Vector2Proxy2.ISerdeProvider.g.cs
@@ -1,0 +1,8 @@
+
+namespace Serde.Json.Test;
+
+partial class Vector2Proxy2 : Serde.ISerdeProvider<Serde.Json.Test.Vector2Proxy2, Serde.Json.Test.Vector2Proxy2._SerdeObj, System.Numerics.Vector2>
+{
+    static Serde.Json.Test.Vector2Proxy2._SerdeObj global::Serde.ISerdeProvider<Serde.Json.Test.Vector2Proxy2, Serde.Json.Test.Vector2Proxy2._SerdeObj, System.Numerics.Vector2>.Instance { get; }
+        = new Serde.Json.Test.Vector2Proxy2._SerdeObj();
+}

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Json.Test.Vector3Proxy.ISerde.g.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Json.Test.Vector3Proxy.ISerde.g.cs
@@ -6,24 +6,26 @@ using Serde;
 
 namespace Serde.Json.Test;
 
-partial class Vector2Proxy
+partial class Vector3Proxy
 {
-    sealed partial class _SerdeObj : global::Serde.ISerde<System.Numerics.Vector2>
+    sealed partial class _SerdeObj : global::Serde.ISerde<System.Numerics.Vector3>
     {
-        global::Serde.ISerdeInfo global::Serde.ISerdeInfoProvider.SerdeInfo => Serde.Json.Test.Vector2Proxy.s_serdeInfo;
+        global::Serde.ISerdeInfo global::Serde.ISerdeInfoProvider.SerdeInfo => Serde.Json.Test.Vector3Proxy.s_serdeInfo;
 
-        void global::Serde.ISerialize<System.Numerics.Vector2>.Serialize(System.Numerics.Vector2 value, global::Serde.ISerializer serializer)
+        void global::Serde.ISerialize<System.Numerics.Vector3>.Serialize(System.Numerics.Vector3 value, global::Serde.ISerializer serializer)
         {
             var _l_info = global::Serde.SerdeInfoProvider.GetInfo(this);
             var _l_type = serializer.WriteType(_l_info);
             _l_type.WriteF32(_l_info, 0, value.X);
             _l_type.WriteF32(_l_info, 1, value.Y);
+            _l_type.WriteF32(_l_info, 2, value.Z);
             _l_type.End(_l_info);
         }
-        System.Numerics.Vector2 Serde.IDeserialize<System.Numerics.Vector2>.Deserialize(IDeserializer deserializer)
+        System.Numerics.Vector3 Serde.IDeserialize<System.Numerics.Vector3>.Deserialize(IDeserializer deserializer)
         {
             float _l_x = default!;
             float _l_y = default!;
+            float _l_z = default!;
 
             byte _r_assignedValid = 0;
 
@@ -49,6 +51,11 @@ partial class Vector2Proxy
                         _l_y = typeDeserialize.ReadF32(_l_serdeInfo, _l_index_);
                         _r_assignedValid |= ((byte)1) << 1;
                         break;
+                    case 2:
+                        Serde.DeserializeException.ThrowIfDuplicate(_r_assignedValid, 2, _l_serdeInfo);
+                        _l_z = typeDeserialize.ReadF32(_l_serdeInfo, _l_index_);
+                        _r_assignedValid |= ((byte)1) << 2;
+                        break;
                     case Serde.ITypeDeserializer.IndexNotFound:
                         typeDeserialize.SkipValue(_l_serdeInfo, _l_index_);
                         break;
@@ -56,13 +63,14 @@ partial class Vector2Proxy
                         throw new InvalidOperationException("Unexpected index: " + _l_index_);
                 }
             }
-            if ((_r_assignedValid & 0b11) != 0b11)
+            if ((_r_assignedValid & 0b111) != 0b111)
             {
                 throw Serde.DeserializeException.UnassignedMember();
             }
-            var newType = new System.Numerics.Vector2() {
+            var newType = new System.Numerics.Vector3() {
                 X = _l_x,
                 Y = _l_y,
+                Z = _l_z,
             };
 
             return newType;

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Json.Test.Vector3Proxy.ISerdeInfoProvider.g.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Json.Test.Vector3Proxy.ISerdeInfoProvider.g.cs
@@ -1,0 +1,17 @@
+
+#nullable enable
+
+namespace Serde.Json.Test;
+
+partial class Vector3Proxy
+{
+    private static global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
+        "Vector3",
+    typeof(System.Numerics.Vector3).GetCustomAttributesData(),
+    new (string, global::Serde.ISerdeInfo, System.Reflection.MemberInfo?)[] {
+        ("x", global::Serde.SerdeInfoProvider.GetSerializeInfo<float, global::Serde.F32Proxy>(), typeof(System.Numerics.Vector3).GetField("X")),
+        ("y", global::Serde.SerdeInfoProvider.GetSerializeInfo<float, global::Serde.F32Proxy>(), typeof(System.Numerics.Vector3).GetField("Y")),
+        ("z", global::Serde.SerdeInfoProvider.GetSerializeInfo<float, global::Serde.F32Proxy>(), typeof(System.Numerics.Vector3).GetField("Z"))
+    }
+    );
+}

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Json.Test.Vector3Proxy.ISerdeProvider.g.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Json.Test.Vector3Proxy.ISerdeProvider.g.cs
@@ -1,0 +1,8 @@
+
+namespace Serde.Json.Test;
+
+partial class Vector3Proxy : Serde.ISerdeProvider<Serde.Json.Test.Vector3Proxy, Serde.Json.Test.Vector3Proxy._SerdeObj, System.Numerics.Vector3>
+{
+    static Serde.Json.Test.Vector3Proxy._SerdeObj global::Serde.ISerdeProvider<Serde.Json.Test.Vector3Proxy, Serde.Json.Test.Vector3Proxy._SerdeObj, System.Numerics.Vector3>.Instance { get; }
+        = new Serde.Json.Test.Vector3Proxy._SerdeObj();
+}

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Json.Test.Vector4Proxy.ISerde.g.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Json.Test.Vector4Proxy.ISerde.g.cs
@@ -6,24 +6,28 @@ using Serde;
 
 namespace Serde.Json.Test;
 
-partial class Vector2Proxy
+partial class Vector4Proxy
 {
-    sealed partial class _SerdeObj : global::Serde.ISerde<System.Numerics.Vector2>
+    sealed partial class _SerdeObj : global::Serde.ISerde<System.Numerics.Vector4>
     {
-        global::Serde.ISerdeInfo global::Serde.ISerdeInfoProvider.SerdeInfo => Serde.Json.Test.Vector2Proxy.s_serdeInfo;
+        global::Serde.ISerdeInfo global::Serde.ISerdeInfoProvider.SerdeInfo => Serde.Json.Test.Vector4Proxy.s_serdeInfo;
 
-        void global::Serde.ISerialize<System.Numerics.Vector2>.Serialize(System.Numerics.Vector2 value, global::Serde.ISerializer serializer)
+        void global::Serde.ISerialize<System.Numerics.Vector4>.Serialize(System.Numerics.Vector4 value, global::Serde.ISerializer serializer)
         {
             var _l_info = global::Serde.SerdeInfoProvider.GetInfo(this);
             var _l_type = serializer.WriteType(_l_info);
             _l_type.WriteF32(_l_info, 0, value.X);
             _l_type.WriteF32(_l_info, 1, value.Y);
+            _l_type.WriteF32(_l_info, 2, value.Z);
+            _l_type.WriteF32(_l_info, 3, value.W);
             _l_type.End(_l_info);
         }
-        System.Numerics.Vector2 Serde.IDeserialize<System.Numerics.Vector2>.Deserialize(IDeserializer deserializer)
+        System.Numerics.Vector4 Serde.IDeserialize<System.Numerics.Vector4>.Deserialize(IDeserializer deserializer)
         {
             float _l_x = default!;
             float _l_y = default!;
+            float _l_z = default!;
+            float _l_w = default!;
 
             byte _r_assignedValid = 0;
 
@@ -49,6 +53,16 @@ partial class Vector2Proxy
                         _l_y = typeDeserialize.ReadF32(_l_serdeInfo, _l_index_);
                         _r_assignedValid |= ((byte)1) << 1;
                         break;
+                    case 2:
+                        Serde.DeserializeException.ThrowIfDuplicate(_r_assignedValid, 2, _l_serdeInfo);
+                        _l_z = typeDeserialize.ReadF32(_l_serdeInfo, _l_index_);
+                        _r_assignedValid |= ((byte)1) << 2;
+                        break;
+                    case 3:
+                        Serde.DeserializeException.ThrowIfDuplicate(_r_assignedValid, 3, _l_serdeInfo);
+                        _l_w = typeDeserialize.ReadF32(_l_serdeInfo, _l_index_);
+                        _r_assignedValid |= ((byte)1) << 3;
+                        break;
                     case Serde.ITypeDeserializer.IndexNotFound:
                         typeDeserialize.SkipValue(_l_serdeInfo, _l_index_);
                         break;
@@ -56,13 +70,15 @@ partial class Vector2Proxy
                         throw new InvalidOperationException("Unexpected index: " + _l_index_);
                 }
             }
-            if ((_r_assignedValid & 0b11) != 0b11)
+            if ((_r_assignedValid & 0b1111) != 0b1111)
             {
                 throw Serde.DeserializeException.UnassignedMember();
             }
-            var newType = new System.Numerics.Vector2() {
+            var newType = new System.Numerics.Vector4() {
                 X = _l_x,
                 Y = _l_y,
+                Z = _l_z,
+                W = _l_w,
             };
 
             return newType;

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Json.Test.Vector4Proxy.ISerdeInfoProvider.g.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Json.Test.Vector4Proxy.ISerdeInfoProvider.g.cs
@@ -1,0 +1,18 @@
+
+#nullable enable
+
+namespace Serde.Json.Test;
+
+partial class Vector4Proxy
+{
+    private static global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
+        "Vector4",
+    typeof(System.Numerics.Vector4).GetCustomAttributesData(),
+    new (string, global::Serde.ISerdeInfo, System.Reflection.MemberInfo?)[] {
+        ("x", global::Serde.SerdeInfoProvider.GetSerializeInfo<float, global::Serde.F32Proxy>(), typeof(System.Numerics.Vector4).GetField("X")),
+        ("y", global::Serde.SerdeInfoProvider.GetSerializeInfo<float, global::Serde.F32Proxy>(), typeof(System.Numerics.Vector4).GetField("Y")),
+        ("z", global::Serde.SerdeInfoProvider.GetSerializeInfo<float, global::Serde.F32Proxy>(), typeof(System.Numerics.Vector4).GetField("Z")),
+        ("w", global::Serde.SerdeInfoProvider.GetSerializeInfo<float, global::Serde.F32Proxy>(), typeof(System.Numerics.Vector4).GetField("W"))
+    }
+    );
+}

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Json.Test.Vector4Proxy.ISerdeProvider.g.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Json.Test.Vector4Proxy.ISerdeProvider.g.cs
@@ -1,0 +1,8 @@
+
+namespace Serde.Json.Test;
+
+partial class Vector4Proxy : Serde.ISerdeProvider<Serde.Json.Test.Vector4Proxy, Serde.Json.Test.Vector4Proxy._SerdeObj, System.Numerics.Vector4>
+{
+    static Serde.Json.Test.Vector4Proxy._SerdeObj global::Serde.ISerdeProvider<Serde.Json.Test.Vector4Proxy, Serde.Json.Test.Vector4Proxy._SerdeObj, System.Numerics.Vector4>.Instance { get; }
+        = new Serde.Json.Test.Vector4Proxy._SerdeObj();
+}


### PR DESCRIPTION
We already have a mechanism for selecting proxies -- SerdeTypeOptions or SerdeMemberOptions. However, there are two downsides.

First, the proxy is meant to match the type of the member exactly. This can get very verbose if the only thing that's interesting in the proxy is nested inside a type substitution.

Second, there's no way to automatically use a proxy for all members in a type.

The new `UseProxy` feature adds an easy way to pick out individual proxies and reduce boilerplate.

Thanks to @Deficuet for the initial implementation here.