### PR TITLE
Fix exception on missing parameter

### DIFF
--- a/src/generator/DeserializeImplGen.cs
+++ b/src/generator/DeserializeImplGen.cs
@@ -410,6 +410,15 @@ namespace Serde
                 foreach (var p in primaryCtor.Parameters)
                 {
                     var index = assignmentMembers.FindIndex(m => m.Name == p.Name);
+                    if (index < 0)
+                    {
+                        context.ReportDiagnostic(CreateDiagnostic(
+                            DiagId.ERR_CtorParamMismatch,
+                            type.Locations[0],
+                            p.Name,
+                            type.ToDisplayString()));
+                        return new SourceBuilder($"var newType = new {typeName}();");
+                    }
                     if (parameters.Length != 0)
                     {
                         parameters.Append(", ");

--- a/src/generator/Diagnostics.cs
+++ b/src/generator/Diagnostics.cs
@@ -19,6 +19,7 @@ namespace Serde
         ERR_WrapperDoesntImplementInterface = 6,
         ERR_CantImplementAbstract = 7,
         ERR_CantFindTypeParameter = 8,
+        ERR_CtorParamMismatch = 9,
     }
 
     internal static class Diagnostics
@@ -33,6 +34,7 @@ namespace Serde
             ERR_WrapperDoesntImplementInterface => nameof(ERR_WrapperDoesntImplementInterface),
             ERR_CantImplementAbstract => nameof(ERR_CantImplementAbstract),
             ERR_CantFindTypeParameter => nameof(ERR_CantFindTypeParameter),
+            ERR_CtorParamMismatch => nameof(ERR_CtorParamMismatch),
         };
 
         public static Diagnostic CreateDiagnostic(DiagId id, Location location, params object[] args)

--- a/src/generator/Resources.resx
+++ b/src/generator/Resources.resx
@@ -145,4 +145,7 @@
   <data name="ERR_CantFindTypeParameter" xml:space="preserve">
     <value>Could not find type parameter named '{0}' in the current context.</value>
   </data>
+  <data name="ERR_CtorParamMismatch" xml:space="preserve">
+    <value>Constructor parameter '{0}' on type '{1}' does not match any member by name. All constructor parameters must have a corresponding member with the same name.</value>
+  </data>
 </root>

--- a/test/Serde.Generation.Test/DeserializeTests.cs
+++ b/test/Serde.Generation.Test/DeserializeTests.cs
@@ -362,5 +362,23 @@ abstract partial record Base
                 nameof(DeserializeTests),
                 caller,
                 multiFile: false);
+
+        [Fact]
+        public Task CtorParamMismatch()
+        {
+            var src = """
+using Serde;
+
+public readonly struct MyForeignType(int myInt, string myString)
+{
+    public readonly int MyInt { get; } = myInt;
+    public readonly string MyString { get; } = myString;
+}
+
+[GenerateSerde(ForType = typeof(MyForeignType))]
+public readonly partial struct MyForeignTypeProxy;
+""";
+            return VerifyMultiFile(src);
+        }
     }
 }

--- a/test/Serde.Generation.Test/test_output/DeserializeTests.CtorParamMismatch/MyForeignTypeProxy.ISerde.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/DeserializeTests.CtorParamMismatch/MyForeignTypeProxy.ISerde.g.verified.cs
@@ -1,0 +1,61 @@
+﻿//HintName: MyForeignTypeProxy.ISerde.g.cs
+
+#nullable enable
+
+using System;
+using Serde;
+partial struct MyForeignTypeProxy
+{
+    sealed partial class _SerdeObj : global::Serde.ISerde<MyForeignType>
+    {
+        global::Serde.ISerdeInfo global::Serde.ISerdeInfoProvider.SerdeInfo => MyForeignTypeProxy.s_serdeInfo;
+
+        void global::Serde.ISerialize<MyForeignType>.Serialize(MyForeignType value, global::Serde.ISerializer serializer)
+        {
+            var _l_info = global::Serde.SerdeInfoProvider.GetInfo(this);
+            var _l_type = serializer.WriteType(_l_info);
+            _l_type.WriteI32(_l_info, 0, value.MyInt);
+            _l_type.WriteString(_l_info, 1, value.MyString);
+            _l_type.End(_l_info);
+        }
+        MyForeignType Serde.IDeserialize<MyForeignType>.Deserialize(IDeserializer deserializer)
+        {
+            int _l_myint = default!;
+            string _l_mystring = default!;
+
+            byte _r_assignedValid = 0;
+
+            var _l_serdeInfo = global::Serde.SerdeInfoProvider.GetInfo(this);
+            var typeDeserialize = deserializer.ReadType(_l_serdeInfo);
+            while (true)
+            {
+                var (_l_index_, _) = typeDeserialize.TryReadIndexWithName(_l_serdeInfo);
+                if (_l_index_ == Serde.ITypeDeserializer.EndOfType)
+                {
+                    break;
+                }
+
+                switch (_l_index_)
+                {
+                    case 0:
+                        Serde.DeserializeException.ThrowIfDuplicate(_r_assignedValid, 0, _l_serdeInfo);
+                        _l_myint = typeDeserialize.ReadI32(_l_serdeInfo, _l_index_);
+                        _r_assignedValid |= ((byte)1) << 0;
+                        break;
+                    case 1:
+                        Serde.DeserializeException.ThrowIfDuplicate(_r_assignedValid, 1, _l_serdeInfo);
+                        _l_mystring = typeDeserialize.ReadString(_l_serdeInfo, _l_index_);
+                        _r_assignedValid |= ((byte)1) << 1;
+                        break;
+                    case Serde.ITypeDeserializer.IndexNotFound:
+                        typeDeserialize.SkipValue(_l_serdeInfo, _l_index_);
+                        break;
+                    default:
+                        throw new InvalidOperationException("Unexpected index: " + _l_index_);
+                }
+            }
+            var newType = new MyForeignType();
+            return newType;
+        }
+    }
+}

--- a/test/Serde.Generation.Test/test_output/DeserializeTests.CtorParamMismatch/MyForeignTypeProxy.ISerdeInfoProvider.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/DeserializeTests.CtorParamMismatch/MyForeignTypeProxy.ISerdeInfoProvider.g.verified.cs
@@ -1,0 +1,14 @@
+﻿//HintName: MyForeignTypeProxy.ISerdeInfoProvider.g.cs
+
+#nullable enable
+partial struct MyForeignTypeProxy
+{
+    private static global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
+        "MyForeignType",
+    typeof(MyForeignType).GetCustomAttributesData(),
+    new (string, global::Serde.ISerdeInfo, System.Reflection.MemberInfo?)[] {
+        ("myInt", global::Serde.SerdeInfoProvider.GetSerializeInfo<int, global::Serde.I32Proxy>(), typeof(MyForeignType).GetProperty("MyInt")),
+        ("myString", global::Serde.SerdeInfoProvider.GetSerializeInfo<string, global::Serde.StringProxy>(), typeof(MyForeignType).GetProperty("MyString"))
+    }
+    );
+}

--- a/test/Serde.Generation.Test/test_output/DeserializeTests.CtorParamMismatch/MyForeignTypeProxy.ISerdeProvider.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/DeserializeTests.CtorParamMismatch/MyForeignTypeProxy.ISerdeProvider.g.verified.cs
@@ -1,0 +1,6 @@
+﻿//HintName: MyForeignTypeProxy.ISerdeProvider.g.cs
+partial struct MyForeignTypeProxy : Serde.ISerdeProvider<MyForeignTypeProxy, MyForeignTypeProxy._SerdeObj, MyForeignType>
+{
+    static MyForeignTypeProxy._SerdeObj global::Serde.ISerdeProvider<MyForeignTypeProxy, MyForeignTypeProxy._SerdeObj, MyForeignType>.Instance { get; }
+        = new MyForeignTypeProxy._SerdeObj();
+}

--- a/test/Serde.Generation.Test/test_output/DeserializeTests.CtorParamMismatch/target.verified.txt
+++ b/test/Serde.Generation.Test/test_output/DeserializeTests.CtorParamMismatch/target.verified.txt
@@ -1,0 +1,23 @@
+﻿{
+  Diagnostics: [
+    {
+      Location: /*
+
+public readonly struct MyForeignType(int myInt, string myString)
+                       ^^^^^^^^^^^^^
+{
+*/
+ : (2,23)-(2,36),
+      Message: Constructor parameter 'myInt' on type 'MyForeignType' does not match any member by name. All constructor parameters must have a corresponding member with the same name.,
+      Severity: Error,
+      Descriptor: {
+        Id: ERR_CtorParamMismatch,
+        Title: ,
+        MessageFormat: Constructor parameter 'myInt' on type 'MyForeignType' does not match any member by name. All constructor parameters must have a corresponding member with the same name.,
+        Category: Serde,
+        DefaultSeverity: Error,
+        IsEnabledByDefault: true
+      }
+    }
+  ]
+}


### PR DESCRIPTION
When using a constructor for deserialization, the constructor parameter names must line up exactly with member names (case-sensitive). Due to a bug, this crashes when a parameter doesn't line up. Now there will be an error explaining the situation instead.