### PR TITLE
Allow passing CustomAttributeData directly to ISerdeInfo

### DIFF
--- a/src/serde/ISerdeInfo.cs
+++ b/src/serde/ISerdeInfo.cs
@@ -1,11 +1,8 @@
-
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
-using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
 using System.Text;
 
 namespace Serde;

--- a/src/serde/SerdeInfo.cs
+++ b/src/serde/SerdeInfo.cs
@@ -22,7 +22,44 @@ public static class SerdeInfo
         string typeName,
         IList<CustomAttributeData> typeAttributes,
         ReadOnlySpan<(string SerializeName, ISerdeInfo SerdeInfo, MemberInfo? MemberInfo)> fields)
+    {
+        var converted = new (string, ISerdeInfo, IList<CustomAttributeData>)[fields.Length];
+        for (int i = 0; i < fields.Length; i++)
+        {
+            converted[i] = (
+                fields[i].SerializeName,
+                fields[i].SerdeInfo,
+                fields[i].MemberInfo?.GetCustomAttributesData()
+                    ?? (IList<CustomAttributeData>)Array.Empty<CustomAttributeData>());
+        }
+        return TypeWithFieldsInfo.Create(typeName, InfoKind.CustomType, typeAttributes, converted);
+    }
+
+    /// <summary>
+    /// Create an <see cref="ISerdeInfo"/> for a custom type with explicit field attributes.
+    /// </summary>
+    public static ISerdeInfo MakeCustom(
+        string typeName,
+        IList<CustomAttributeData> typeAttributes,
+        ReadOnlySpan<(string SerializeName, ISerdeInfo SerdeInfo, IList<CustomAttributeData> FieldAttributes)> fields)
         => TypeWithFieldsInfo.Create(typeName, InfoKind.CustomType, typeAttributes, fields);
+
+    /// <summary>
+    /// Create an <see cref="ISerdeInfo"/> for a custom type without field attributes or MemberInfo.
+    /// Field attributes default to empty.
+    /// </summary>
+    public static ISerdeInfo MakeCustom(
+        string typeName,
+        IList<CustomAttributeData> typeAttributes,
+        ReadOnlySpan<(string SerializeName, ISerdeInfo SerdeInfo)> fields)
+    {
+        var converted = new (string, ISerdeInfo, IList<CustomAttributeData>)[fields.Length];
+        for (int i = 0; i < fields.Length; i++)
+        {
+            converted[i] = (fields[i].SerializeName, fields[i].SerdeInfo, Array.Empty<CustomAttributeData>());
+        }
+        return TypeWithFieldsInfo.Create(typeName, InfoKind.CustomType, typeAttributes, converted);
+    }
 
     public static ISerdeInfo MakeEnum(
         string typeName,
@@ -30,10 +67,14 @@ public static class SerdeInfo
         ISerdeInfo underlyingInfo,
         ReadOnlySpan<(string SerializeName, MemberInfo? MemberInfo)> fields)
     {
-        var fieldsWithInfo = new (string SerializeName, ISerdeInfo SerdeInfo, MemberInfo? MemberInfo)[fields.Length];
+        var fieldsWithInfo = new (string SerializeName, ISerdeInfo SerdeInfo, IList<CustomAttributeData> FieldAttributes)[fields.Length];
         for (int i = 0; i < fields.Length; i++)
         {
-            fieldsWithInfo[i] = (fields[i].SerializeName, underlyingInfo, fields[i].MemberInfo);
+            fieldsWithInfo[i] = (
+                fields[i].SerializeName,
+                underlyingInfo,
+                fields[i].MemberInfo?.GetCustomAttributesData()
+                    ?? (IList<CustomAttributeData>)Array.Empty<CustomAttributeData>());
         }
 
         return TypeWithFieldsInfo.Create(typeName, InfoKind.Enum, typeAttributes, fieldsWithInfo);
@@ -107,7 +148,11 @@ public static class SerdeInfo
         private ArgumentOutOfRangeException GetOOR(int index)
             => new ArgumentOutOfRangeException(nameof(index), index, $"{Name} has {TypeArgInfos.Length} type argument(s).");
     }
+}
 
+public static class SerdeInfoExtensions
+{
+    public static ISerdeInfo WithName(this ISerdeInfo @this, string newName) => new WrappingInfo(@this, newName);
 }
 
 /// <summary>
@@ -140,6 +185,28 @@ file sealed record NullableSerdeInfo(ISerdeInfo UnderlyingInfo) : ISerdeInfo
 
     private ArgumentOutOfRangeException GetOOR(int index)
         => new ArgumentOutOfRangeException(nameof(index), index, $"{Name} has only one field.");
+}
+
+/// <summary>
+/// Wraps an existing <see cref="ISerdeInfo"/> with a new name.
+/// </summary>
+file sealed class WrappingInfo(ISerdeInfo underlying, string name) : ISerdeInfo
+{
+    public string Name => name;
+    public InfoKind Kind => underlying.Kind;
+    public PrimitiveKind? PrimitiveKind => underlying.PrimitiveKind;
+    public IList<CustomAttributeData> Attributes => underlying.Attributes;
+    public int FieldCount => underlying.FieldCount;
+
+    public Utf8Span GetFieldName(int index) => underlying.GetFieldName(index);
+    public string GetFieldStringName(int index) => underlying.GetFieldStringName(index);
+    public IList<CustomAttributeData> GetFieldAttributes(int index) => underlying.GetFieldAttributes(index);
+    public int TryGetIndex(Utf8Span fieldName) => underlying.TryGetIndex(fieldName);
+
+    [Experimental("SerdeExperimentalFieldInfo")]
+#pragma warning disable SerdeExperimentalFieldInfo
+    public ISerdeInfo GetFieldInfo(int index) => underlying.GetFieldInfo(index);
+#pragma warning restore SerdeExperimentalFieldInfo
 }
 
 
@@ -216,19 +283,19 @@ file sealed record TypeWithFieldsInfo : ISerdeInfo
         string typeName,
         InfoKind typeKind,
         IList<CustomAttributeData> typeAttributes,
-        ReadOnlySpan<(string SerializeName, ISerdeInfo SerdeInfo, MemberInfo? MemberInfo)> fields)
+        ReadOnlySpan<(string SerializeName, ISerdeInfo SerdeInfo, IList<CustomAttributeData> FieldAttributes)> fields)
     {
         var nameToIndexBuilder = ImmutableArray.CreateBuilder<(ReadOnlyMemory<byte> Utf8Name, int Index)>(fields.Length);
         var indexToInfoBuilder = ImmutableArray.CreateBuilder<PrivateFieldInfo>(fields.Length);
         for (int index = 0; index < fields.Length; index++)
         {
-            var (serializeName, serdeInfo, memberInfo) = fields[index];
+            var (serializeName, serdeInfo, fieldAttributes) = fields[index];
 
             nameToIndexBuilder.Add((ISerdeInfo.UTF8Encoding.GetBytes(serializeName), index));
             var fieldInfo = new PrivateFieldInfo(
                 serializeName,
                 default,
-                memberInfo?.GetCustomAttributesData().ToImmutableArray() ?? ImmutableArray<CustomAttributeData>.Empty,
+                fieldAttributes,
                 serdeInfo);
             indexToInfoBuilder.Add(fieldInfo);
         }

--- a/test/Serde.Test/SerdeInfoTests.cs
+++ b/test/Serde.Test/SerdeInfoTests.cs
@@ -1,7 +1,9 @@
 
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
+using System.Reflection;
 using System.Runtime.Serialization;
 using StaticCs;
 using Xunit;
@@ -179,6 +181,135 @@ public sealed partial class SerdeInfoTests
         Assert.Equal(I32Proxy.SerdeInfo, valueInfo);
         Assert.Equal(InfoKind.Primitive, valueInfo.Kind);
         Assert.Equal(PrimitiveKind.I32, valueInfo.PrimitiveKind);
+    }
+
+    [Fact]
+    public void WithName_PreservesFieldsAndKind()
+    {
+        var original = SerdeInfoProvider.GetDeserializeInfo<Rgb, RgbProxy>();
+        var renamed = original.WithName("NewRgb");
+
+        Assert.Equal("NewRgb", renamed.Name);
+        Assert.Equal(original.Kind, renamed.Kind);
+        Assert.Equal(original.FieldCount, renamed.FieldCount);
+        Assert.Equal(original.Attributes, renamed.Attributes);
+
+        for (int i = 0; i < original.FieldCount; i++)
+        {
+            Assert.Equal(original.GetFieldStringName(i), renamed.GetFieldStringName(i));
+            Assert.Equal(original.GetFieldAttributes(i), renamed.GetFieldAttributes(i));
+            Assert.Equal(original.GetFieldInfo(i), renamed.GetFieldInfo(i));
+        }
+
+        Assert.Equal(0, renamed.TryGetIndex("r"u8));
+        Assert.Equal(1, renamed.TryGetIndex("g"u8));
+        Assert.Equal(2, renamed.TryGetIndex("b"u8));
+    }
+
+    [Fact]
+    public void MakeCustom_NoMemberInfo_SimpleOverload()
+    {
+        var info = SerdeInfo.MakeCustom(
+            "SimpleType",
+            System.Array.Empty<System.Reflection.CustomAttributeData>(),
+            new (string, ISerdeInfo)[] {
+                ("x", I32Proxy.SerdeInfo),
+                ("y", StringProxy.SerdeInfo)
+            });
+
+        Assert.Equal("SimpleType", info.Name);
+        Assert.Equal(InfoKind.CustomType, info.Kind);
+        Assert.Equal(2, info.FieldCount);
+        Assert.Equal("x", info.GetFieldStringName(0));
+        Assert.Equal("y", info.GetFieldStringName(1));
+        Assert.Equal(0, info.TryGetIndex("x"u8));
+        Assert.Equal(1, info.TryGetIndex("y"u8));
+        Assert.Empty(info.GetFieldAttributes(0));
+        Assert.Empty(info.GetFieldAttributes(1));
+        Assert.Equal(I32Proxy.SerdeInfo, info.GetFieldInfo(0));
+        Assert.Equal(StringProxy.SerdeInfo, info.GetFieldInfo(1));
+    }
+
+    [Fact]
+    public void MakeCustom_ExplicitFieldAttributes()
+    {
+        var info = SerdeInfo.MakeCustom(
+            "AttrType",
+            System.Array.Empty<System.Reflection.CustomAttributeData>(),
+            new (string, ISerdeInfo, IList<System.Reflection.CustomAttributeData>)[] {
+                ("a", I32Proxy.SerdeInfo, System.Array.Empty<System.Reflection.CustomAttributeData>()),
+                ("b", StringProxy.SerdeInfo, System.Array.Empty<System.Reflection.CustomAttributeData>())
+            });
+
+        Assert.Equal("AttrType", info.Name);
+        Assert.Equal(InfoKind.CustomType, info.Kind);
+        Assert.Equal(2, info.FieldCount);
+        Assert.Equal("a", info.GetFieldStringName(0));
+        Assert.Equal("b", info.GetFieldStringName(1));
+        Assert.Equal(0, info.TryGetIndex("a"u8));
+        Assert.Equal(1, info.TryGetIndex("b"u8));
+        Assert.Equal(I32Proxy.SerdeInfo, info.GetFieldInfo(0));
+        Assert.Equal(StringProxy.SerdeInfo, info.GetFieldInfo(1));
+    }
+
+    [Fact]
+    public void MakeCustom_SyntheticCustomAttributeData()
+    {
+        // Verify that CustomAttributeData can be subclassed to synthesize
+        // attribute metadata for types that aren't actually loaded.
+        var syntheticAttr = new SyntheticCustomAttributeData(
+            typeof(DefaultValueAttribute),
+            [new CustomAttributeTypedArgument(typeof(string), "synthetic")],
+            []);
+
+        var info = SerdeInfo.MakeCustom(
+            "SyntheticType",
+            new CustomAttributeData[] { syntheticAttr },
+            new (string, ISerdeInfo, IList<CustomAttributeData>)[] {
+                ("field1", I32Proxy.SerdeInfo, new CustomAttributeData[] { syntheticAttr }),
+                ("field2", StringProxy.SerdeInfo, System.Array.Empty<CustomAttributeData>())
+            });
+
+        Assert.Equal("SyntheticType", info.Name);
+        Assert.Equal(InfoKind.CustomType, info.Kind);
+
+        // Type-level synthetic attribute
+        var typeAttr = Assert.Single(info.Attributes);
+        Assert.Equal(typeof(DefaultValueAttribute), typeAttr.AttributeType);
+        Assert.Equal("synthetic", typeAttr.ConstructorArguments[0].Value);
+
+        // Field-level synthetic attribute
+        var fieldAttr = Assert.Single(info.GetFieldAttributes(0));
+        Assert.Equal(typeof(DefaultValueAttribute), fieldAttr.AttributeType);
+        Assert.Equal("synthetic", fieldAttr.ConstructorArguments[0].Value);
+
+        // Second field has no attributes
+        Assert.Empty(info.GetFieldAttributes(1));
+    }
+
+    /// <summary>
+    /// A subclass of CustomAttributeData that can be constructed without
+    /// a real metadata-backed type, for synthesizing ISerdeInfo.
+    /// </summary>
+    private sealed class SyntheticCustomAttributeData : CustomAttributeData
+    {
+        private readonly Type _attributeType;
+        private readonly IList<CustomAttributeTypedArgument> _constructorArguments;
+        private readonly IList<CustomAttributeNamedArgument> _namedArguments;
+
+        public SyntheticCustomAttributeData(
+            Type attributeType,
+            IList<CustomAttributeTypedArgument> constructorArguments,
+            IList<CustomAttributeNamedArgument> namedArguments)
+        {
+            _attributeType = attributeType;
+            _constructorArguments = constructorArguments;
+            _namedArguments = namedArguments;
+        }
+
+        public override Type AttributeType => _attributeType;
+        public override IList<CustomAttributeTypedArgument> ConstructorArguments => _constructorArguments;
+        public override IList<CustomAttributeNamedArgument> NamedArguments => _namedArguments;
     }
 
 #pragma warning restore SerdeExperimentalFieldInfo // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.


### PR DESCRIPTION
The most efficient way to store attribute data is usually to rely on the built-in .NET implementation of attributes. However, you might want to provide attribute data without actually forcing attributes to appear in source. This is especially interesting for proxy types.