### PR TITLE
Add support for using conversions in Generate ForType

### DIFF
--- a/docs/book.toml
+++ b/docs/book.toml
@@ -1,6 +1,5 @@
 [book]
 authors = ["Andy Gocke"]
 language = "en"
-multilingual = false
 src = "guide"
 title = "Serde.NET"

--- a/docs/guide/customization.md
+++ b/docs/guide/customization.md
@@ -7,7 +7,7 @@ To specify the custom object, use `[GenerateSerde(With = typeof(CustomObject))]`
 Here is a simple example where Colors are converted to strings:
 
 ```csharp
-{{#include ../samples/CustomSerialize.cs }}
+{{#include ../../samples/CustomSerialize.cs }}
 ```
 
 In the above, the custom implementation also implements the required interface `ISerdeInfo`. The implementation of all these interfaces must match.

--- a/docs/guide/data-model.md
+++ b/docs/guide/data-model.md
@@ -30,5 +30,5 @@ The Serde data model is as follows:
   - Sometimes referred to as "polymorphic types." C# does not yet have built-in support for discriminated unions, but the source generator will match a particular pattern anyway. To write a union type, use an abstract record type, with nested records that inherit from the parent record. The parent record must only have private constructors. For example,
 
 ```csharp
-{{#include ../samples/Unions.cs:union-def}}
+{{#include ../../samples/Unions.cs:union-def}}
 ```

--- a/docs/guide/foreign-types.md
+++ b/docs/guide/foreign-types.md
@@ -3,5 +3,40 @@
 Sometimes you need to serialize or deserialize a type you don't control or can't modify. In these cases, Serde uses a "proxy type" to stand-in for the external type. To create a proxy type, simply create a new class and add the attribute `[GenerateSerde(ForType = typeof(ExternalType)]`. Serde will automatically use the public properties and fields on the external type if the proxy type is empty. Here's a simple example that assumes there's an external `Response` record that you can't modify.
 
 ```csharp
-{{#include ../samples/ExternalTypes.cs }}
+{{#include ../../samples/ExternalTypes.cs }}
 ```
+
+## Types that need conversion
+
+An empty proxy works when the external type has a parameterless constructor (or a
+matching primary constructor) so Serde can construct it during deserialization.
+Some external types don't fit that mold — for example, a BCL type like
+`System.Version` ships without any Serde support, can't be annotated with
+`[GenerateSerde]`, and has no parameterless constructor. For those, write a
+*non-empty* proxy that mirrors the data you want on the wire, and provide explicit
+conversion operators in both directions:
+
+- `ExternalType -> Proxy`, used when **serializing**.
+- `Proxy -> ExternalType`, used when **deserializing**.
+
+Serde generates the serialization against the proxy's own fields and uses the
+operators to convert to and from the external type at the call site. The operators
+are the contract that the proxy faithfully represents the external type, and the
+compiler enforces that they exist: if you generate serialization you must supply
+`ExternalType -> Proxy`, and if you generate deserialization you must supply
+`Proxy -> ExternalType`.
+
+```csharp
+{{#include ../../samples/ConversionProxy.cs }}
+```
+
+Serializing a `Version` then produces JSON from the proxy's fields:
+
+```json
+{"major":1,"minor":2,"build":3,"revision":4}
+```
+
+Note that the proxy only needs the conversion operators for the directions you
+actually generate. A serialize-only proxy (`[GenerateSerialize(ForType = ...)]`)
+needs only `ExternalType -> Proxy`, and a deserialize-only proxy
+(`[GenerateDeserialize(ForType = ...)]`) needs only `Proxy -> ExternalType`.

--- a/docs/guide/generic-types.md
+++ b/docs/guide/generic-types.md
@@ -5,5 +5,5 @@ Generic types are more complicated because serialize and deserialize must be sep
 The pattern is to separate into two separate classes nested underneath a generic type. An example of a custom collection type is as follows:
 
 ```csharp
-{{#include ../samples/GenericTypeSample.cs}}
+{{#include ../../samples/GenericTypeSample.cs}}
 ```

--- a/src/generator/DeserializeImplGen.cs
+++ b/src/generator/DeserializeImplGen.cs
@@ -19,6 +19,7 @@ namespace Serde
         internal static SourceBuilder GenDeserialize(
             GeneratorExecutionContext context,
             ITypeSymbol receiverType,
+            INamedTypeSymbol? foreignType,
             ImmutableList<(ITypeSymbol Receiver, ITypeSymbol Containing)> inProgress)
         {
             var typeFqn = receiverType.ToDisplayString();
@@ -33,7 +34,7 @@ namespace Serde
             // Generate members for IDeserialize.Deserialize implementation
             var members = receiverType.TypeKind == TypeKind.Enum
                 ? GenerateEnumDeserializeMethod(receiverType, typeSyntax)
-                : GenerateCustomDeserializeMethod(context, receiverType, typeSyntax, inProgress);
+                : GenerateCustomDeserializeMethod(context, receiverType, typeSyntax, foreignType, inProgress);
             return members;
         }
 
@@ -65,13 +66,6 @@ namespace Serde
 
             var members = SymbolUtilities.GetDUTypeMembers(type);
             var typeFqn = type.ToDisplayString();
-            var assignedVarType = members.Length switch {
-                (<= 8) => "byte",
-                (<= 16) => "ushort",
-                (<= 32) => "uint",
-                (<= 64) => "ulong",
-                _ => throw new InvalidOperationException("Too many members in type")
-            };
             var membersBuilder = new StringBuilder();
             for (int i = 0; i < members.Length; i++)
             {
@@ -196,6 +190,7 @@ namespace Serde
             GeneratorExecutionContext context,
             ITypeSymbol type,
             TypeSyntax typeSyntax,
+            INamedTypeSymbol? foreignType,
             ImmutableList<(ITypeSymbol Receiver, ITypeSymbol Containing)> inProgress)
         {
             Debug.Assert(type.TypeKind != TypeKind.Enum);
@@ -213,6 +208,7 @@ namespace Serde
             };
             var (cases, locals, requiredMask) = InitCasesAndLocals();
             var typeCreationExpr = GenerateTypeCreation(context, typeFqn, type, members, requiredMask);
+            string foreignTypeConversionOpt = foreignType is not null ? $"({foreignType.ToDisplayString()})" : "";
 
             const string typeInfoLocalName = "_l_serdeInfo";
             const string indexLocalName = "_l_index_";
@@ -222,8 +218,9 @@ namespace Serde
                 ? $"{IndexErrorName}"
                 : "_";
 
+            var interfaceString = (foreignType ?? type).ToDisplayString(SymbolUtilities.FqnFormat);
             var methodText = new SourceBuilder($$"""
-{{typeFqn}} Serde.IDeserialize<{{typeFqn}}>.Deserialize(IDeserializer deserializer)
+{{interfaceString}} Serde.IDeserialize<{{interfaceString}}>.Deserialize(IDeserializer deserializer)
 {
     {{locals}}
     {{assignedVarType}} {{AssignedVarName}} = 0;
@@ -244,7 +241,7 @@ namespace Serde
         }
     }
     {{typeCreationExpr}}
-    return newType;
+    return {{foreignTypeConversionOpt}}newType;
 }
 """);
             return methodText;
@@ -365,8 +362,9 @@ namespace Serde
 
         /// <summary>
         /// If the type has a parameterless constructor then we will use that and just set
-        /// each member in the initializer. If there is no parameterlss constructor, there
-        /// must be a primary constructor.
+        /// each member in the initializer. If there is no parameterless constructor, there
+        /// must be a primary constructor. When foreignType is set, the proxy (type) is
+        /// constructed instead and converted to the foreign type via explicit conversion.
         /// </summary>
         private static SourceBuilder GenerateTypeCreation(
             GeneratorExecutionContext context,
@@ -449,6 +447,7 @@ namespace Serde
             }
             typeCreation.Dedent();
             typeCreation.AppendLine("};");
+
             return typeCreation;
         }
 

--- a/src/generator/Diagnostics.cs
+++ b/src/generator/Diagnostics.cs
@@ -20,6 +20,8 @@ namespace Serde
         ERR_CantImplementAbstract = 7,
         ERR_CantFindTypeParameter = 8,
         ERR_CtorParamMismatch = 9,
+        ERR_MissingExplicitConversion = 10,
+        ERR_MissingReverseConversion = 11,
     }
 
     internal static class Diagnostics
@@ -35,6 +37,8 @@ namespace Serde
             ERR_CantImplementAbstract => nameof(ERR_CantImplementAbstract),
             ERR_CantFindTypeParameter => nameof(ERR_CantFindTypeParameter),
             ERR_CtorParamMismatch => nameof(ERR_CtorParamMismatch),
+            ERR_MissingExplicitConversion => nameof(ERR_MissingExplicitConversion),
+            ERR_MissingReverseConversion => nameof(ERR_MissingReverseConversion),
         };
 
         public static Diagnostic CreateDiagnostic(DiagId id, Location location, params object[] args)

--- a/src/generator/Resources.resx
+++ b/src/generator/Resources.resx
@@ -148,4 +148,10 @@
   <data name="ERR_CtorParamMismatch" xml:space="preserve">
     <value>Constructor parameter '{0}' on type '{1}' does not match any member by name. All constructor parameters must have a corresponding member with the same name.</value>
   </data>
+  <data name="ERR_MissingExplicitConversion" xml:space="preserve">
+    <value>Proxy type '{0}' must be either empty or define a public explicit conversion operator to '{1}'. Add: public static explicit operator {1}({0} proxy)</value>
+  </data>
+  <data name="ERR_MissingReverseConversion" xml:space="preserve">
+    <value>Proxy type '{0}' must define a public explicit conversion operator from '{1}' in order to serialize it. Add: public static explicit operator {0}({1} value)</value>
+  </data>
 </root>

--- a/src/generator/SerdeImplRoslynGenerator.cs
+++ b/src/generator/SerdeImplRoslynGenerator.cs
@@ -1,15 +1,12 @@
 
 using System;
-using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
-using System.Runtime.InteropServices;
 using System.Threading;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using StaticCs;
-using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 using static Serde.Diagnostics;
 
 namespace Serde;
@@ -153,23 +150,58 @@ public class SerdeImplRoslynGenerator : IIncrementalGenerator
         INamedTypeSymbol receiverType = typeSymbol;
         var proxiedOpt = TryGetProxiedType(attributeData);
         bool isEnum = typeDecl.IsKind(SyntaxKind.EnumDeclaration);
-        // If the Through property is set, then we are implementing a wrapper type
-        if (proxiedOpt is { Item1: null })
-        {
-            // Error already reported
-            return;
-        }
-        else if (proxiedOpt is { Item1: { } proxiedType })
-        {
-            receiverType = proxiedType;
+        // foreignType is non-null only when we have a non-empty proxy with an explicit
+        // conversion. It represents the target type for the interface signatures and the
+        // final conversion step. The rest of the pipeline operates on receiverType (the proxy).
+        INamedTypeSymbol? foreignType = null;
 
-            if (receiverType.SpecialType != SpecialType.None)
+        if (proxiedOpt is { } proxiedType)
+        {
+            if (proxiedType.SpecialType != SpecialType.None)
             {
                 generationContext.ReportDiagnostic(CreateDiagnostic(
                     DiagId.ERR_CantWrapSpecialType,
                     attributeData.ApplicationSyntaxReference!.GetSyntax().GetLocation(),
-                    receiverType));
+                    proxiedType));
                 return;
+            }
+
+            if (SymbolUtilities.GetDataMembers(typeSymbol, SerdeUsage.Both).Count != 0)
+            {
+                // Non-empty proxy: it is a representation (surrogate) of the foreign
+                // type. We deserialize the proxy and convert it to the foreign type,
+                // and convert the foreign type to the proxy to serialize. This requires
+                // explicit conversion operators in both directions (depending on usage).
+                foreignType = proxiedType;
+
+                var conversionLocation = attributeData.ApplicationSyntaxReference!.GetSyntax().GetLocation();
+
+                // Deserialize converts the deserialized proxy to the foreign type.
+                if ((usage & SerdeUsage.Deserialize) != 0
+                    && !HasExplicitConversion(typeSymbol, fromType: typeSymbol, toType: proxiedType))
+                {
+                    generationContext.ReportDiagnostic(CreateDiagnostic(
+                        DiagId.ERR_MissingExplicitConversion,
+                        conversionLocation,
+                        typeSymbol, proxiedType));
+                    return;
+                }
+
+                // Serialize converts the foreign value to the proxy before writing.
+                if ((usage & SerdeUsage.Serialize) != 0
+                    && !HasExplicitConversion(typeSymbol, fromType: proxiedType, toType: typeSymbol))
+                {
+                    generationContext.ReportDiagnostic(CreateDiagnostic(
+                        DiagId.ERR_MissingReverseConversion,
+                        conversionLocation,
+                        typeSymbol, proxiedType));
+                    return;
+                }
+            }
+            else
+            {
+                // Empty proxy: receiverType becomes the foreign type
+                receiverType = proxiedType;
             }
         }
         else if (!isEnum)
@@ -197,7 +229,7 @@ public class SerdeImplRoslynGenerator : IIncrementalGenerator
         string serdeObjString;
         if (TryGetSerdeObj(attributeData) is not { Item1: { } serdeObj })
         {
-            GenerateInfoAndSerdeImpls(usage, generationContext, typeDeclContext, receiverType, inProgress);
+            GenerateInfoAndSerdeImpls(usage, generationContext, typeDeclContext, receiverType, foreignType, inProgress);
             serdeObjString = isEnum
                 ? typeDeclContext.GetFqn()
                 : $"{typeDeclContext.GetFqn()}.{usage.GetSerdeObjName()}";
@@ -214,7 +246,8 @@ public class SerdeImplRoslynGenerator : IIncrementalGenerator
             generationContext,
             serdeObjString,
             typeDeclContext,
-            receiverType);
+            receiverType,
+            foreignType);
     }
 
     internal static void GenerateProviderImpls(
@@ -222,7 +255,8 @@ public class SerdeImplRoslynGenerator : IIncrementalGenerator
         GeneratorExecutionContext generationContext,
         string serdeObjName,
         TypeDeclContext typeDeclContext,
-        INamedTypeSymbol receiverType)
+        INamedTypeSymbol receiverType,
+        INamedTypeSymbol? foreignType)
     {
         string fullTypeName = typeDeclContext.GetFqn(includeTypeParameters: false);
 
@@ -233,17 +267,22 @@ public class SerdeImplRoslynGenerator : IIncrementalGenerator
         generationContext.AddSource(srcName, content);
 
         SourceBuilder GenProviderImplHelper(SerdeUsage usage)
-            => GenProviderImpl(usage, serdeObjName, typeDeclContext, receiverType);
+            => GenProviderImpl(usage, serdeObjName, typeDeclContext, receiverType, foreignType);
     }
 
     private static SourceBuilder GenProviderImpl(
         SerdeUsage usage,
         string serdeObjName,
         TypeDeclContext typeDeclContext,
-        ITypeSymbol receiverType
+        ITypeSymbol receiverType,
+        INamedTypeSymbol? foreignType
     )
     {
-        var receiverString = receiverType.ToDisplayString();
+        // The provided type (the `T` in ISerdeProvider/I{Serialize,Deserialize}Provider)
+        // is the type the SerdeObj actually implements serde for: the foreign type
+        // when present, otherwise the receiver (proxy).
+        var providedType = (ITypeSymbol?)foreignType ?? receiverType;
+        var receiverString = providedType.ToDisplayString();
         var containerString = typeDeclContext.GetFqn();
 
         string baseList;
@@ -259,9 +298,9 @@ public class SerdeImplRoslynGenerator : IIncrementalGenerator
         else
         {
             var interfaceName = $"{usage.GetInterfaceName()}Provider";
-            baseList = $" : Serde.{interfaceName}<{receiverType.ToFqn()}>";
+            baseList = $" : Serde.{interfaceName}<{providedType.ToFqn()}>";
             members = new SourceBuilder($$"""
-            static global::Serde.{{usage.GetInterfaceName()}}<{{receiverType.ToDisplayString()}}> global::Serde.{{interfaceName}}<{{receiverType.ToFqn()}}>.Instance { get; }
+            static global::Serde.{{usage.GetInterfaceName()}}<{{providedType.ToDisplayString()}}> global::Serde.{{interfaceName}}<{{providedType.ToFqn()}}>.Instance { get; }
                 = new {{serdeObjName}}();
             """);
 
@@ -278,32 +317,37 @@ public class SerdeImplRoslynGenerator : IIncrementalGenerator
         GeneratorExecutionContext generationContext,
         TypeDeclContext typeDeclContext,
         INamedTypeSymbol receiverType,
-        ImmutableList<(ITypeSymbol Receiver, ITypeSymbol Containing)> inProgress)
+        INamedTypeSymbol? foreignType,
+        ImmutableList<(ITypeSymbol Receiver, ITypeSymbol Containing)> inProgress
+    )
     {
         SerdeInfoGenerator.GenerateSerdeInfo(
             typeDeclContext,
             receiverType,
+            foreignType,
             generationContext,
             usage,
-            inProgress);
+            inProgress
+        );
 
         GenSerdeObjImpl(
             usage,
             typeDeclContext,
             receiverType,
+            foreignType,
             generationContext,
-            inProgress);
+            inProgress
+        );
     }
 
     /// <summary>
-    /// If the type has a `Through` property then we are generating a proxy type and need to find
+    /// If the type has a `ForType` property then we are generating a proxy type and need to find
     /// the proxied type.
     /// </summary>
     /// <returns>
-    /// Returns null if there is no `Through` property. Returns ValueTuple(null) if there is an
-    /// error. Returns ValueTuple(ITypeSymbol) if there is a valid proxied type.
+    /// Returns null if there is no `ForType` property.
     /// </returns>
-    private static ValueTuple<INamedTypeSymbol?>? TryGetProxiedType(AttributeData attributeData)
+    private static INamedTypeSymbol? TryGetProxiedType(AttributeData attributeData)
     {
         foreach (var namedArg in attributeData.NamedArguments)
         {
@@ -314,9 +358,9 @@ public class SerdeImplRoslynGenerator : IIncrementalGenerator
                     if (typeSymbol is not INamedTypeSymbol namedTypeSymbol)
                     {
                         // TODO: Error about bad type
-                        return new(null);
+                        return null;
                     }
-                    return new(namedTypeSymbol);
+                    return namedTypeSymbol;
             }
         }
         return null;
@@ -349,11 +393,15 @@ public class SerdeImplRoslynGenerator : IIncrementalGenerator
         SerdeUsage usage,
         TypeDeclContext typeDeclContext,
         ITypeSymbol receiverType,
+        INamedTypeSymbol? foreignType,
         GeneratorExecutionContext context,
         ImmutableList<(ITypeSymbol Receiver, ITypeSymbol Containing)> inProgress)
     {
         string fullTypeName = typeDeclContext.GetFqn(includeTypeParameters: false);
         var fullTypeString = typeDeclContext.GetFqn();
+
+        // The interface type is the foreign type when present, otherwise the receiver.
+        var interfaceType = (ITypeSymbol?)foreignType ?? receiverType;
 
         // Generate statements for the implementation
         SourceBuilder implMembers;
@@ -361,18 +409,18 @@ public class SerdeImplRoslynGenerator : IIncrementalGenerator
         switch (usage)
         {
             case SerdeUsage.Serialize:
-                implMembers = SerializeImplGen.GenSerialize(context, receiverType, inProgress);
-                baseList = $" : Serde.ISerialize<{receiverType.ToDisplayString()}>";
+                implMembers = SerializeImplGen.GenSerialize(context, receiverType, foreignType, inProgress);
+                baseList = $" : Serde.ISerialize<{interfaceType.ToDisplayString()}>";
                 break;
             case SerdeUsage.Deserialize:
-                implMembers = DeserializeImplGen.GenDeserialize(context, receiverType, inProgress);
-                baseList = $" : Serde.IDeserialize<{receiverType.ToDisplayString()}>";
+                implMembers = DeserializeImplGen.GenDeserialize(context, receiverType, foreignType, inProgress);
+                baseList = $" : Serde.IDeserialize<{interfaceType.ToDisplayString()}>";
                 break;
             case SerdeUsage.Both:
-                implMembers = SerializeImplGen.GenSerialize(context, receiverType, inProgress);
-                var deserializeMembers = DeserializeImplGen.GenDeserialize(context, receiverType, inProgress);
+                implMembers = SerializeImplGen.GenSerialize(context, receiverType, foreignType, inProgress);
+                var deserializeMembers = DeserializeImplGen.GenDeserialize(context, receiverType, foreignType, inProgress);
                 implMembers.Append(deserializeMembers);
-                baseList = $" : global::Serde.ISerde<{receiverType.ToFqn()}>";
+                baseList = $" : global::Serde.ISerde<{interfaceType.ToFqn()}>";
                 break;
             default:
                 throw ExceptionUtilities.Unreachable;
@@ -506,6 +554,33 @@ public class SerdeImplRoslynGenerator : IIncrementalGenerator
             return rename;
         }
         return type.Name;
+    }
+
+    /// <summary>
+    /// Check if <paramref name="declaringType"/> declares a public static explicit
+    /// conversion operator that converts from <paramref name="fromType"/> to
+    /// <paramref name="toType"/>.
+    /// </summary>
+    internal static bool HasExplicitConversion(INamedTypeSymbol declaringType, ITypeSymbol fromType, ITypeSymbol toType)
+    {
+        foreach (var m in declaringType.GetMembers())
+        {
+            if (m is IMethodSymbol
+                {
+                    MethodKind: MethodKind.Conversion,
+                    Name: "op_Explicit",
+                    DeclaredAccessibility: Accessibility.Public,
+                    IsStatic: true,
+                    Parameters: [{ Type: var paramType }],
+                    ReturnType: var returnType,
+                }
+                && SymbolEqualityComparer.Default.Equals(paramType, fromType)
+                && SymbolEqualityComparer.Default.Equals(returnType, toType))
+            {
+                return true;
+            }
+        }
+        return false;
     }
 }
 

--- a/src/generator/SerdeInfoGenerator.cs
+++ b/src/generator/SerdeInfoGenerator.cs
@@ -31,9 +31,11 @@ internal static class SerdeInfoGenerator
     public static void GenerateSerdeInfo(
         TypeDeclContext typeDeclContext,
         INamedTypeSymbol receiverType,
+        INamedTypeSymbol? foreignType,
         GeneratorExecutionContext context,
         SerdeUsage usage,
-        ImmutableList<(ITypeSymbol Receiver, ITypeSymbol Containing)> inProgress)
+        ImmutableList<(ITypeSymbol Receiver, ITypeSymbol Containing)> inProgress
+    )
     {
         if (receiverType.IsAbstract)
         {
@@ -62,11 +64,13 @@ internal static class SerdeInfoGenerator
             fieldArrayType = "(string, global::Serde.ISerdeInfo, System.Reflection.MemberInfo?)[]";
         }
 
-        var typeString = receiverType.ToDisplayString();
-        if (typeString.IndexOf('<') is var index && index != -1)
+        // reflectionType is used for typeof() in reflection calls.
+        var reflectionType = receiverType;
+        var reflectionTypeString = reflectionType.ToDisplayString();
+        if (reflectionTypeString.IndexOf('<') is var index && index != -1)
         {
-            typeString = typeString[..index];
-            typeString = typeString + "<" + new string(',', receiverType.TypeParameters.Length - 1) + ">";
+            reflectionTypeString = reflectionTypeString[..index];
+            reflectionTypeString = reflectionTypeString + "<" + new string(',', reflectionType is INamedTypeSymbol nts ? nts.TypeParameters.Length - 1 : 0) + ">";
         }
 
         var classScopeProxyMap = ProxyMap.FromSymbol(receiverType);
@@ -74,7 +78,19 @@ internal static class SerdeInfoGenerator
         var membersString = string.Join("," + Utilities.NewLine,
             SymbolUtilities.GetDataMembers(receiverType, SerdeUsage.Both).SelectNotNull(GetMemberEntry));
 
-        List<string> makeArgs = [ $"\"{receiverType.Name}\"", $"typeof({typeString}).GetCustomAttributesData()" ];
+        // Type identity: the SerdeInfo Name is the conceptual type being
+        // (de)serialized. For a non-empty conversion proxy that is the foreign
+        // type, not the proxy (which is an implementation detail). Type-level
+        // attributes and member reflection still come from the proxy, since
+        // that is where serde configuration and the mirrored members live.
+        var typeString = receiverType.ToDisplayString();
+        if (typeString.IndexOf('<') is var idx && idx != -1)
+        {
+            typeString = typeString[..idx];
+            typeString = typeString + "<" + new string(',', receiverType.TypeParameters.Length - 1) + ">";
+        }
+        var identityName = (foreignType ?? receiverType).Name;
+        List<string> makeArgs = [ $"\"{identityName}\"", $"typeof({typeString}).GetCustomAttributesData()" ];
 
         if (isEnum)
         {
@@ -141,8 +157,9 @@ private static global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.Make{{make
                 elements.Add($"global::Serde.SerdeInfoProvider.Get{name}Info<{m.Type.ToDisplayString()}, {wrapperName}>()");
             }
 
+            // Member reflection points at the member source type (proxy when non-empty)
             var getAccessor = m.Symbol.Kind == SymbolKind.Field ? "GetField" : "GetProperty";
-            elements.Add($"typeof({typeString}).{getAccessor}(\"{m.Name}\")");
+            elements.Add($"typeof({reflectionTypeString}).{getAccessor}(\"{m.Name}\")");
 
             return $"""({string.Join(", ", elements)})""";
         }
@@ -173,9 +190,9 @@ partial {{declKeywords}} {{typeName}}{{originalCtx.TypeParameterList}}
 }
 """));
             var newCtx = TypeDeclContext.FromFile(nestedType.ToString(), proxyName);
-            SerdeImplRoslynGenerator.GenerateInfoAndSerdeImpls(usage, context, newCtx, m, inProgress.Add((m, receiverType)));
+            SerdeImplRoslynGenerator.GenerateInfoAndSerdeImpls(usage, context, newCtx, m, foreignType: null, inProgress.Add((m, receiverType)));
             var serdeObjFqn = $"{newCtx.GetFqn()}.{usage.GetSerdeObjName()}";
-            SerdeImplRoslynGenerator.GenerateProviderImpls(usage, context, serdeObjFqn, newCtx, m);
+            SerdeImplRoslynGenerator.GenerateProviderImpls(usage, context, serdeObjFqn, newCtx, m, foreignType: null);
         }
 
         var bodies = new SourceBuilder($$"""

--- a/src/generator/SerializeImplGen.cs
+++ b/src/generator/SerializeImplGen.cs
@@ -13,6 +13,7 @@ public partial class SerializeImplGen
     internal static SourceBuilder GenSerialize(
         GeneratorExecutionContext context,
         ITypeSymbol receiverType,
+        INamedTypeSymbol? foreignType,
         ImmutableList<(ITypeSymbol Receiver, ITypeSymbol Containing)> inProgress)
     {
         if (receiverType.IsAbstract)
@@ -63,6 +64,20 @@ public partial class SerializeImplGen
         {
             var classScopeProxyMap = ProxyMap.FromSymbol(receiverType);
 
+            // When serializing for a foreign type, convert the foreign value to the
+            // proxy via the explicit conversion operator and read members off the
+            // proxy. Otherwise read members directly off the value.
+            string receiverExpr;
+            if (foreignType is not null)
+            {
+                receiverExpr = "_l_self";
+                statements.AppendLine($"var _l_self = ({receiverType.ToDisplayString()})value;");
+            }
+            else
+            {
+                receiverExpr = "value";
+            }
+
             // `var _l_info = GetInfo(this);`
             statements.AppendLine($"var _l_info = global::Serde.SerdeInfoProvider.GetInfo(this);");
 
@@ -78,12 +93,12 @@ public partial class SerializeImplGen
                 // 1. Check if this member has an explicit proxy. If so, we'll use it.
                 if (Proxies.TryGetExplicitWrapper(m, context, SerdeUsage.Serialize, inProgress, proxyContext) is { } proxy)
                 {
-                    statements.AppendLine(MakeWriteValueStmt(m, m.Type.ToDisplayString(), proxy, i));
+                    statements.AppendLine(MakeWriteValueStmt(m, m.Type.ToDisplayString(), proxy, i, receiverExpr));
                 }
                 // 2. Check for a direct implementation of ISerialize
                 else if (SerdeImplRoslynGenerator.ImplementsSerde(m.Type, m.Type, context, SerdeUsage.Serialize))
                 {
-                    statements.AppendLine(MakeWriteValueStmt(m, m.Type.ToDisplayString(), m.Type.ToDisplayString(), i));
+                    statements.AppendLine(MakeWriteValueStmt(m, m.Type.ToDisplayString(), m.Type.ToDisplayString(), i, receiverExpr));
                 }
                 // 3. Check if the member type is a primitive type. If so, it has a dedicated 'Write'
                 //    method. Check using the non-null form (even if it's nullable), since nullable
@@ -95,12 +110,12 @@ public partial class SerializeImplGen
                         // Use WriteValueIfNotNull if it's not been disabled and the field is nullable
                         primName += "IfNotNull";
                     }
-                    statements.AppendLine($"_l_type.Write{primName}(_l_info, {i}, value.{m.Name});");
+                    statements.AppendLine($"_l_type.Write{primName}(_l_info, {i}, {receiverExpr}.{m.Name});");
                 }
                 // 4. A wrapper that implements ISerialize
                 else if (Proxies.TryGetImplicitWrapper(m.Type, context, SerdeUsage.Serialize, inProgress, proxyContext) is { } wrapper)
                 {
-                    statements.AppendLine(MakeWriteValueStmt(m, wrapper.Type, wrapper.Proxy, i));
+                    statements.AppendLine(MakeWriteValueStmt(m, wrapper.Type, wrapper.Proxy, i, receiverExpr));
                 }
                 else
                 {
@@ -115,7 +130,7 @@ public partial class SerializeImplGen
                 }
             }
 
-            static string MakeWriteValueStmt(DataMemberSymbol m, string type, string proxy, int i)
+            static string MakeWriteValueStmt(DataMemberSymbol m, string type, string proxy, int i, string valueExpr)
             {
                 // Generate statements of the form `type.WriteValue<FieldType, Serialize>("FieldName", value.FieldValue)`
                 string methodName = m.Type.IsReferenceType
@@ -126,18 +141,19 @@ public partial class SerializeImplGen
                 {
                     methodName += "IfNotNull";
                 }
-                return $"_l_type.{methodName}<{type}, {proxy}>(_l_info, {i}, value.{m.Name});";
+                return $"_l_type.{methodName}<{type}, {proxy}>(_l_info, {i}, {valueExpr}.{m.Name});";
             }
         }
         // `type.End();`
         statements.Append("_l_type.End(_l_info);");
 
-        var receiverSyntax = ((INamedTypeSymbol)receiverType).ToFqnSyntax();
-        var receiverString = receiverType.ToDisplayString();
+        // The interface type is the foreign type when present, otherwise the receiver.
+        var interfaceType = (ITypeSymbol?)foreignType ?? receiverType;
+        var interfaceString = interfaceType.ToDisplayString();
 
         // Generate method `void ISerialize<type>.Serialize(type value, ISerializer serializer) { ... }`
         var members = new SourceBuilder($$"""
-        void global::Serde.ISerialize<{{receiverSyntax}}>.Serialize({{receiverSyntax}} value, global::Serde.ISerializer serializer)
+        void global::Serde.ISerialize<{{interfaceString}}>.Serialize({{interfaceString}} value, global::Serde.ISerializer serializer)
         {
             {{statements}}
         }

--- a/test/Serde.Generation.Test/DeserializeTests.cs
+++ b/test/Serde.Generation.Test/DeserializeTests.cs
@@ -59,7 +59,7 @@ using System.Collections.Immutable;
 using System.Runtime.InteropServices.ComTypes;
 
 [GenerateDeserialize(ForType = typeof(BIND_OPTS))]
-readonly partial record struct OptsWrap(BIND_OPTS Value);
+readonly partial record struct OptsWrap;
 
 [GenerateDeserialize]
 partial struct S
@@ -80,7 +80,7 @@ using Serde;
 using System.Runtime.InteropServices.ComTypes;
 
 [GenerateDeserialize(ForType = typeof(BIND_OPTS))]
-readonly partial record struct Wrap(BIND_OPTS Value);
+readonly partial record struct Wrap;
 
 """;
             return VerifyDeserialize(src);

--- a/test/Serde.Generation.Test/ProxyTests.cs
+++ b/test/Serde.Generation.Test/ProxyTests.cs
@@ -404,5 +404,108 @@ partial class C
 """;
             return VerifyMultiFile(src);
         }
+
+        /// <summary>
+        /// A non-empty proxy with an explicit conversion operator should use the proxy's
+        /// members for serialization/deserialization, constructing the proxy on deserialize
+        /// and converting to the foreign type.
+        /// </summary>
+        [Fact]
+        public Task NonEmptyProxyWithExplicitConversion()
+        {
+            var src = """
+using Serde;
+
+class ForeignPoint
+{
+    public int X { get; }
+    public int Y { get; }
+    public ForeignPoint(int x, int y) { X = x; Y = y; }
+}
+
+[GenerateSerde(ForType = typeof(ForeignPoint))]
+partial struct ForeignPointProxy
+{
+    public int X;
+    public int Y;
+
+    public static explicit operator ForeignPoint(ForeignPointProxy p)
+        => new ForeignPoint(p.X, p.Y);
+
+    public static explicit operator ForeignPointProxy(ForeignPoint p)
+        => new ForeignPointProxy { X = p.X, Y = p.Y };
+}
+""";
+            return VerifyMultiFile(src);
+        }
+
+        /// <summary>
+        /// A non-empty proxy used as a member proxy in another type.
+        /// </summary>
+        [Fact]
+        public Task NonEmptyProxyAsMemberProxy()
+        {
+            var src = """
+using Serde;
+
+class ForeignPoint
+{
+    public int X { get; }
+    public int Y { get; }
+    public ForeignPoint(int x, int y) { X = x; Y = y; }
+}
+
+[GenerateSerde(ForType = typeof(ForeignPoint))]
+partial struct ForeignPointProxy
+{
+    public int X;
+    public int Y;
+
+    public static explicit operator ForeignPoint(ForeignPointProxy p)
+        => new ForeignPoint(p.X, p.Y);
+
+    public static explicit operator ForeignPointProxy(ForeignPoint p)
+        => new ForeignPointProxy { X = p.X, Y = p.Y };
+}
+
+[GenerateSerde]
+partial class Container
+{
+    [SerdeMemberOptions(Proxy = typeof(ForeignPointProxy))]
+    public required ForeignPoint Point { get; init; }
+}
+""";
+            return VerifyMultiFile(src);
+        }
+
+        /// <summary>
+        /// A non-empty proxy that is missing the reverse (foreign -> proxy) conversion
+        /// operator required for serialization should produce a diagnostic.
+        /// </summary>
+        [Fact]
+        public Task NonEmptyProxyMissingReverseConversion()
+        {
+            var src = """
+using Serde;
+
+class ForeignPoint
+{
+    public int X { get; }
+    public int Y { get; }
+    public ForeignPoint(int x, int y) { X = x; Y = y; }
+}
+
+[GenerateSerde(ForType = typeof(ForeignPoint))]
+partial struct ForeignPointProxy
+{
+    public int X;
+    public int Y;
+
+    public static explicit operator ForeignPoint(ForeignPointProxy p)
+        => new ForeignPoint(p.X, p.Y);
+}
+""";
+            return VerifyMultiFile(src);
+        }
     }
 }

--- a/test/Serde.Generation.Test/test_output/ProxyTests.NonEmptyProxyAsMemberProxy/Container.ISerde.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/ProxyTests.NonEmptyProxyAsMemberProxy/Container.ISerde.g.verified.cs
@@ -1,0 +1,61 @@
+﻿//HintName: Container.ISerde.g.cs
+
+#nullable enable
+
+using System;
+using Serde;
+partial class Container
+{
+    sealed partial class _SerdeObj : global::Serde.ISerde<Container>
+    {
+        global::Serde.ISerdeInfo global::Serde.ISerdeInfoProvider.SerdeInfo => Container.s_serdeInfo;
+
+        void global::Serde.ISerialize<Container>.Serialize(Container value, global::Serde.ISerializer serializer)
+        {
+            var _l_info = global::Serde.SerdeInfoProvider.GetInfo(this);
+            var _l_type = serializer.WriteType(_l_info);
+            _l_type.WriteValue<ForeignPoint, ForeignPointProxy>(_l_info, 0, value.Point);
+            _l_type.End(_l_info);
+        }
+        Container Serde.IDeserialize<Container>.Deserialize(IDeserializer deserializer)
+        {
+            ForeignPoint _l_point = default!;
+
+            byte _r_assignedValid = 0;
+
+            var _l_serdeInfo = global::Serde.SerdeInfoProvider.GetInfo(this);
+            var typeDeserialize = deserializer.ReadType(_l_serdeInfo);
+            while (true)
+            {
+                var (_l_index_, _) = typeDeserialize.TryReadIndexWithName(_l_serdeInfo);
+                if (_l_index_ == Serde.ITypeDeserializer.EndOfType)
+                {
+                    break;
+                }
+
+                switch (_l_index_)
+                {
+                    case 0:
+                        Serde.DeserializeException.ThrowIfDuplicate(_r_assignedValid, 0, _l_serdeInfo);
+                        _l_point = typeDeserialize.ReadValue<ForeignPoint, ForeignPointProxy>(_l_serdeInfo, _l_index_);
+                        _r_assignedValid |= ((byte)1) << 0;
+                        break;
+                    case Serde.ITypeDeserializer.IndexNotFound:
+                        typeDeserialize.SkipValue(_l_serdeInfo, _l_index_);
+                        break;
+                    default:
+                        throw new InvalidOperationException("Unexpected index: " + _l_index_);
+                }
+            }
+            if ((_r_assignedValid & 0b1) != 0b1)
+            {
+                throw Serde.DeserializeException.UnassignedMember();
+            }
+            var newType = new Container() {
+                Point = _l_point,
+            };
+
+            return newType;
+        }
+    }
+}

--- a/test/Serde.Generation.Test/test_output/ProxyTests.NonEmptyProxyAsMemberProxy/Container.ISerdeInfoProvider.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/ProxyTests.NonEmptyProxyAsMemberProxy/Container.ISerdeInfoProvider.g.verified.cs
@@ -1,0 +1,13 @@
+﻿//HintName: Container.ISerdeInfoProvider.g.cs
+
+#nullable enable
+partial class Container
+{
+    private static global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
+        "Container",
+    typeof(Container).GetCustomAttributesData(),
+    new (string, global::Serde.ISerdeInfo, System.Reflection.MemberInfo?)[] {
+        ("point", global::Serde.SerdeInfoProvider.GetSerializeInfo<ForeignPoint, ForeignPointProxy>(), typeof(Container).GetProperty("Point"))
+    }
+    );
+}

--- a/test/Serde.Generation.Test/test_output/ProxyTests.NonEmptyProxyAsMemberProxy/Container.ISerdeProvider.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/ProxyTests.NonEmptyProxyAsMemberProxy/Container.ISerdeProvider.g.verified.cs
@@ -1,0 +1,6 @@
+﻿//HintName: Container.ISerdeProvider.g.cs
+partial class Container : Serde.ISerdeProvider<Container, Container._SerdeObj, Container>
+{
+    static Container._SerdeObj global::Serde.ISerdeProvider<Container, Container._SerdeObj, Container>.Instance { get; }
+        = new Container._SerdeObj();
+}

--- a/test/Serde.Generation.Test/test_output/ProxyTests.NonEmptyProxyAsMemberProxy/ForeignPointProxy.ISerde.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/ProxyTests.NonEmptyProxyAsMemberProxy/ForeignPointProxy.ISerde.g.verified.cs
@@ -1,0 +1,70 @@
+﻿//HintName: ForeignPointProxy.ISerde.g.cs
+
+#nullable enable
+
+using System;
+using Serde;
+partial struct ForeignPointProxy
+{
+    sealed partial class _SerdeObj : global::Serde.ISerde<ForeignPoint>
+    {
+        global::Serde.ISerdeInfo global::Serde.ISerdeInfoProvider.SerdeInfo => ForeignPointProxy.s_serdeInfo;
+
+        void global::Serde.ISerialize<ForeignPoint>.Serialize(ForeignPoint value, global::Serde.ISerializer serializer)
+        {
+            var _l_self = (ForeignPointProxy)value;
+            var _l_info = global::Serde.SerdeInfoProvider.GetInfo(this);
+            var _l_type = serializer.WriteType(_l_info);
+            _l_type.WriteI32(_l_info, 0, _l_self.X);
+            _l_type.WriteI32(_l_info, 1, _l_self.Y);
+            _l_type.End(_l_info);
+        }
+        ForeignPoint Serde.IDeserialize<ForeignPoint>.Deserialize(IDeserializer deserializer)
+        {
+            int _l_x = default!;
+            int _l_y = default!;
+
+            byte _r_assignedValid = 0;
+
+            var _l_serdeInfo = global::Serde.SerdeInfoProvider.GetInfo(this);
+            var typeDeserialize = deserializer.ReadType(_l_serdeInfo);
+            while (true)
+            {
+                var (_l_index_, _) = typeDeserialize.TryReadIndexWithName(_l_serdeInfo);
+                if (_l_index_ == Serde.ITypeDeserializer.EndOfType)
+                {
+                    break;
+                }
+
+                switch (_l_index_)
+                {
+                    case 0:
+                        Serde.DeserializeException.ThrowIfDuplicate(_r_assignedValid, 0, _l_serdeInfo);
+                        _l_x = typeDeserialize.ReadI32(_l_serdeInfo, _l_index_);
+                        _r_assignedValid |= ((byte)1) << 0;
+                        break;
+                    case 1:
+                        Serde.DeserializeException.ThrowIfDuplicate(_r_assignedValid, 1, _l_serdeInfo);
+                        _l_y = typeDeserialize.ReadI32(_l_serdeInfo, _l_index_);
+                        _r_assignedValid |= ((byte)1) << 1;
+                        break;
+                    case Serde.ITypeDeserializer.IndexNotFound:
+                        typeDeserialize.SkipValue(_l_serdeInfo, _l_index_);
+                        break;
+                    default:
+                        throw new InvalidOperationException("Unexpected index: " + _l_index_);
+                }
+            }
+            if ((_r_assignedValid & 0b11) != 0b11)
+            {
+                throw Serde.DeserializeException.UnassignedMember();
+            }
+            var newType = new ForeignPointProxy() {
+                X = _l_x,
+                Y = _l_y,
+            };
+
+            return (ForeignPoint)newType;
+        }
+    }
+}

--- a/test/Serde.Generation.Test/test_output/ProxyTests.NonEmptyProxyAsMemberProxy/ForeignPointProxy.ISerdeInfoProvider.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/ProxyTests.NonEmptyProxyAsMemberProxy/ForeignPointProxy.ISerdeInfoProvider.g.verified.cs
@@ -1,0 +1,14 @@
+﻿//HintName: ForeignPointProxy.ISerdeInfoProvider.g.cs
+
+#nullable enable
+partial struct ForeignPointProxy
+{
+    private static global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
+        "ForeignPoint",
+    typeof(ForeignPointProxy).GetCustomAttributesData(),
+    new (string, global::Serde.ISerdeInfo, System.Reflection.MemberInfo?)[] {
+        ("x", global::Serde.SerdeInfoProvider.GetSerializeInfo<int, global::Serde.I32Proxy>(), typeof(ForeignPointProxy).GetField("X")),
+        ("y", global::Serde.SerdeInfoProvider.GetSerializeInfo<int, global::Serde.I32Proxy>(), typeof(ForeignPointProxy).GetField("Y"))
+    }
+    );
+}

--- a/test/Serde.Generation.Test/test_output/ProxyTests.NonEmptyProxyAsMemberProxy/ForeignPointProxy.ISerdeProvider.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/ProxyTests.NonEmptyProxyAsMemberProxy/ForeignPointProxy.ISerdeProvider.g.verified.cs
@@ -1,0 +1,6 @@
+﻿//HintName: ForeignPointProxy.ISerdeProvider.g.cs
+partial struct ForeignPointProxy : Serde.ISerdeProvider<ForeignPointProxy, ForeignPointProxy._SerdeObj, ForeignPoint>
+{
+    static ForeignPointProxy._SerdeObj global::Serde.ISerdeProvider<ForeignPointProxy, ForeignPointProxy._SerdeObj, ForeignPoint>.Instance { get; }
+        = new ForeignPointProxy._SerdeObj();
+}

--- a/test/Serde.Generation.Test/test_output/ProxyTests.NonEmptyProxyMissingReverseConversion/target.verified.txt
+++ b/test/Serde.Generation.Test/test_output/ProxyTests.NonEmptyProxyMissingReverseConversion/target.verified.txt
@@ -1,0 +1,23 @@
+﻿{
+  Diagnostics: [
+    {
+      Location: /*
+
+[GenerateSerde(ForType = typeof(ForeignPoint))]
+ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+partial struct ForeignPointProxy
+*/
+ : (9,1)-(9,46),
+      Message: Proxy type 'ForeignPointProxy' must define a public explicit conversion operator from 'ForeignPoint' in order to serialize it. Add: public static explicit operator ForeignPointProxy(ForeignPoint value),
+      Severity: Error,
+      Descriptor: {
+        Id: ERR_MissingReverseConversion,
+        Title: ,
+        MessageFormat: Proxy type 'ForeignPointProxy' must define a public explicit conversion operator from 'ForeignPoint' in order to serialize it. Add: public static explicit operator ForeignPointProxy(ForeignPoint value),
+        Category: Serde,
+        DefaultSeverity: Error,
+        IsEnabledByDefault: true
+      }
+    }
+  ]
+}

--- a/test/Serde.Generation.Test/test_output/ProxyTests.NonEmptyProxyWithExplicitConversion/ForeignPointProxy.ISerde.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/ProxyTests.NonEmptyProxyWithExplicitConversion/ForeignPointProxy.ISerde.g.verified.cs
@@ -1,0 +1,70 @@
+﻿//HintName: ForeignPointProxy.ISerde.g.cs
+
+#nullable enable
+
+using System;
+using Serde;
+partial struct ForeignPointProxy
+{
+    sealed partial class _SerdeObj : global::Serde.ISerde<ForeignPoint>
+    {
+        global::Serde.ISerdeInfo global::Serde.ISerdeInfoProvider.SerdeInfo => ForeignPointProxy.s_serdeInfo;
+
+        void global::Serde.ISerialize<ForeignPoint>.Serialize(ForeignPoint value, global::Serde.ISerializer serializer)
+        {
+            var _l_self = (ForeignPointProxy)value;
+            var _l_info = global::Serde.SerdeInfoProvider.GetInfo(this);
+            var _l_type = serializer.WriteType(_l_info);
+            _l_type.WriteI32(_l_info, 0, _l_self.X);
+            _l_type.WriteI32(_l_info, 1, _l_self.Y);
+            _l_type.End(_l_info);
+        }
+        ForeignPoint Serde.IDeserialize<ForeignPoint>.Deserialize(IDeserializer deserializer)
+        {
+            int _l_x = default!;
+            int _l_y = default!;
+
+            byte _r_assignedValid = 0;
+
+            var _l_serdeInfo = global::Serde.SerdeInfoProvider.GetInfo(this);
+            var typeDeserialize = deserializer.ReadType(_l_serdeInfo);
+            while (true)
+            {
+                var (_l_index_, _) = typeDeserialize.TryReadIndexWithName(_l_serdeInfo);
+                if (_l_index_ == Serde.ITypeDeserializer.EndOfType)
+                {
+                    break;
+                }
+
+                switch (_l_index_)
+                {
+                    case 0:
+                        Serde.DeserializeException.ThrowIfDuplicate(_r_assignedValid, 0, _l_serdeInfo);
+                        _l_x = typeDeserialize.ReadI32(_l_serdeInfo, _l_index_);
+                        _r_assignedValid |= ((byte)1) << 0;
+                        break;
+                    case 1:
+                        Serde.DeserializeException.ThrowIfDuplicate(_r_assignedValid, 1, _l_serdeInfo);
+                        _l_y = typeDeserialize.ReadI32(_l_serdeInfo, _l_index_);
+                        _r_assignedValid |= ((byte)1) << 1;
+                        break;
+                    case Serde.ITypeDeserializer.IndexNotFound:
+                        typeDeserialize.SkipValue(_l_serdeInfo, _l_index_);
+                        break;
+                    default:
+                        throw new InvalidOperationException("Unexpected index: " + _l_index_);
+                }
+            }
+            if ((_r_assignedValid & 0b11) != 0b11)
+            {
+                throw Serde.DeserializeException.UnassignedMember();
+            }
+            var newType = new ForeignPointProxy() {
+                X = _l_x,
+                Y = _l_y,
+            };
+
+            return (ForeignPoint)newType;
+        }
+    }
+}

--- a/test/Serde.Generation.Test/test_output/ProxyTests.NonEmptyProxyWithExplicitConversion/ForeignPointProxy.ISerdeInfoProvider.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/ProxyTests.NonEmptyProxyWithExplicitConversion/ForeignPointProxy.ISerdeInfoProvider.g.verified.cs
@@ -1,0 +1,14 @@
+﻿//HintName: ForeignPointProxy.ISerdeInfoProvider.g.cs
+
+#nullable enable
+partial struct ForeignPointProxy
+{
+    private static global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
+        "ForeignPoint",
+    typeof(ForeignPointProxy).GetCustomAttributesData(),
+    new (string, global::Serde.ISerdeInfo, System.Reflection.MemberInfo?)[] {
+        ("x", global::Serde.SerdeInfoProvider.GetSerializeInfo<int, global::Serde.I32Proxy>(), typeof(ForeignPointProxy).GetField("X")),
+        ("y", global::Serde.SerdeInfoProvider.GetSerializeInfo<int, global::Serde.I32Proxy>(), typeof(ForeignPointProxy).GetField("Y"))
+    }
+    );
+}

--- a/test/Serde.Generation.Test/test_output/ProxyTests.NonEmptyProxyWithExplicitConversion/ForeignPointProxy.ISerdeProvider.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/ProxyTests.NonEmptyProxyWithExplicitConversion/ForeignPointProxy.ISerdeProvider.g.verified.cs
@@ -1,0 +1,6 @@
+﻿//HintName: ForeignPointProxy.ISerdeProvider.g.cs
+partial struct ForeignPointProxy : Serde.ISerdeProvider<ForeignPointProxy, ForeignPointProxy._SerdeObj, ForeignPoint>
+{
+    static ForeignPointProxy._SerdeObj global::Serde.ISerdeProvider<ForeignPointProxy, ForeignPointProxy._SerdeObj, ForeignPoint>.Instance { get; }
+        = new ForeignPointProxy._SerdeObj();
+}

--- a/test/Serde.Test/RoundtripTests.cs
+++ b/test/Serde.Test/RoundtripTests.cs
@@ -41,6 +41,42 @@ public sealed partial class RoundtripTests
         public int Y { get; init; }
     }
 
+    /// <summary>
+    /// A "foreign" type with no parameterless constructor and read-only members,
+    /// serialized through a non-empty proxy that converts to and from it.
+    /// </summary>
+    public sealed class ForeignPoint(int x, int y)
+    {
+        public int X { get; } = x;
+        public int Y { get; } = y;
+    }
+
+    [GenerateSerde(ForType = typeof(ForeignPoint))]
+    [SerdeTypeOptions(MemberFormat = MemberFormat.None)]
+    public partial struct ForeignPointProxy
+    {
+        public int X;
+        public int Y;
+
+        public static explicit operator ForeignPoint(ForeignPointProxy p)
+            => new ForeignPoint(p.X, p.Y);
+
+        public static explicit operator ForeignPointProxy(ForeignPoint p)
+            => new ForeignPointProxy { X = p.X, Y = p.Y };
+    }
+
+    [Fact]
+    public void NonEmptyConversionProxyRoundtrip()
+    {
+        var p = new ForeignPoint(3, 7);
+        var json = JsonSerializer.Serialize<ForeignPoint, ForeignPointProxy>(p);
+        Assert.Equal("""{"X":3,"Y":7}""", json);
+
+        var back = JsonSerializer.Deserialize<ForeignPoint, ForeignPointProxy>(json);
+        Assert.Equal(p.X, back.X);
+        Assert.Equal(p.Y, back.Y);
+    }
+
     private static void AssertRoundTrip<T>(T t) where T : ISerializeProvider<T>, IDeserializeProvider<T>
     {
         var result = JsonSerializer.Deserialize<T>(JsonSerializer.Serialize(t));

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.RoundtripTests.ForeignPointProxy.ISerde.g.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.RoundtripTests.ForeignPointProxy.ISerde.g.cs
@@ -1,0 +1,75 @@
+
+#nullable enable
+
+using System;
+using Serde;
+
+namespace Serde.Test;
+
+partial class RoundtripTests
+{
+    partial struct ForeignPointProxy
+    {
+        sealed partial class _SerdeObj : global::Serde.ISerde<Serde.Test.RoundtripTests.ForeignPoint>
+        {
+            global::Serde.ISerdeInfo global::Serde.ISerdeInfoProvider.SerdeInfo => Serde.Test.RoundtripTests.ForeignPointProxy.s_serdeInfo;
+
+            void global::Serde.ISerialize<Serde.Test.RoundtripTests.ForeignPoint>.Serialize(Serde.Test.RoundtripTests.ForeignPoint value, global::Serde.ISerializer serializer)
+            {
+                var _l_self = (Serde.Test.RoundtripTests.ForeignPointProxy)value;
+                var _l_info = global::Serde.SerdeInfoProvider.GetInfo(this);
+                var _l_type = serializer.WriteType(_l_info);
+                _l_type.WriteI32(_l_info, 0, _l_self.X);
+                _l_type.WriteI32(_l_info, 1, _l_self.Y);
+                _l_type.End(_l_info);
+            }
+            Serde.Test.RoundtripTests.ForeignPoint Serde.IDeserialize<Serde.Test.RoundtripTests.ForeignPoint>.Deserialize(IDeserializer deserializer)
+            {
+                int _l_x = default!;
+                int _l_y = default!;
+
+                byte _r_assignedValid = 0;
+
+                var _l_serdeInfo = global::Serde.SerdeInfoProvider.GetInfo(this);
+                var typeDeserialize = deserializer.ReadType(_l_serdeInfo);
+                while (true)
+                {
+                    var (_l_index_, _) = typeDeserialize.TryReadIndexWithName(_l_serdeInfo);
+                    if (_l_index_ == Serde.ITypeDeserializer.EndOfType)
+                    {
+                        break;
+                    }
+
+                    switch (_l_index_)
+                    {
+                        case 0:
+                            Serde.DeserializeException.ThrowIfDuplicate(_r_assignedValid, 0, _l_serdeInfo);
+                            _l_x = typeDeserialize.ReadI32(_l_serdeInfo, _l_index_);
+                            _r_assignedValid |= ((byte)1) << 0;
+                            break;
+                        case 1:
+                            Serde.DeserializeException.ThrowIfDuplicate(_r_assignedValid, 1, _l_serdeInfo);
+                            _l_y = typeDeserialize.ReadI32(_l_serdeInfo, _l_index_);
+                            _r_assignedValid |= ((byte)1) << 1;
+                            break;
+                        case Serde.ITypeDeserializer.IndexNotFound:
+                            typeDeserialize.SkipValue(_l_serdeInfo, _l_index_);
+                            break;
+                        default:
+                            throw new InvalidOperationException("Unexpected index: " + _l_index_);
+                    }
+                }
+                if ((_r_assignedValid & 0b11) != 0b11)
+                {
+                    throw Serde.DeserializeException.UnassignedMember();
+                }
+                var newType = new Serde.Test.RoundtripTests.ForeignPointProxy() {
+                    X = _l_x,
+                    Y = _l_y,
+                };
+
+                return (Serde.Test.RoundtripTests.ForeignPoint)newType;
+            }
+        }
+    }
+}

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.RoundtripTests.ForeignPointProxy.ISerdeInfoProvider.g.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.RoundtripTests.ForeignPointProxy.ISerdeInfoProvider.g.cs
@@ -1,0 +1,19 @@
+
+#nullable enable
+
+namespace Serde.Test;
+
+partial class RoundtripTests
+{
+    partial struct ForeignPointProxy
+    {
+        private static global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
+            "ForeignPoint",
+        typeof(Serde.Test.RoundtripTests.ForeignPointProxy).GetCustomAttributesData(),
+        new (string, global::Serde.ISerdeInfo, System.Reflection.MemberInfo?)[] {
+            ("X", global::Serde.SerdeInfoProvider.GetSerializeInfo<int, global::Serde.I32Proxy>(), typeof(Serde.Test.RoundtripTests.ForeignPointProxy).GetField("X")),
+            ("Y", global::Serde.SerdeInfoProvider.GetSerializeInfo<int, global::Serde.I32Proxy>(), typeof(Serde.Test.RoundtripTests.ForeignPointProxy).GetField("Y"))
+        }
+        );
+    }
+}

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.RoundtripTests.ForeignPointProxy.ISerdeProvider.g.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.RoundtripTests.ForeignPointProxy.ISerdeProvider.g.cs
@@ -1,0 +1,11 @@
+
+namespace Serde.Test;
+
+partial class RoundtripTests
+{
+    partial struct ForeignPointProxy : Serde.ISerdeProvider<Serde.Test.RoundtripTests.ForeignPointProxy, Serde.Test.RoundtripTests.ForeignPointProxy._SerdeObj, Serde.Test.RoundtripTests.ForeignPoint>
+    {
+        static Serde.Test.RoundtripTests.ForeignPointProxy._SerdeObj global::Serde.ISerdeProvider<Serde.Test.RoundtripTests.ForeignPointProxy, Serde.Test.RoundtripTests.ForeignPointProxy._SerdeObj, Serde.Test.RoundtripTests.ForeignPoint>.Instance { get; }
+            = new Serde.Test.RoundtripTests.ForeignPointProxy._SerdeObj();
+    }
+}


### PR DESCRIPTION
GenerateSerde/Serialize/Deserialize support using the ForType flag to serialize and deserialize external types using proxies. auto proxies can be generated by the compiler when the external type has all public members with a parameterless constructor. Sometimes, however, that doesn't work. Either the type has private members, or a constructor, or just requires manipulation during (de)serialization.

Now users can define explicit conversion operators to and from their proxies, providing a space for all the customization to live. The generated implementations will use these conversions automatically.