### PR TITLE
Add support for GenerateSerde(As = ...)

### DIFF
--- a/docs/guide/generator/options.md
+++ b/docs/guide/generator/options.md
@@ -15,6 +15,29 @@ The `GenerateSerde`, `GenerateSerialize`, and `GenerateDeserialize` attributes h
 
   Used to override the generation of the serde object with the specified custom serde object. The target type needs to implement `ISerde<T>`.
 
+- `[GenerateSerde(As = typeof(...))]`
+
+  Serializes and deserializes the declaring type *as* the given type by going through user-defined
+  conversions. When serializing, the declaring type is converted to the target type and serialized
+  as that type; when deserializing, the target type is deserialized and converted back to the
+  declaring type. User-defined conversions (implicit or explicit) must exist in the directions
+  required by the usage: declaring type → target type for serialization, and target type →
+  declaring type for deserialization. This is useful when a type should be represented on
+  the wire as a primitive or another serializable type. `As` cannot be combined with `ForType` or
+  `With`, and cannot be applied to enums.
+
+  ```csharp
+  [GenerateSerde(As = typeof(string))]
+  public readonly partial struct Rgb
+  {
+      public readonly byte R, G, B;
+      public Rgb(byte r, byte g, byte b) => (R, G, B) = (r, g, b);
+
+      public static explicit operator string(Rgb c) => $"#{c.R:X2}{c.G:X2}{c.B:X2}";
+      public static explicit operator Rgb(string s) => /* parse "#RRGGBB" */;
+  }
+  ```
+
 ## Type options
 
 To apply options to an entire type and all its members, use `[SerdeTypeOptions]`. To apply options to one member in particular, use `[SerdeMemberOptions]`.

--- a/samples/AsConversion.cs
+++ b/samples/AsConversion.cs
@@ -1,0 +1,45 @@
+using System;
+using System.Globalization;
+using Serde;
+using Serde.Json;
+
+namespace AsConversionSample;
+
+// An RGB color is naturally three bytes, but is often represented on the wire as a "#RRGGBB" hex
+// string. The `As` option serializes and deserializes the declaring type *as* another type, going
+// through user-defined conversions. You must define both directions:
+//   Rgb    -> string  (used when serializing)
+//   string -> Rgb     (used when deserializing)
+[GenerateSerde(As = typeof(string))]
+partial record struct Rgb(byte R, byte G, byte B)
+{
+    public static explicit operator string(Rgb c) => $"#{c.R:X2}{c.G:X2}{c.B:X2}";
+
+    public static explicit operator Rgb(string s)
+    {
+        var hex = s.AsSpan();
+        hex = hex[0] == '#' ? hex[1..] : hex;
+        return new Rgb(
+            byte.Parse(hex[..2], NumberStyles.HexNumber),
+            byte.Parse(hex[2..4], NumberStyles.HexNumber),
+            byte.Parse(hex[4..6], NumberStyles.HexNumber));
+    }
+}
+
+public static class Sample
+{
+    public static void Run()
+    {
+        var color = new Rgb(0x12, 0xAB, 0xFF);
+        Console.WriteLine($"Original color: R={color.R} G={color.G} B={color.B}");
+
+        // Serialized as a JSON string, going through the Rgb -> string conversion.
+        var json = JsonSerializer.Serialize(color);
+        Console.WriteLine($"Serialized color: {json}");
+
+        // Deserialized from a JSON string, going through the string -> Rgb conversion.
+        var deColor = JsonSerializer.Deserialize<Rgb>(json);
+        Utils.AssertEq(color, deColor);
+        Console.WriteLine($"Deserialized color: R={deColor.R} G={deColor.G} B={deColor.B}");
+    }
+}

--- a/samples/Program.cs
+++ b/samples/Program.cs
@@ -25,3 +25,9 @@ ExternalTypesSample.Sample.Run();
 Console.WriteLine();
 Console.WriteLine("Generic types sample:");
 GenericTypeSample.Run();
+
+// Representing a type as another (the `As` option)
+Console.WriteLine();
+Console.WriteLine("As conversion sample:");
+Console.WriteLine("=========================");
+AsConversionSample.Sample.Run();

--- a/src/generator/Diagnostics.cs
+++ b/src/generator/Diagnostics.cs
@@ -22,6 +22,12 @@ namespace Serde
         ERR_CtorParamMismatch = 9,
         ERR_MissingExplicitConversion = 10,
         ERR_MissingReverseConversion = 11,
+        ERR_AsTypeNoConversion = 12,
+        ERR_AsTypeNotNamed = 13,
+        ERR_AsTypeOnEnum = 14,
+        ERR_AsTypeWithOption = 15,
+        ERR_ForTypeUnsupported = 16,
+        ERR_WithTypeUnsupported = 17,
     }
 
     internal static class Diagnostics
@@ -39,6 +45,12 @@ namespace Serde
             ERR_CtorParamMismatch => nameof(ERR_CtorParamMismatch),
             ERR_MissingExplicitConversion => nameof(ERR_MissingExplicitConversion),
             ERR_MissingReverseConversion => nameof(ERR_MissingReverseConversion),
+            ERR_AsTypeNoConversion => nameof(ERR_AsTypeNoConversion),
+            ERR_AsTypeNotNamed => nameof(ERR_AsTypeNotNamed),
+            ERR_AsTypeOnEnum => nameof(ERR_AsTypeOnEnum),
+            ERR_AsTypeWithOption => nameof(ERR_AsTypeWithOption),
+            ERR_ForTypeUnsupported => nameof(ERR_ForTypeUnsupported),
+            ERR_WithTypeUnsupported => nameof(ERR_WithTypeUnsupported),
         };
 
         public static Diagnostic CreateDiagnostic(DiagId id, Location location, params object[] args)

--- a/src/generator/HelpersAndUtilities/Utilities.cs
+++ b/src/generator/HelpersAndUtilities/Utilities.cs
@@ -94,5 +94,18 @@ namespace Serde
                 }
             }
         }
+
+        public static T? FirstOrNull<T>(this IEnumerable<T> en, Func<T, bool> predicate)
+            where T : struct
+        {
+            foreach (var item in en)
+            {
+                if (predicate(item))
+                {
+                    return item;
+                }
+            }
+            return null;
+        }
     }
 }

--- a/src/generator/Resources.resx
+++ b/src/generator/Resources.resx
@@ -154,4 +154,22 @@
   <data name="ERR_MissingReverseConversion" xml:space="preserve">
     <value>Proxy type '{0}' must define a public explicit conversion operator from '{1}' in order to serialize it. Add: public static explicit operator {0}({1} value)</value>
   </data>
+  <data name="ERR_AsTypeNoConversion" xml:space="preserve">
+    <value>Cannot represent '{0}' as '{1}' because no user-defined conversion from '{0}' to '{1}' was found. Define an explicit or implicit conversion operator between the types.</value>
+  </data>
+  <data name="ERR_AsTypeNotNamed" xml:space="preserve">
+    <value>The 'As' option cannot be applied to type '{0}': the 'As' type must be a named type.</value>
+  </data>
+  <data name="ERR_AsTypeOnEnum" xml:space="preserve">
+    <value>The 'As' option cannot be applied to type '{0}': enums cannot define user-defined conversions.</value>
+  </data>
+  <data name="ERR_AsTypeWithOption" xml:space="preserve">
+    <value>The 'As' option cannot be combined with the '{0}' option.</value>
+  </data>
+  <data name="ERR_ForTypeUnsupported" xml:space="preserve">
+    <value>The 'ForType' option cannot be applied to type '{0}': the proxied type must be a named type.</value>
+  </data>
+  <data name="ERR_WithTypeUnsupported" xml:space="preserve">
+    <value>The 'With' option cannot be applied to type '{0}': the serde object must be a named type.</value>
+  </data>
 </root>

--- a/src/generator/SerdeImplRoslynGenerator.cs
+++ b/src/generator/SerdeImplRoslynGenerator.cs
@@ -148,14 +148,75 @@ public class SerdeImplRoslynGenerator : IIncrementalGenerator
         var attributeData = attrCtx.Attributes.Single();
 
         INamedTypeSymbol receiverType = typeSymbol;
-        var proxiedOpt = TryGetProxiedType(attributeData);
         bool isEnum = typeDecl.IsKind(SyntaxKind.EnumDeclaration);
+
+        // If the `ForType` property is set then we are generating a proxy for the given type.
+        INamedTypeSymbol? proxiedType = null;
+        if (attributeData.NamedArguments.FirstOrNull(a => a.Key == nameof(GenerateSerialize.ForType)) is (_, { } forTypeArg))
+        {
+            proxiedType = TryGetProxiedType(attributeData, forTypeArg, typeSymbol, generationContext);
+            if (proxiedType is null)
+            {
+                // Error already reported
+                return;
+            }
+        }
+
+        // If the `With` property is set then a custom serde object is used for the type.
+        INamedTypeSymbol? serdeObj = null;
+        if (attributeData.NamedArguments.FirstOrNull(a => a.Key == nameof(GenerateSerde.With)) is (_, { } withArg))
+        {
+            serdeObj = TryGetSerdeObj(attributeData, withArg, typeSymbol, generationContext);
+            if (serdeObj is null)
+            {
+                // Error already reported
+                return;
+            }
+        }
+
         // foreignType is non-null only when we have a non-empty proxy with an explicit
         // conversion. It represents the target type for the interface signatures and the
         // final conversion step. The rest of the pipeline operates on receiverType (the proxy).
         INamedTypeSymbol? foreignType = null;
 
-        if (proxiedOpt is { } proxiedType)
+        // If the `As` property is set, the type is serialized/deserialized by converting to and
+        // from the given type. This is incompatible with `ForType`, `With`, and enums.
+        INamedTypeSymbol? asType = null;
+        if (attributeData.NamedArguments.FirstOrNull(a => a.Key == nameof(GenerateSerialize.As)) is (_, { } asArg))
+        {
+            asType = TryGetAsType(attributeData, asArg, typeSymbol, generationContext);
+            if (asType is null)
+            {
+                // Error already reported
+                return;
+            }
+            if (isEnum)
+            {
+                generationContext.ReportDiagnostic(CreateDiagnostic(
+                    DiagId.ERR_AsTypeOnEnum,
+                    attributeData.ApplicationSyntaxReference!.GetSyntax().GetLocation(),
+                    typeSymbol));
+                return;
+            }
+            if (proxiedType is not null)
+            {
+                generationContext.ReportDiagnostic(CreateDiagnostic(
+                    DiagId.ERR_AsTypeWithOption,
+                    attributeData.ApplicationSyntaxReference!.GetSyntax().GetLocation(),
+                    nameof(GenerateSerialize.ForType)));
+                return;
+            }
+            if (serdeObj is not null)
+            {
+                generationContext.ReportDiagnostic(CreateDiagnostic(
+                    DiagId.ERR_AsTypeWithOption,
+                    attributeData.ApplicationSyntaxReference!.GetSyntax().GetLocation(),
+                    nameof(GenerateSerde.With)));
+                return;
+            }
+        }
+
+        if (proxiedType is not null)
         {
             if (proxiedType.SpecialType != SpecialType.None)
             {
@@ -227,7 +288,16 @@ public class SerdeImplRoslynGenerator : IIncrementalGenerator
             (receiverType.WithNullableAnnotation(NullableAnnotation.Annotated), typeSymbol));
 
         string serdeObjString;
-        if (TryGetSerdeObj(attributeData) is not { Item1: { } serdeObj })
+        if (asType is not null)
+        {
+            // Serialize/deserialize the type by converting to and from `asType`.
+            if (!GenAsSerdeObjImpl(usage, generationContext, typeDeclContext, receiverType, asType, inProgress))
+            {
+                return;
+            }
+            serdeObjString = $"{typeDeclContext.GetFqn()}.{usage.GetSerdeObjName()}";
+        }
+        else if (serdeObj is null)
         {
             GenerateInfoAndSerdeImpls(usage, generationContext, typeDeclContext, receiverType, foreignType, inProgress);
             serdeObjString = isEnum
@@ -345,22 +415,59 @@ public class SerdeImplRoslynGenerator : IIncrementalGenerator
     /// the proxied type.
     /// </summary>
     /// <returns>
-    /// Returns null if there is no `ForType` property.
+    /// Returns null if the `ForType` value is not a named type (in which case an error has already
+    /// been reported). Otherwise returns the proxied type.
     /// </returns>
-    private static INamedTypeSymbol? TryGetProxiedType(AttributeData attributeData)
+    private static INamedTypeSymbol? TryGetProxiedType(
+        AttributeData attributeData,
+        TypedConstant namedArg,
+        ISymbol attributedType,
+        GeneratorExecutionContext generationContext)
     {
-        foreach (var namedArg in attributeData.NamedArguments)
+        if (namedArg is { Kind: TypedConstantKind.Type, Value: ITypeSymbol typeSymbol })
         {
-            switch (namedArg)
+            if (typeSymbol is INamedTypeSymbol namedTypeSymbol)
             {
-                case { Key: nameof(GenerateSerialize.ForType),
-                       Value: { Kind: TypedConstantKind.Type, Value: ITypeSymbol typeSymbol } }:
-                    if (typeSymbol is not INamedTypeSymbol namedTypeSymbol)
-                    {
-                        // TODO: Error about bad type
-                        return null;
-                    }
-                    return namedTypeSymbol;
+                return namedTypeSymbol;
+            }
+            else
+            {
+                generationContext.ReportDiagnostic(CreateDiagnostic(
+                    DiagId.ERR_ForTypeUnsupported,
+                    attributeData.ApplicationSyntaxReference!.GetSyntax().GetLocation(),
+                    attributedType));
+            }
+        }
+        return null;
+    }
+
+    /// <summary>
+    /// If the type has an `As` property, then we are generating an implementation that serializes
+    /// and deserializes the type by converting to and from the given type.
+    /// </summary>
+    /// <returns>
+    /// Returns null if there is no `As` property or the `As` value is not a named type (in which
+    /// case an error has already been reported). Otherwise returns the `As` type.
+    /// </returns>
+    private static INamedTypeSymbol? TryGetAsType(
+        AttributeData attributeData,
+        TypedConstant namedArg,
+        ISymbol attributedType,
+        GeneratorExecutionContext generationContext)
+    {
+        if (namedArg is { Kind: TypedConstantKind.Type, Value: ITypeSymbol typeSymbol })
+        {
+            if (typeSymbol is INamedTypeSymbol namedTypeSymbol)
+            {
+                return namedTypeSymbol;
+            }
+            else
+            {
+                // The `As` type wasn't a named type (e.g. an array, pointer, or type parameter).
+                generationContext.ReportDiagnostic(CreateDiagnostic(
+                    DiagId.ERR_AsTypeNotNamed,
+                    attributeData.ApplicationSyntaxReference!.GetSyntax().GetLocation(),
+                    attributedType));
             }
         }
         return null;
@@ -370,20 +477,28 @@ public class SerdeImplRoslynGenerator : IIncrementalGenerator
     /// Check if the generation attribute has a <see cref="GenerateSerde.With"/> property,
     /// which specifies a custom serde object to use for serialization or deserialization.
     /// </summary>
-    private static ValueTuple<INamedTypeSymbol?>? TryGetSerdeObj(AttributeData attributeData)
+    /// <returns>
+    /// Returns null if the `With` value is not a named type (in which case an error has already
+    /// been reported). Otherwise returns the serde object type.
+    /// </returns>
+    private static INamedTypeSymbol? TryGetSerdeObj(
+        AttributeData attributeData,
+        TypedConstant namedArg,
+        ISymbol attributedType,
+        GeneratorExecutionContext generationContext)
     {
-        foreach (var namedArg in attributeData.NamedArguments)
+        if (namedArg is { Kind: TypedConstantKind.Type, Value: ITypeSymbol typeSymbol })
         {
-            switch (namedArg)
+            if (typeSymbol is INamedTypeSymbol namedTypeSymbol)
             {
-                case { Key: nameof(GenerateSerde.With),
-                       Value: { Kind: TypedConstantKind.Type, Value: ITypeSymbol typeSymbol } }:
-                    if (typeSymbol is not INamedTypeSymbol namedTypeSymbol)
-                    {
-                        // TODO: Error about bad type
-                        return new(null);
-                    }
-                    return new(namedTypeSymbol);
+                return namedTypeSymbol;
+            }
+            else
+            {
+                generationContext.ReportDiagnostic(CreateDiagnostic(
+                    DiagId.ERR_WithTypeUnsupported,
+                    attributeData.ApplicationSyntaxReference!.GetSyntax().GetLocation(),
+                    attributedType));
             }
         }
         return null;
@@ -458,6 +573,125 @@ public class SerdeImplRoslynGenerator : IIncrementalGenerator
 
         var srcName = fullTypeName + "." + usage.GetInterfaceName();
         context.AddSource(srcName, newType);
+    }
+
+    /// <summary>
+    /// Generates a serde object that serializes and deserializes <paramref name="receiverType"/> by
+    /// converting to and from <paramref name="asType"/> through user-defined conversions. The
+    /// generated object delegates the actual serialization to <paramref name="asType"/>'s proxy.
+    /// </summary>
+    /// <returns>True if generation succeeded; false if a diagnostic was reported.</returns>
+    internal static bool GenAsSerdeObjImpl(
+        SerdeUsage usage,
+        GeneratorExecutionContext context,
+        TypeDeclContext typeDeclContext,
+        INamedTypeSymbol receiverType,
+        INamedTypeSymbol asType,
+        ImmutableList<(ITypeSymbol Receiver, ITypeSymbol Containing)> inProgress)
+    {
+        string fullTypeName = typeDeclContext.GetFqn(includeTypeParameters: false);
+        var location = receiverType.Locations.Length > 0 ? receiverType.Locations[0] : Location.None;
+        var receiverDisplay = receiverType.ToDisplayString();
+        var asTypeFqn = asType.ToFqn();
+
+        string? serProxy = null;
+        string? deProxy = null;
+
+        if (usage.HasFlag(SerdeUsage.Serialize))
+        {
+            var conversion = context.Compilation.ClassifyConversion(receiverType, asType);
+            if (!conversion.Exists || !conversion.IsUserDefined)
+            {
+                context.ReportDiagnostic(CreateDiagnostic(
+                    DiagId.ERR_AsTypeNoConversion, location, receiverType, asType));
+                return false;
+            }
+            serProxy = Proxies.TryGetProxyString(null, asType, context, SerdeUsage.Serialize, inProgress, ProxyContext.Empty);
+            if (serProxy is null)
+            {
+                context.ReportDiagnostic(CreateDiagnostic(
+                    DiagId.ERR_DoesntImplementInterface, location, asType, asType, "Serde.ISerializeProvider<T>"));
+                return false;
+            }
+        }
+
+        if (usage.HasFlag(SerdeUsage.Deserialize))
+        {
+            var conversion = context.Compilation.ClassifyConversion(asType, receiverType);
+            if (!conversion.Exists || !conversion.IsUserDefined)
+            {
+                context.ReportDiagnostic(CreateDiagnostic(
+                    DiagId.ERR_AsTypeNoConversion, location, asType, receiverType));
+                return false;
+            }
+            deProxy = Proxies.TryGetProxyString(null, asType, context, SerdeUsage.Deserialize, inProgress, ProxyContext.Empty);
+            if (deProxy is null)
+            {
+                context.ReportDiagnostic(CreateDiagnostic(
+                    DiagId.ERR_DoesntImplementInterface, location, asType, asType, "Serde.IDeserializeProvider<T>"));
+                return false;
+            }
+        }
+
+        // The SerdeInfo delegates to the target type so the wire format matches, but overrides the
+        // name so it reflects the declaring type rather than the target type.
+        var targetInfoExpr = serProxy is not null
+            ? $"global::Serde.SerdeInfoProvider.GetSerializeInfo<{asTypeFqn}, {serProxy}>()"
+            : $"global::Serde.SerdeInfoProvider.GetDeserializeInfo<{asTypeFqn}, {deProxy}>()";
+        var serdeInfoExpr = $"global::Serde.SerdeInfoExtensions.WithName({targetInfoExpr}, \"{receiverType.Name}\")";
+
+        var implMembers = new SourceBuilder($"global::Serde.ISerdeInfo global::Serde.ISerdeInfoProvider.SerdeInfo {{ get; }} = {serdeInfoExpr};");
+        if (serProxy is not null)
+        {
+            implMembers.AppendLine("");
+            implMembers.AppendLine($$"""
+            void global::Serde.ISerialize<{{receiverDisplay}}>.Serialize({{receiverDisplay}} value, global::Serde.ISerializer serializer)
+            {
+                global::Serde.SerializeProvider.GetSerialize<{{asTypeFqn}}, {{serProxy}}>().Serialize(({{asTypeFqn}})value, serializer);
+            }
+            """);
+        }
+        if (deProxy is not null)
+        {
+            implMembers.AppendLine("");
+            implMembers.AppendLine($$"""
+            {{receiverDisplay}} global::Serde.IDeserialize<{{receiverDisplay}}>.Deserialize(global::Serde.IDeserializer deserializer)
+            {
+                return ({{receiverDisplay}})global::Serde.DeserializeProvider.GetDeserialize<{{asTypeFqn}}, {{deProxy}}>().Deserialize(deserializer);
+            }
+            """);
+        }
+
+        string baseList = usage switch
+        {
+            SerdeUsage.Serialize => $" : Serde.ISerialize<{receiverDisplay}>",
+            SerdeUsage.Deserialize => $" : Serde.IDeserialize<{receiverDisplay}>",
+            SerdeUsage.Both => $" : global::Serde.ISerde<{receiverType.ToFqn()}>",
+            _ => throw ExceptionUtilities.Unreachable
+        };
+
+        var newType = new SourceBuilder("""
+
+            #nullable enable
+
+            using System;
+            using Serde;
+
+            """
+        );
+
+        var objName = usage.GetSerdeObjName();
+        var proxyType = new SourceBuilder($$"""
+        sealed partial class {{objName}}{{baseList}}
+        {
+            {{implMembers}}
+        }
+        """);
+        typeDeclContext.AppendPartialDecl(newType, "", proxyType);
+
+        var srcName = fullTypeName + "." + usage.GetInterfaceName();
+        context.AddSource(srcName, newType);
+        return true;
     }
 
     internal static (string FileName, SourceBuilder Decl) MakePartialDecl(

--- a/src/serde/Attributes.cs
+++ b/src/serde/Attributes.cs
@@ -23,6 +23,14 @@ sealed class GenerateSerialize : Attribute
     /// This is used to implement serialization and deserialization for a proxy type.
     /// </summary>
     public Type? ForType { get; init; }
+
+    /// <summary>
+    /// If non-null, serialize the declaring type <em>as</em> the given type by going through a
+    /// user-defined conversion. The generated implementation converts the declaring type to this
+    /// type and serializes the result. A user-defined conversion from the declaring type to this
+    /// type must exist.
+    /// </summary>
+    public Type? As { get; init; }
 }
 
 /// <summary>
@@ -42,6 +50,14 @@ sealed class GenerateDeserialize : Attribute
     /// This is used to implement serialization and deserialization for a proxy type.
     /// </summary>
     public Type? ForType { get; init; }
+
+    /// <summary>
+    /// If non-null, deserialize the declaring type <em>as</em> the given type by going through a
+    /// user-defined conversion. The generated implementation deserializes this type and converts
+    /// the result to the declaring type. A user-defined conversion from this type to the declaring
+    /// type must exist.
+    /// </summary>
+    public Type? As { get; init; }
 }
 
 /// <summary>
@@ -66,6 +82,14 @@ sealed class GenerateSerde : Attribute
     /// Override the generated <see cref="ISerde{T}"/> object with a custom one.
     /// </summary>
     public Type? With { get; init; }
+
+    /// <summary>
+    /// If non-null, serialize and deserialize the declaring type <em>as</em> the given type by
+    /// going through user-defined conversions. The generated implementation converts the declaring
+    /// type to this type when serializing and back when deserializing. User-defined conversions in
+    /// both directions between the declaring type and this type must exist.
+    /// </summary>
+    public Type? As { get; init; }
 }
 
 /// <summary>

--- a/test/Serde.Generation.Test/ProxyTests.cs
+++ b/test/Serde.Generation.Test/ProxyTests.cs
@@ -507,5 +507,173 @@ partial struct ForeignPointProxy
 """;
             return VerifyMultiFile(src);
         }
+
+        [Fact]
+        public Task AsString()
+        {
+            var src = """
+using Serde;
+
+[GenerateSerde(As = typeof(string))]
+public readonly partial struct StringId
+{
+    public readonly string Value;
+    public StringId(string value) => Value = value;
+
+    public static explicit operator string(StringId id) => id.Value;
+    public static explicit operator StringId(string value) => new StringId(value);
+}
+""";
+            return VerifyMultiFile(src);
+        }
+
+        [Fact]
+        public Task AsGeneratedType()
+        {
+            var src = """
+using Serde;
+
+[GenerateSerde]
+public partial record Point(int X, int Y);
+
+[GenerateSerde(As = typeof(Point))]
+public readonly partial struct PointWrapper
+{
+    public readonly int X;
+    public readonly int Y;
+    public PointWrapper(int x, int y) { X = x; Y = y; }
+
+    public static implicit operator Point(PointWrapper p) => new Point(p.X, p.Y);
+    public static implicit operator PointWrapper(Point p) => new PointWrapper(p.X, p.Y);
+}
+""";
+            return VerifyMultiFile(src);
+        }
+
+        [Fact]
+        public Task AsSerializeOnly()
+        {
+            var src = """
+using Serde;
+
+[GenerateSerialize(As = typeof(int))]
+public readonly partial struct SerOnlyId
+{
+    public readonly int Value;
+    public SerOnlyId(int value) => Value = value;
+
+    public static implicit operator int(SerOnlyId id) => id.Value;
+}
+""";
+            return VerifyMultiFile(src);
+        }
+
+        [Fact]
+        public Task AsNoConversion()
+        {
+            var src = """
+using Serde;
+
+[GenerateSerde(As = typeof(string))]
+public readonly partial struct NoConversionId
+{
+    public readonly string Value;
+    public NoConversionId(string value) => Value = value;
+}
+""";
+            return VerifyMultiFile(src);
+        }
+
+        [Fact]
+        public Task AsCombinedWithForType()
+        {
+            var src = """
+using Serde;
+
+public partial record Point(int X, int Y);
+
+[GenerateSerde(ForType = typeof(Point), As = typeof(string))]
+public partial struct BadCombo {}
+""";
+            return VerifyMultiFile(src);
+        }
+
+        [Fact]
+        public Task AsTypeNotNamed()
+        {
+            var src = """
+using Serde;
+
+[GenerateSerde(As = typeof(string[]))]
+public readonly partial struct ArrayAsId
+{
+    public readonly string Value;
+    public ArrayAsId(string value) => Value = value;
+}
+""";
+            return VerifyMultiFile(src);
+        }
+
+        [Fact]
+        public Task AsCombinedWithEnum()
+        {
+            var src = """
+using Serde;
+
+[GenerateSerde(As = typeof(int))]
+public enum BadEnum { A, B }
+""";
+            return VerifyMultiFile(src);
+        }
+
+        [Fact]
+        public Task AsCombinedWithWith()
+        {
+            var src = """
+using Serde;
+
+class StringIdSerdeObj : ISerde<StringId>
+{
+    public ISerdeInfo SerdeInfo => StringProxy.SerdeInfo;
+    public void Serialize(StringId value, ISerializer serializer) => serializer.WriteString(value.Value);
+    public StringId Deserialize(IDeserializer deserializer) => new StringId(deserializer.ReadString());
+}
+
+[GenerateSerde(As = typeof(string), With = typeof(StringIdSerdeObj))]
+public readonly partial struct StringId
+{
+    public readonly string Value;
+    public StringId(string value) => Value = value;
+
+    public static explicit operator string(StringId id) => id.Value;
+    public static explicit operator StringId(string value) => new StringId(value);
+}
+""";
+            return VerifyMultiFile(src);
+        }
+
+        [Fact]
+        public Task ForTypeNotNamed()
+        {
+            var src = """
+using Serde;
+
+[GenerateSerde(ForType = typeof(int[]))]
+public partial struct BadForType {}
+""";
+            return VerifyMultiFile(src);
+        }
+
+        [Fact]
+        public Task WithTypeNotNamed()
+        {
+            var src = """
+using Serde;
+
+[GenerateSerde(With = typeof(int[]))]
+public partial struct BadWith {}
+""";
+            return VerifyMultiFile(src);
+        }
     }
 }

--- a/test/Serde.Generation.Test/test_output/ProxyTests.AsCombinedWithEnum/target.verified.txt
+++ b/test/Serde.Generation.Test/test_output/ProxyTests.AsCombinedWithEnum/target.verified.txt
@@ -1,0 +1,23 @@
+﻿{
+  Diagnostics: [
+    {
+      Location: /*
+
+[GenerateSerde(As = typeof(int))]
+ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+public enum BadEnum { A, B }
+*/
+ : (2,1)-(2,32),
+      Message: The 'As' option cannot be applied to type 'BadEnum': enums cannot define user-defined conversions.,
+      Severity: Error,
+      Descriptor: {
+        Id: ERR_AsTypeOnEnum,
+        Title: ,
+        MessageFormat: The 'As' option cannot be applied to type 'BadEnum': enums cannot define user-defined conversions.,
+        Category: Serde,
+        DefaultSeverity: Error,
+        IsEnabledByDefault: true
+      }
+    }
+  ]
+}

--- a/test/Serde.Generation.Test/test_output/ProxyTests.AsCombinedWithForType/target.verified.txt
+++ b/test/Serde.Generation.Test/test_output/ProxyTests.AsCombinedWithForType/target.verified.txt
@@ -1,0 +1,23 @@
+﻿{
+  Diagnostics: [
+    {
+      Location: /*
+
+[GenerateSerde(ForType = typeof(Point), As = typeof(string))]
+ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+public partial struct BadCombo {}
+*/
+ : (4,1)-(4,60),
+      Message: The 'As' option cannot be combined with the 'ForType' option.,
+      Severity: Error,
+      Descriptor: {
+        Id: ERR_AsTypeWithOption,
+        Title: ,
+        MessageFormat: The 'As' option cannot be combined with the 'ForType' option.,
+        Category: Serde,
+        DefaultSeverity: Error,
+        IsEnabledByDefault: true
+      }
+    }
+  ]
+}

--- a/test/Serde.Generation.Test/test_output/ProxyTests.AsCombinedWithWith/target.verified.txt
+++ b/test/Serde.Generation.Test/test_output/ProxyTests.AsCombinedWithWith/target.verified.txt
@@ -1,0 +1,23 @@
+﻿{
+  Diagnostics: [
+    {
+      Location: /*
+
+[GenerateSerde(As = typeof(string), With = typeof(StringIdSerdeObj))]
+ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+public readonly partial struct StringId
+*/
+ : (9,1)-(9,68),
+      Message: The 'As' option cannot be combined with the 'With' option.,
+      Severity: Error,
+      Descriptor: {
+        Id: ERR_AsTypeWithOption,
+        Title: ,
+        MessageFormat: The 'As' option cannot be combined with the 'With' option.,
+        Category: Serde,
+        DefaultSeverity: Error,
+        IsEnabledByDefault: true
+      }
+    }
+  ]
+}

--- a/test/Serde.Generation.Test/test_output/ProxyTests.AsGeneratedType/Point.ISerde.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/ProxyTests.AsGeneratedType/Point.ISerde.g.verified.cs
@@ -1,0 +1,67 @@
+﻿//HintName: Point.ISerde.g.cs
+
+#nullable enable
+
+using System;
+using Serde;
+partial record Point
+{
+    sealed partial class _SerdeObj : global::Serde.ISerde<Point>
+    {
+        global::Serde.ISerdeInfo global::Serde.ISerdeInfoProvider.SerdeInfo => Point.s_serdeInfo;
+
+        void global::Serde.ISerialize<Point>.Serialize(Point value, global::Serde.ISerializer serializer)
+        {
+            var _l_info = global::Serde.SerdeInfoProvider.GetInfo(this);
+            var _l_type = serializer.WriteType(_l_info);
+            _l_type.WriteI32(_l_info, 0, value.X);
+            _l_type.WriteI32(_l_info, 1, value.Y);
+            _l_type.End(_l_info);
+        }
+        Point Serde.IDeserialize<Point>.Deserialize(IDeserializer deserializer)
+        {
+            int _l_x = default!;
+            int _l_y = default!;
+
+            byte _r_assignedValid = 0;
+
+            var _l_serdeInfo = global::Serde.SerdeInfoProvider.GetInfo(this);
+            var typeDeserialize = deserializer.ReadType(_l_serdeInfo);
+            while (true)
+            {
+                var (_l_index_, _) = typeDeserialize.TryReadIndexWithName(_l_serdeInfo);
+                if (_l_index_ == Serde.ITypeDeserializer.EndOfType)
+                {
+                    break;
+                }
+
+                switch (_l_index_)
+                {
+                    case 0:
+                        Serde.DeserializeException.ThrowIfDuplicate(_r_assignedValid, 0, _l_serdeInfo);
+                        _l_x = typeDeserialize.ReadI32(_l_serdeInfo, _l_index_);
+                        _r_assignedValid |= ((byte)1) << 0;
+                        break;
+                    case 1:
+                        Serde.DeserializeException.ThrowIfDuplicate(_r_assignedValid, 1, _l_serdeInfo);
+                        _l_y = typeDeserialize.ReadI32(_l_serdeInfo, _l_index_);
+                        _r_assignedValid |= ((byte)1) << 1;
+                        break;
+                    case Serde.ITypeDeserializer.IndexNotFound:
+                        typeDeserialize.SkipValue(_l_serdeInfo, _l_index_);
+                        break;
+                    default:
+                        throw new InvalidOperationException("Unexpected index: " + _l_index_);
+                }
+            }
+            if ((_r_assignedValid & 0b11) != 0b11)
+            {
+                throw Serde.DeserializeException.UnassignedMember();
+            }
+            var newType = new Point(_l_x, _l_y) {
+            };
+
+            return newType;
+        }
+    }
+}

--- a/test/Serde.Generation.Test/test_output/ProxyTests.AsGeneratedType/Point.ISerdeInfoProvider.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/ProxyTests.AsGeneratedType/Point.ISerdeInfoProvider.g.verified.cs
@@ -1,0 +1,14 @@
+﻿//HintName: Point.ISerdeInfoProvider.g.cs
+
+#nullable enable
+partial record Point
+{
+    private static global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
+        "Point",
+    typeof(Point).GetCustomAttributesData(),
+    new (string, global::Serde.ISerdeInfo, System.Reflection.MemberInfo?)[] {
+        ("x", global::Serde.SerdeInfoProvider.GetSerializeInfo<int, global::Serde.I32Proxy>(), typeof(Point).GetProperty("X")),
+        ("y", global::Serde.SerdeInfoProvider.GetSerializeInfo<int, global::Serde.I32Proxy>(), typeof(Point).GetProperty("Y"))
+    }
+    );
+}

--- a/test/Serde.Generation.Test/test_output/ProxyTests.AsGeneratedType/Point.ISerdeProvider.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/ProxyTests.AsGeneratedType/Point.ISerdeProvider.g.verified.cs
@@ -1,0 +1,6 @@
+﻿//HintName: Point.ISerdeProvider.g.cs
+partial record Point : Serde.ISerdeProvider<Point, Point._SerdeObj, Point>
+{
+    static Point._SerdeObj global::Serde.ISerdeProvider<Point, Point._SerdeObj, Point>.Instance { get; }
+        = new Point._SerdeObj();
+}

--- a/test/Serde.Generation.Test/test_output/ProxyTests.AsGeneratedType/PointWrapper.ISerde.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/ProxyTests.AsGeneratedType/PointWrapper.ISerde.g.verified.cs
@@ -1,0 +1,23 @@
+﻿//HintName: PointWrapper.ISerde.g.cs
+
+#nullable enable
+
+using System;
+using Serde;
+partial struct PointWrapper
+{
+    sealed partial class _SerdeObj : global::Serde.ISerde<PointWrapper>
+    {
+        global::Serde.ISerdeInfo global::Serde.ISerdeInfoProvider.SerdeInfo { get; } = global::Serde.SerdeInfoExtensions.WithName(global::Serde.SerdeInfoProvider.GetSerializeInfo<Point, Point>(), "PointWrapper");
+        void global::Serde.ISerialize<PointWrapper>.Serialize(PointWrapper value, global::Serde.ISerializer serializer)
+        {
+            global::Serde.SerializeProvider.GetSerialize<Point, Point>().Serialize((Point)value, serializer);
+        }
+
+        PointWrapper global::Serde.IDeserialize<PointWrapper>.Deserialize(global::Serde.IDeserializer deserializer)
+        {
+            return (PointWrapper)global::Serde.DeserializeProvider.GetDeserialize<Point, Point>().Deserialize(deserializer);
+        }
+
+    }
+}

--- a/test/Serde.Generation.Test/test_output/ProxyTests.AsGeneratedType/PointWrapper.ISerdeProvider.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/ProxyTests.AsGeneratedType/PointWrapper.ISerdeProvider.g.verified.cs
@@ -1,0 +1,6 @@
+﻿//HintName: PointWrapper.ISerdeProvider.g.cs
+partial struct PointWrapper : Serde.ISerdeProvider<PointWrapper, PointWrapper._SerdeObj, PointWrapper>
+{
+    static PointWrapper._SerdeObj global::Serde.ISerdeProvider<PointWrapper, PointWrapper._SerdeObj, PointWrapper>.Instance { get; }
+        = new PointWrapper._SerdeObj();
+}

--- a/test/Serde.Generation.Test/test_output/ProxyTests.AsNoConversion/target.verified.txt
+++ b/test/Serde.Generation.Test/test_output/ProxyTests.AsNoConversion/target.verified.txt
@@ -1,0 +1,23 @@
+﻿{
+  Diagnostics: [
+    {
+      Location: /*
+[GenerateSerde(As = typeof(string))]
+public readonly partial struct NoConversionId
+                               ^^^^^^^^^^^^^^
+{
+*/
+ : (3,31)-(3,45),
+      Message: Cannot represent 'NoConversionId' as 'string' because no user-defined conversion from 'NoConversionId' to 'string' was found. Define an explicit or implicit conversion operator between the types.,
+      Severity: Error,
+      Descriptor: {
+        Id: ERR_AsTypeNoConversion,
+        Title: ,
+        MessageFormat: Cannot represent 'NoConversionId' as 'string' because no user-defined conversion from 'NoConversionId' to 'string' was found. Define an explicit or implicit conversion operator between the types.,
+        Category: Serde,
+        DefaultSeverity: Error,
+        IsEnabledByDefault: true
+      }
+    }
+  ]
+}

--- a/test/Serde.Generation.Test/test_output/ProxyTests.AsSerializeOnly/SerOnlyId.ISerialize.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/ProxyTests.AsSerializeOnly/SerOnlyId.ISerialize.g.verified.cs
@@ -1,0 +1,18 @@
+﻿//HintName: SerOnlyId.ISerialize.g.cs
+
+#nullable enable
+
+using System;
+using Serde;
+partial struct SerOnlyId
+{
+    sealed partial class _SerObj : Serde.ISerialize<SerOnlyId>
+    {
+        global::Serde.ISerdeInfo global::Serde.ISerdeInfoProvider.SerdeInfo { get; } = global::Serde.SerdeInfoExtensions.WithName(global::Serde.SerdeInfoProvider.GetSerializeInfo<int, global::Serde.I32Proxy>(), "SerOnlyId");
+        void global::Serde.ISerialize<SerOnlyId>.Serialize(SerOnlyId value, global::Serde.ISerializer serializer)
+        {
+            global::Serde.SerializeProvider.GetSerialize<int, global::Serde.I32Proxy>().Serialize((int)value, serializer);
+        }
+
+    }
+}

--- a/test/Serde.Generation.Test/test_output/ProxyTests.AsSerializeOnly/SerOnlyId.ISerializeProvider.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/ProxyTests.AsSerializeOnly/SerOnlyId.ISerializeProvider.g.verified.cs
@@ -1,0 +1,6 @@
+﻿//HintName: SerOnlyId.ISerializeProvider.g.cs
+partial struct SerOnlyId : Serde.ISerializeProvider<SerOnlyId>
+{
+    static global::Serde.ISerialize<SerOnlyId> global::Serde.ISerializeProvider<SerOnlyId>.Instance { get; }
+        = new SerOnlyId._SerObj();
+}

--- a/test/Serde.Generation.Test/test_output/ProxyTests.AsString/StringId.ISerde.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/ProxyTests.AsString/StringId.ISerde.g.verified.cs
@@ -1,0 +1,23 @@
+﻿//HintName: StringId.ISerde.g.cs
+
+#nullable enable
+
+using System;
+using Serde;
+partial struct StringId
+{
+    sealed partial class _SerdeObj : global::Serde.ISerde<StringId>
+    {
+        global::Serde.ISerdeInfo global::Serde.ISerdeInfoProvider.SerdeInfo { get; } = global::Serde.SerdeInfoExtensions.WithName(global::Serde.SerdeInfoProvider.GetSerializeInfo<string, global::Serde.StringProxy>(), "StringId");
+        void global::Serde.ISerialize<StringId>.Serialize(StringId value, global::Serde.ISerializer serializer)
+        {
+            global::Serde.SerializeProvider.GetSerialize<string, global::Serde.StringProxy>().Serialize((string)value, serializer);
+        }
+
+        StringId global::Serde.IDeserialize<StringId>.Deserialize(global::Serde.IDeserializer deserializer)
+        {
+            return (StringId)global::Serde.DeserializeProvider.GetDeserialize<string, global::Serde.StringProxy>().Deserialize(deserializer);
+        }
+
+    }
+}

--- a/test/Serde.Generation.Test/test_output/ProxyTests.AsString/StringId.ISerdeProvider.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/ProxyTests.AsString/StringId.ISerdeProvider.g.verified.cs
@@ -1,0 +1,6 @@
+﻿//HintName: StringId.ISerdeProvider.g.cs
+partial struct StringId : Serde.ISerdeProvider<StringId, StringId._SerdeObj, StringId>
+{
+    static StringId._SerdeObj global::Serde.ISerdeProvider<StringId, StringId._SerdeObj, StringId>.Instance { get; }
+        = new StringId._SerdeObj();
+}

--- a/test/Serde.Generation.Test/test_output/ProxyTests.AsTypeNotNamed/target.verified.txt
+++ b/test/Serde.Generation.Test/test_output/ProxyTests.AsTypeNotNamed/target.verified.txt
@@ -1,0 +1,23 @@
+﻿{
+  Diagnostics: [
+    {
+      Location: /*
+
+[GenerateSerde(As = typeof(string[]))]
+ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+public readonly partial struct ArrayAsId
+*/
+ : (2,1)-(2,37),
+      Message: The 'As' option cannot be applied to type 'ArrayAsId': the 'As' type must be a named type.,
+      Severity: Error,
+      Descriptor: {
+        Id: ERR_AsTypeNotNamed,
+        Title: ,
+        MessageFormat: The 'As' option cannot be applied to type 'ArrayAsId': the 'As' type must be a named type.,
+        Category: Serde,
+        DefaultSeverity: Error,
+        IsEnabledByDefault: true
+      }
+    }
+  ]
+}

--- a/test/Serde.Generation.Test/test_output/ProxyTests.ForTypeNotNamed/target.verified.txt
+++ b/test/Serde.Generation.Test/test_output/ProxyTests.ForTypeNotNamed/target.verified.txt
@@ -1,0 +1,23 @@
+﻿{
+  Diagnostics: [
+    {
+      Location: /*
+
+[GenerateSerde(ForType = typeof(int[]))]
+ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+public partial struct BadForType {}
+*/
+ : (2,1)-(2,39),
+      Message: The 'ForType' option cannot be applied to type 'BadForType': the proxied type must be a named type.,
+      Severity: Error,
+      Descriptor: {
+        Id: ERR_ForTypeUnsupported,
+        Title: ,
+        MessageFormat: The 'ForType' option cannot be applied to type 'BadForType': the proxied type must be a named type.,
+        Category: Serde,
+        DefaultSeverity: Error,
+        IsEnabledByDefault: true
+      }
+    }
+  ]
+}

--- a/test/Serde.Generation.Test/test_output/ProxyTests.WithTypeNotNamed/target.verified.txt
+++ b/test/Serde.Generation.Test/test_output/ProxyTests.WithTypeNotNamed/target.verified.txt
@@ -1,0 +1,23 @@
+﻿{
+  Diagnostics: [
+    {
+      Location: /*
+
+[GenerateSerde(With = typeof(int[]))]
+ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+public partial struct BadWith {}
+*/
+ : (2,1)-(2,36),
+      Message: The 'With' option cannot be applied to type 'BadWith': the serde object must be a named type.,
+      Severity: Error,
+      Descriptor: {
+        Id: ERR_WithTypeUnsupported,
+        Title: ,
+        MessageFormat: The 'With' option cannot be applied to type 'BadWith': the serde object must be a named type.,
+        Category: Serde,
+        DefaultSeverity: Error,
+        IsEnabledByDefault: true
+      }
+    }
+  ]
+}

--- a/test/Serde.Test/AsTests.cs
+++ b/test/Serde.Test/AsTests.cs
@@ -1,0 +1,85 @@
+using Serde.Json;
+using Xunit;
+
+namespace Serde.Test;
+
+public partial class AsTests
+{
+    [GenerateSerde(As = typeof(string))]
+    public readonly partial struct StringId
+    {
+        public readonly string Value;
+        public StringId(string value) => Value = value;
+
+        public static explicit operator string(StringId id) => id.Value;
+        public static explicit operator StringId(string value) => new StringId(value);
+    }
+
+    [Fact]
+    public void RoundTripStringId()
+    {
+        var id = new StringId("hello");
+        var json = JsonSerializer.Serialize(id);
+        Assert.Equal("\"hello\"", json);
+
+        var back = JsonSerializer.Deserialize<StringId>(json);
+        Assert.Equal("hello", back.Value);
+    }
+
+    [GenerateSerde]
+    public partial record Point(int X, int Y);
+
+    [GenerateSerde(As = typeof(Point))]
+    public readonly partial struct PointWrapper
+    {
+        public readonly int X;
+        public readonly int Y;
+        public PointWrapper(int x, int y)
+        {
+            X = x;
+            Y = y;
+        }
+
+        public static implicit operator Point(PointWrapper p) => new Point(p.X, p.Y);
+        public static implicit operator PointWrapper(Point p) => new PointWrapper(p.X, p.Y);
+    }
+
+    [Fact]
+    public void RoundTripPointWrapper()
+    {
+        var p = new PointWrapper(1, 2);
+        var json = JsonSerializer.Serialize(p);
+        Assert.Equal("""{"x":1,"y":2}""", json);
+
+        var back = JsonSerializer.Deserialize<PointWrapper>(json);
+        Assert.Equal(1, back.X);
+        Assert.Equal(2, back.Y);
+    }
+
+    [GenerateSerialize(As = typeof(string))]
+    public readonly partial record struct SerOnlyId(int Value)
+    {
+        public static explicit operator string(SerOnlyId id) => id.Value.ToString();
+    }
+
+    [Fact]
+    public void SerializeOnlyAsString()
+    {
+        var id = new SerOnlyId(42);
+        var json = JsonSerializer.Serialize<SerOnlyId, SerOnlyId>(id);
+        Assert.Equal("\"42\"", json);
+    }
+
+    [GenerateDeserialize(As = typeof(string))]
+    public readonly partial record struct DeOnlyId(int Value)
+    {
+        public static explicit operator DeOnlyId(string value) => new DeOnlyId(int.Parse(value));
+    }
+
+    [Fact]
+    public void DeserializeOnlyAsString()
+    {
+        var id = JsonSerializer.Deserialize<DeOnlyId, DeOnlyId>("\"42\"");
+        Assert.Equal(42, id.Value);
+    }
+}

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.AsTests.DeOnlyId.IDeserialize.g.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.AsTests.DeOnlyId.IDeserialize.g.cs
@@ -1,0 +1,23 @@
+
+#nullable enable
+
+using System;
+using Serde;
+
+namespace Serde.Test;
+
+partial class AsTests
+{
+    partial record struct DeOnlyId
+    {
+        sealed partial class _DeObj : Serde.IDeserialize<Serde.Test.AsTests.DeOnlyId>
+        {
+            global::Serde.ISerdeInfo global::Serde.ISerdeInfoProvider.SerdeInfo { get; } = global::Serde.SerdeInfoExtensions.WithName(global::Serde.SerdeInfoProvider.GetDeserializeInfo<string, global::Serde.StringProxy>(), "DeOnlyId");
+            Serde.Test.AsTests.DeOnlyId global::Serde.IDeserialize<Serde.Test.AsTests.DeOnlyId>.Deserialize(global::Serde.IDeserializer deserializer)
+            {
+                return (Serde.Test.AsTests.DeOnlyId)global::Serde.DeserializeProvider.GetDeserialize<string, global::Serde.StringProxy>().Deserialize(deserializer);
+            }
+
+        }
+    }
+}

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.AsTests.DeOnlyId.IDeserializeProvider.g.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.AsTests.DeOnlyId.IDeserializeProvider.g.cs
@@ -1,0 +1,11 @@
+
+namespace Serde.Test;
+
+partial class AsTests
+{
+    partial record struct DeOnlyId : Serde.IDeserializeProvider<Serde.Test.AsTests.DeOnlyId>
+    {
+        static global::Serde.IDeserialize<Serde.Test.AsTests.DeOnlyId> global::Serde.IDeserializeProvider<Serde.Test.AsTests.DeOnlyId>.Instance { get; }
+            = new Serde.Test.AsTests.DeOnlyId._DeObj();
+    }
+}

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.AsTests.Point.ISerde.g.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.AsTests.Point.ISerde.g.cs
@@ -1,0 +1,72 @@
+
+#nullable enable
+
+using System;
+using Serde;
+
+namespace Serde.Test;
+
+partial class AsTests
+{
+    partial record Point
+    {
+        sealed partial class _SerdeObj : global::Serde.ISerde<Serde.Test.AsTests.Point>
+        {
+            global::Serde.ISerdeInfo global::Serde.ISerdeInfoProvider.SerdeInfo => Serde.Test.AsTests.Point.s_serdeInfo;
+
+            void global::Serde.ISerialize<Serde.Test.AsTests.Point>.Serialize(Serde.Test.AsTests.Point value, global::Serde.ISerializer serializer)
+            {
+                var _l_info = global::Serde.SerdeInfoProvider.GetInfo(this);
+                var _l_type = serializer.WriteType(_l_info);
+                _l_type.WriteI32(_l_info, 0, value.X);
+                _l_type.WriteI32(_l_info, 1, value.Y);
+                _l_type.End(_l_info);
+            }
+            Serde.Test.AsTests.Point Serde.IDeserialize<Serde.Test.AsTests.Point>.Deserialize(IDeserializer deserializer)
+            {
+                int _l_x = default!;
+                int _l_y = default!;
+
+                byte _r_assignedValid = 0;
+
+                var _l_serdeInfo = global::Serde.SerdeInfoProvider.GetInfo(this);
+                var typeDeserialize = deserializer.ReadType(_l_serdeInfo);
+                while (true)
+                {
+                    var (_l_index_, _) = typeDeserialize.TryReadIndexWithName(_l_serdeInfo);
+                    if (_l_index_ == Serde.ITypeDeserializer.EndOfType)
+                    {
+                        break;
+                    }
+
+                    switch (_l_index_)
+                    {
+                        case 0:
+                            Serde.DeserializeException.ThrowIfDuplicate(_r_assignedValid, 0, _l_serdeInfo);
+                            _l_x = typeDeserialize.ReadI32(_l_serdeInfo, _l_index_);
+                            _r_assignedValid |= ((byte)1) << 0;
+                            break;
+                        case 1:
+                            Serde.DeserializeException.ThrowIfDuplicate(_r_assignedValid, 1, _l_serdeInfo);
+                            _l_y = typeDeserialize.ReadI32(_l_serdeInfo, _l_index_);
+                            _r_assignedValid |= ((byte)1) << 1;
+                            break;
+                        case Serde.ITypeDeserializer.IndexNotFound:
+                            typeDeserialize.SkipValue(_l_serdeInfo, _l_index_);
+                            break;
+                        default:
+                            throw new InvalidOperationException("Unexpected index: " + _l_index_);
+                    }
+                }
+                if ((_r_assignedValid & 0b11) != 0b11)
+                {
+                    throw Serde.DeserializeException.UnassignedMember();
+                }
+                var newType = new Serde.Test.AsTests.Point(_l_x, _l_y) {
+                };
+
+                return newType;
+            }
+        }
+    }
+}

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.AsTests.Point.ISerdeInfoProvider.g.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.AsTests.Point.ISerdeInfoProvider.g.cs
@@ -1,0 +1,19 @@
+
+#nullable enable
+
+namespace Serde.Test;
+
+partial class AsTests
+{
+    partial record Point
+    {
+        private static global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
+            "Point",
+        typeof(Serde.Test.AsTests.Point).GetCustomAttributesData(),
+        new (string, global::Serde.ISerdeInfo, System.Reflection.MemberInfo?)[] {
+            ("x", global::Serde.SerdeInfoProvider.GetSerializeInfo<int, global::Serde.I32Proxy>(), typeof(Serde.Test.AsTests.Point).GetProperty("X")),
+            ("y", global::Serde.SerdeInfoProvider.GetSerializeInfo<int, global::Serde.I32Proxy>(), typeof(Serde.Test.AsTests.Point).GetProperty("Y"))
+        }
+        );
+    }
+}

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.AsTests.Point.ISerdeProvider.g.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.AsTests.Point.ISerdeProvider.g.cs
@@ -1,0 +1,11 @@
+
+namespace Serde.Test;
+
+partial class AsTests
+{
+    partial record Point : Serde.ISerdeProvider<Serde.Test.AsTests.Point, Serde.Test.AsTests.Point._SerdeObj, Serde.Test.AsTests.Point>
+    {
+        static Serde.Test.AsTests.Point._SerdeObj global::Serde.ISerdeProvider<Serde.Test.AsTests.Point, Serde.Test.AsTests.Point._SerdeObj, Serde.Test.AsTests.Point>.Instance { get; }
+            = new Serde.Test.AsTests.Point._SerdeObj();
+    }
+}

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.AsTests.PointWrapper.ISerde.g.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.AsTests.PointWrapper.ISerde.g.cs
@@ -1,0 +1,28 @@
+
+#nullable enable
+
+using System;
+using Serde;
+
+namespace Serde.Test;
+
+partial class AsTests
+{
+    partial struct PointWrapper
+    {
+        sealed partial class _SerdeObj : global::Serde.ISerde<Serde.Test.AsTests.PointWrapper>
+        {
+            global::Serde.ISerdeInfo global::Serde.ISerdeInfoProvider.SerdeInfo { get; } = global::Serde.SerdeInfoExtensions.WithName(global::Serde.SerdeInfoProvider.GetSerializeInfo<Serde.Test.AsTests.Point, Serde.Test.AsTests.Point>(), "PointWrapper");
+            void global::Serde.ISerialize<Serde.Test.AsTests.PointWrapper>.Serialize(Serde.Test.AsTests.PointWrapper value, global::Serde.ISerializer serializer)
+            {
+                global::Serde.SerializeProvider.GetSerialize<Serde.Test.AsTests.Point, Serde.Test.AsTests.Point>().Serialize((Serde.Test.AsTests.Point)value, serializer);
+            }
+
+            Serde.Test.AsTests.PointWrapper global::Serde.IDeserialize<Serde.Test.AsTests.PointWrapper>.Deserialize(global::Serde.IDeserializer deserializer)
+            {
+                return (Serde.Test.AsTests.PointWrapper)global::Serde.DeserializeProvider.GetDeserialize<Serde.Test.AsTests.Point, Serde.Test.AsTests.Point>().Deserialize(deserializer);
+            }
+
+        }
+    }
+}

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.AsTests.PointWrapper.ISerdeProvider.g.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.AsTests.PointWrapper.ISerdeProvider.g.cs
@@ -1,0 +1,11 @@
+
+namespace Serde.Test;
+
+partial class AsTests
+{
+    partial struct PointWrapper : Serde.ISerdeProvider<Serde.Test.AsTests.PointWrapper, Serde.Test.AsTests.PointWrapper._SerdeObj, Serde.Test.AsTests.PointWrapper>
+    {
+        static Serde.Test.AsTests.PointWrapper._SerdeObj global::Serde.ISerdeProvider<Serde.Test.AsTests.PointWrapper, Serde.Test.AsTests.PointWrapper._SerdeObj, Serde.Test.AsTests.PointWrapper>.Instance { get; }
+            = new Serde.Test.AsTests.PointWrapper._SerdeObj();
+    }
+}

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.AsTests.SerOnlyId.ISerialize.g.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.AsTests.SerOnlyId.ISerialize.g.cs
@@ -1,0 +1,23 @@
+
+#nullable enable
+
+using System;
+using Serde;
+
+namespace Serde.Test;
+
+partial class AsTests
+{
+    partial record struct SerOnlyId
+    {
+        sealed partial class _SerObj : Serde.ISerialize<Serde.Test.AsTests.SerOnlyId>
+        {
+            global::Serde.ISerdeInfo global::Serde.ISerdeInfoProvider.SerdeInfo { get; } = global::Serde.SerdeInfoExtensions.WithName(global::Serde.SerdeInfoProvider.GetSerializeInfo<string, global::Serde.StringProxy>(), "SerOnlyId");
+            void global::Serde.ISerialize<Serde.Test.AsTests.SerOnlyId>.Serialize(Serde.Test.AsTests.SerOnlyId value, global::Serde.ISerializer serializer)
+            {
+                global::Serde.SerializeProvider.GetSerialize<string, global::Serde.StringProxy>().Serialize((string)value, serializer);
+            }
+
+        }
+    }
+}

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.AsTests.SerOnlyId.ISerializeProvider.g.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.AsTests.SerOnlyId.ISerializeProvider.g.cs
@@ -1,0 +1,11 @@
+
+namespace Serde.Test;
+
+partial class AsTests
+{
+    partial record struct SerOnlyId : Serde.ISerializeProvider<Serde.Test.AsTests.SerOnlyId>
+    {
+        static global::Serde.ISerialize<Serde.Test.AsTests.SerOnlyId> global::Serde.ISerializeProvider<Serde.Test.AsTests.SerOnlyId>.Instance { get; }
+            = new Serde.Test.AsTests.SerOnlyId._SerObj();
+    }
+}

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.AsTests.StringId.ISerde.g.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.AsTests.StringId.ISerde.g.cs
@@ -1,0 +1,28 @@
+
+#nullable enable
+
+using System;
+using Serde;
+
+namespace Serde.Test;
+
+partial class AsTests
+{
+    partial struct StringId
+    {
+        sealed partial class _SerdeObj : global::Serde.ISerde<Serde.Test.AsTests.StringId>
+        {
+            global::Serde.ISerdeInfo global::Serde.ISerdeInfoProvider.SerdeInfo { get; } = global::Serde.SerdeInfoExtensions.WithName(global::Serde.SerdeInfoProvider.GetSerializeInfo<string, global::Serde.StringProxy>(), "StringId");
+            void global::Serde.ISerialize<Serde.Test.AsTests.StringId>.Serialize(Serde.Test.AsTests.StringId value, global::Serde.ISerializer serializer)
+            {
+                global::Serde.SerializeProvider.GetSerialize<string, global::Serde.StringProxy>().Serialize((string)value, serializer);
+            }
+
+            Serde.Test.AsTests.StringId global::Serde.IDeserialize<Serde.Test.AsTests.StringId>.Deserialize(global::Serde.IDeserializer deserializer)
+            {
+                return (Serde.Test.AsTests.StringId)global::Serde.DeserializeProvider.GetDeserialize<string, global::Serde.StringProxy>().Deserialize(deserializer);
+            }
+
+        }
+    }
+}

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.AsTests.StringId.ISerdeProvider.g.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.AsTests.StringId.ISerdeProvider.g.cs
@@ -1,0 +1,11 @@
+
+namespace Serde.Test;
+
+partial class AsTests
+{
+    partial struct StringId : Serde.ISerdeProvider<Serde.Test.AsTests.StringId, Serde.Test.AsTests.StringId._SerdeObj, Serde.Test.AsTests.StringId>
+    {
+        static Serde.Test.AsTests.StringId._SerdeObj global::Serde.ISerdeProvider<Serde.Test.AsTests.StringId, Serde.Test.AsTests.StringId._SerdeObj, Serde.Test.AsTests.StringId>.Instance { get; }
+            = new Serde.Test.AsTests.StringId._SerdeObj();
+    }
+}


### PR DESCRIPTION
This is a feature for making it easier to serialize a given type with the wire format of another type. For example, a Color type could easily be serialized as an RGB-formatted string.

To use this feature, users only have to define explicit conversion operators. This is much simpler than declaring a custom serializer.