### PR TITLE
Update SerdePkgVersion from 0.11.0 to 0.12.0

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,6 +5,6 @@
     <Deterministic>true</Deterministic>
     <TestTfm>net10.0</TestTfm>
     <SerdeAssemblyVersion>0.10.1</SerdeAssemblyVersion>
-    <SerdePkgVersion>0.11.0</SerdePkgVersion>
+    <SerdePkgVersion>0.12.0</SerdePkgVersion>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Bumps `SerdePkgVersion` to `0.12.0` in preparation for the next release.

## Changes since v0.11.0
- Add support for `GenerateSerde(As = ...)` (#339)
- Add support for using conversions in `Generate ForType` (#338)
- Replace FsCheck with CsCheck (#337)
- Cleanup docs and samples (#340)