### PR TITLE
Docs: restructure guide and add self-contained deploy workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,41 @@
+name: docs
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - 'docs/**'
+      - '.github/workflows/docs.yml'
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}
+      cancel-in-progress: true
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup mdBook
+        uses: peaceiris/actions-mdbook@v2
+        with:
+          mdbook-version: '0.5.1'
+
+      - name: Build book
+        run: mdbook build ./docs
+
+      # Publishes the rendered book to the gh-pages branch of the
+      # serdedotnet.github.io repo, which serves https://serdedotnet.github.io/.
+      # Requires the DOCS_DEPLOY_KEY secret (SSH private key whose public half is
+      # registered as a write-enabled deploy key on serdedotnet/serdedotnet.github.io).
+      - name: Deploy to serdedotnet.github.io
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          deploy_key: ${{ secrets.DOCS_DEPLOY_KEY }}
+          external_repository: serdedotnet/serdedotnet.github.io
+          publish_branch: gh-pages
+          publish_dir: ./docs/book
+          force_orphan: true

--- a/docs/guide/SUMMARY.md
+++ b/docs/guide/SUMMARY.md
@@ -1,9 +1,9 @@
 # Summary
 
 - [Overview](./overview.md)
+- [Data model](./data-model.md)
 - [Using the source generator](./generator/generator.md)
     - [Configuration options](./generator/options.md)
-- [Data model](./data-model.md)
-- [Customization](./customization.md)
-- [External types](./foreign-types.md)
-- [Generic types](./generic-types.md)
+    - [External types](./foreign-types.md)
+- [Custom implementations](./customization.md)
+    - [Generic types](./generic-types.md)


### PR DESCRIPTION
## Summary
- Reorganizes the mdbook guide `SUMMARY.md` (Data model promoted; External types nested under the generator; Generic types nested under Custom implementations).
- Adds `.github/workflows/docs.yml` to build the guide and publish it to `serdedotnet.github.io` automatically.

## Why the deploy workflow
`https://serdedotnet.github.io/` is served from the `gh-pages` branch of `serdedotnet/serdedotnet.github.io`, which pulled `serde` in as a git submodule and rebuilt only when a Dependabot submodule-bump PR was merged. Those PRs stopped being merged after 2025-05-31, so the published docs froze ~1 year (65+ commits) behind `main`.

This workflow moves docs deployment into this repo: on docs changes to `main` (or manual dispatch) it builds the mdbook and force-pushes the rendered site to the `.github.io` repo's `gh-pages` branch, keeping the root URL. The submodule/Dependabot indirection is being retired in serdedotnet/serdedotnet.github.io#23.

## Required infra (already provisioned)
- Deploy key (write) added to `serdedotnet/serdedotnet.github.io`.
- `DOCS_DEPLOY_KEY` secret set on this repo.

After merge, run the **docs** workflow once to refresh the live site.