### PR TITLE
Persist constant default values and most static accesses

### DIFF
--- a/src/generator/DataMemberSymbol.cs
+++ b/src/generator/DataMemberSymbol.cs
@@ -5,6 +5,8 @@ using System.Diagnostics;
 using System.Linq;
 using System.Text;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace Serde
 {
@@ -28,8 +30,9 @@ namespace Serde
             MemberOptions memberOptions)
         {
             Debug.Assert(symbol is
-                IFieldSymbol or
-                IPropertySymbol { Parameters.Length: 0 });
+                IFieldSymbol { ContainingType: { TypeKind: TypeKind.Enum}, IsStatic: true } or
+                IFieldSymbol { IsStatic: false } or
+                IPropertySymbol { IsStatic: false, Parameters.Length: 0 });
             Symbol = symbol;
             _typeOptions = typeOptions;
             _memberOptions = memberOptions;
@@ -184,6 +187,75 @@ namespace Serde
                     wordBuilder.Clear();
                 }
             }
+        }
+
+        /// <summary>
+        /// Returns the initializer expression string for this member, or null if there is no
+        /// initializer or the initializer is not "constant". Constant here means either an
+        /// actual const, or a static member reference. This expression should be safe to emit
+        /// into methods inside the type.
+        /// </summary>
+        public string? GetConstInitializer(Compilation compilation)
+        {
+            foreach (var syntaxRef in Symbol.DeclaringSyntaxReferences)
+            {
+                var syntax = syntaxRef.GetSyntax();
+                EqualsValueClauseSyntax? initializer = syntax switch
+                {
+                    VariableDeclaratorSyntax v => v.Initializer,
+                    PropertyDeclarationSyntax p => p.Initializer,
+                    _ => null
+                };
+                if (initializer is null)
+                    continue;
+
+                var semanticModel = compilation.GetSemanticModel(syntax.SyntaxTree);
+
+                var expr = initializer.Value;
+                // Check if the expression resolves to a symbol we can safely fully-qualify.
+                var symbolInfo = semanticModel.GetSymbolInfo(expr);
+                if (symbolInfo.Symbol is IFieldSymbol { IsStatic: true } or
+                    IPropertySymbol { IsStatic: true })
+                {
+                    return symbolInfo.Symbol.ToDisplayString(SymbolUtilities.FqnFormat);
+                }
+
+                if (expr is InvocationExpressionSyntax)
+                {
+                    return null;
+                }
+
+                var constant = semanticModel.GetConstantValue(expr);
+                if (constant.HasValue)
+                {
+                    var val = constant.Value;
+                    // A null constant has no identifiers; preserve the original text so
+                    // that null-forgiving syntax (null!) is kept for non-nullable members.
+                    if (val is null)
+                    {
+                        return expr.ToString();
+                    }
+
+                    // Reconstruct the constant from its value rather than echoing the
+                    // source text, so that no unqualified identifiers (type names relying
+                    // on a using directive, or named constants) can leak into the
+                    // generated file. FormatPrimitive emits a self-contained literal.
+                    var literal = SymbolDisplay.FormatPrimitive(val, quoteStrings: true, useHexadecimalNumbers: false);
+                    if (literal is null)
+                    {
+                        return null;
+                    }
+
+                    // Enum constants (e.g. a cast like (Color)0 or a flags combination)
+                    // carry their underlying integral value; cast it back to the
+                    // fully-qualified enum type.
+                    var constType = semanticModel.GetTypeInfo(expr).Type;
+                    return constType is { TypeKind: TypeKind.Enum }
+                        ? $"({constType.ToFqn()}){literal}"
+                        : literal;
+                }
+            }
+            return null;
         }
     }
 }

--- a/src/generator/DeserializeImplGen.cs
+++ b/src/generator/DeserializeImplGen.cs
@@ -197,6 +197,15 @@ namespace Serde
 
             var classScopeProxyMap = ProxyMap.FromSymbol(type);
 
+            // Field initializers are only preserved when the deserializer is generated
+            // into the same type whose members we are reading (its own nested _DeObj).
+            // For an empty ForType proxy, `type` is the foreign target but the code is
+            // emitted in the proxy type, so the initializers — which may reference members
+            // inaccessible from the proxy — must not be copied.
+            var containingType = inProgress.IsEmpty ? null : inProgress[0].Containing;
+            var preserveInitializers = containingType is not null
+                && SymbolEqualityComparer.Default.Equals(type, containingType);
+
             var members = SymbolUtilities.GetDataMembers(type, SerdeUsage.Both);
             var typeFqn = typeSyntax.ToString();
             var assignedVarType = members.Count switch {
@@ -304,7 +313,10 @@ namespace Serde
                         readValueCall = $"ReadValue<{memberType}, {memberType}>";
                     }
                     var localName = GetLocalName(m);
-                    localsBuilder.AppendLine($"{memberType} {localName} = default!;");
+                    var initializer = preserveInitializers
+                        ? (m.GetConstInitializer(context.Compilation) ?? "default!")
+                        : "default!";
+                    localsBuilder.AppendLine($"{memberType} {localName} = {initializer};");
 
                     var typeOptions = SymbolUtilities.GetTypeOptions(type);
                     var duplicateKeyCheck = !typeOptions.AllowDuplicateKeys

--- a/src/generator/HelpersAndUtilities/SymbolUtilities.cs
+++ b/src/generator/HelpersAndUtilities/SymbolUtilities.cs
@@ -213,6 +213,7 @@ namespace Serde
             SymbolDisplayGlobalNamespaceStyle.OmittedAsContaining,
             SymbolDisplayTypeQualificationStyle.NameAndContainingTypesAndNamespaces,
             SymbolDisplayGenericsOptions.IncludeTypeParameters,
+            SymbolDisplayMemberOptions.IncludeContainingType,
             miscellaneousOptions:
                 SymbolDisplayMiscellaneousOptions.UseSpecialTypes
                 | SymbolDisplayMiscellaneousOptions.EscapeKeywordIdentifiers

--- a/test/Serde.Generation.Test/FieldInitializerTests.cs
+++ b/test/Serde.Generation.Test/FieldInitializerTests.cs
@@ -1,0 +1,195 @@
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+using Xunit;
+using static Serde.Test.GeneratorTestUtils;
+
+namespace Serde.Test
+{
+    public class FieldInitializerTests
+    {
+        [Fact]
+        public Task FieldInitializers()
+        {
+            var src = """
+using Serde;
+[GenerateDeserialize]
+partial class C
+{
+    // Compile-time constants
+    public string Str = "hello";
+    public int Num = 42;
+    public bool Flag = true;
+    public string? Nullable = null;
+    public double Dbl = 3.14;
+    public char Ch = 'x';
+
+    // Static member access
+    public string FromMethod = string.Empty;
+    public int MaxInt = int.MaxValue;
+}
+""";
+            return VerifyDeserialize(src);
+        }
+
+        /// <summary>
+        /// Enum field initializers should be preserved as compile-time constants.
+        /// </summary>
+        [Fact]
+        public Task FieldInitializerEnum()
+        {
+            var src = """
+using Serde;
+
+[GenerateDeserialize]
+enum Color { Red, Green, Blue }
+
+[GenerateDeserialize]
+partial class C
+{
+    public Color Color = Color.Green;
+}
+""";
+            return VerifyDeserialize(src);
+        }
+
+        /// <summary>
+        /// Arithmetic/complex expressions in initializers should NOT be preserved
+        /// (not compile-time constants from GetConstantValue's perspective when involving
+        /// non-literal sub-expressions), falling back to default!.
+        /// </summary>
+        [Fact]
+        public Task FieldInitializerUnsafe()
+        {
+            var src = """
+using Serde;
+using System.Collections.Generic;
+
+[GenerateDeserialize]
+partial class C
+{
+    // new expressions are not constants or static member accesses
+    public List<int> Items = new List<int>();
+    // Array creation is not a constant
+    public int[] Arr = new int[10];
+    // nameof references a symbol that may not be in scope in generated code
+    public string Name = nameof(C);
+}
+""";
+            return VerifyDeserialize(src);
+        }
+
+        /// <summary>
+        /// Verify that null! on a non-nullable reference type roundtrips correctly.
+        /// GetConstantValue returns null (without the !), so we need to re-add the
+        /// null-forgiving operator for the generated code to compile under #nullable enable.
+        /// </summary>
+        [Fact]
+        public Task FieldInitializerNullForgiving()
+        {
+            var src = """
+using Serde;
+
+[GenerateDeserialize]
+partial class C
+{
+    // null! on non-nullable types — must roundtrip as null!
+    public string S = null!;
+    public int[] Arr = null!;
+    // null on nullable type — no ! needed
+    public string? N = null;
+}
+""";
+            return VerifyDeserialize(src);
+        }
+
+        /// <summary>
+        /// Primary constructor parameters referenced in field initializers must NOT be
+        /// preserved. This was the root cause of https://github.com/serdedotnet/serde/issues/313.
+        /// We use a record here so the primary ctor params are proper public properties
+        /// The field `Extra = X + 1` references ctor param `X`, so GetConstantValue
+        /// won't succeed and it falls back to default!.
+        /// </summary>
+        [Fact]
+        public Task FieldInitializerPrimaryCtorParam()
+        {
+            var src = """
+using Serde;
+
+[GenerateDeserialize]
+partial record C(int X)
+{
+    // References primary ctor parameter — must fall back to default!
+    public int Extra = X + 1;
+    // Safe constant — should be preserved
+    public int Z = 100;
+}
+""";
+            return VerifyDeserialize(src);
+        }
+
+        /// <summary>
+        /// Enum constants that are not a direct member access (e.g. a cast like (Color)0)
+        /// reach the constant path. The initializer text uses a simple type name that may
+        /// rely on a using directive not present in the generated file, so it must be
+        /// reconstructed with the fully-qualified enum type name.
+        /// </summary>
+        [Fact]
+        public Task FieldInitializerEnumCast()
+        {
+            var src = """
+using Serde;
+using Other;
+
+namespace Mine
+{
+    [GenerateDeserialize]
+    partial class C
+    {
+        public Color Field = (Color)0;
+        public int Y;
+    }
+}
+
+namespace Other
+{
+    [GenerateDeserialize]
+    public enum Color { Red, Green }
+}
+""";
+            return VerifyDeserialize(src);
+        }
+
+        /// <summary>
+        /// Field initializers must NOT be preserved for a ForType proxy: the generated
+        /// deserializer lives in the proxy type, not nested in the target, so a
+        /// fully-qualified reference to a private/inaccessible static member would fail
+        /// to compile. The initializer falls back to default! instead.
+        /// </summary>
+        [Fact]
+        public Task FieldInitializerForeignTypeProxy()
+        {
+            var src = """
+using Serde;
+
+class Target
+{
+    private static readonly int s_def = 7;
+    public int X = s_def;
+    public int Y;
+}
+
+[GenerateDeserialize(ForType = typeof(Target))]
+partial struct TargetProxy { }
+""";
+            return VerifyDeserialize(src);
+        }
+
+        private static Task VerifyDeserialize(
+            string src,
+            [CallerMemberName] string caller = "")
+            => VerifyGeneratedCode(src,
+                nameof(FieldInitializerTests),
+                caller,
+                multiFile: false);
+    }
+}

--- a/test/Serde.Generation.Test/test_output/AllInOneTest.GeneratorTest/Serde.Test.AllInOne.IDeserialize.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/AllInOneTest.GeneratorTest/Serde.Test.AllInOne.IDeserialize.g.verified.cs
@@ -27,17 +27,17 @@ partial record AllInOne
             int _l_intfield = default!;
             long _l_longfield = default!;
             System.Int128 _l_int128field = default!;
-            string _l_stringfield = default!;
+            string _l_stringfield = "StringValue";
             System.DateTimeOffset _l_datetimeoffsetfield = default!;
             System.DateTime _l_datetimefield = default!;
             System.DateOnly _l_dateonlyfield = default!;
             System.TimeOnly _l_timeonlyfield = default!;
             System.Guid _l_guidfield = default!;
             string _l_escapedstringfield = default!;
-            string? _l_nullstringfield = default!;
-            uint[] _l_uintarr = default!;
-            int[][] _l_nestedarr = default!;
-            byte[] _l_bytearr = default!;
+            string? _l_nullstringfield = null;
+            uint[] _l_uintarr = null!;
+            int[][] _l_nestedarr = null!;
+            byte[] _l_bytearr = null!;
             System.Collections.Immutable.ImmutableArray<int> _l_intimm = default!;
             Serde.Test.AllInOne.ColorEnum _l_color = default!;
 

--- a/test/Serde.Generation.Test/test_output/FieldInitializerTests/FieldInitializerEnum#C.IDeserialize.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/FieldInitializerTests/FieldInitializerEnum#C.IDeserialize.g.verified.cs
@@ -1,18 +1,18 @@
-﻿//HintName: Container.IDeserialize.g.cs
+﻿//HintName: C.IDeserialize.g.cs
 
 #nullable enable
 
 using System;
 using Serde;
-partial record Container
+partial class C
 {
-    sealed partial class _DeObj : Serde.IDeserialize<Container>
+    sealed partial class _DeObj : Serde.IDeserialize<C>
     {
-        global::Serde.ISerdeInfo global::Serde.ISerdeInfoProvider.SerdeInfo => Container.s_serdeInfo;
+        global::Serde.ISerdeInfo global::Serde.ISerdeInfoProvider.SerdeInfo => C.s_serdeInfo;
 
-        Container Serde.IDeserialize<Container>.Deserialize(IDeserializer deserializer)
+        C Serde.IDeserialize<C>.Deserialize(IDeserializer deserializer)
         {
-            Original? _l_sdkdir = null;
+            Color _l_color = Color.Green;
 
             byte _r_assignedValid = 0;
 
@@ -30,7 +30,7 @@ partial record Container
                 {
                     case 0:
                         Serde.DeserializeException.ThrowIfDuplicate(_r_assignedValid, 0, _l_serdeInfo);
-                        _l_sdkdir = typeDeserialize.ReadBoxedValue<Original?, Serde.NullableProxy.De<Original, Proxy>>(_l_serdeInfo, _l_index_);
+                        _l_color = typeDeserialize.ReadBoxedValue<Color, ColorProxy>(_l_serdeInfo, _l_index_);
                         _r_assignedValid |= ((byte)1) << 0;
                         break;
                     case Serde.ITypeDeserializer.IndexNotFound:
@@ -40,12 +40,12 @@ partial record Container
                         throw new InvalidOperationException("Unexpected index: " + _l_index_);
                 }
             }
-            if ((_r_assignedValid & 0b0) != 0b0)
+            if ((_r_assignedValid & 0b1) != 0b1)
             {
                 throw Serde.DeserializeException.UnassignedMember();
             }
-            var newType = new Container() {
-                SdkDir = _l_sdkdir,
+            var newType = new C() {
+                Color = _l_color,
             };
 
             return newType;

--- a/test/Serde.Generation.Test/test_output/FieldInitializerTests/FieldInitializerEnum#C.IDeserializeProvider.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/FieldInitializerTests/FieldInitializerEnum#C.IDeserializeProvider.g.verified.cs
@@ -1,0 +1,6 @@
+﻿//HintName: C.IDeserializeProvider.g.cs
+partial class C : Serde.IDeserializeProvider<C>
+{
+    static global::Serde.IDeserialize<C> global::Serde.IDeserializeProvider<C>.Instance { get; }
+        = new C._DeObj();
+}

--- a/test/Serde.Generation.Test/test_output/FieldInitializerTests/FieldInitializerEnum#C.ISerdeInfoProvider.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/FieldInitializerTests/FieldInitializerEnum#C.ISerdeInfoProvider.g.verified.cs
@@ -1,0 +1,13 @@
+﻿//HintName: C.ISerdeInfoProvider.g.cs
+
+#nullable enable
+partial class C
+{
+    private static global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
+        "C",
+    typeof(C).GetCustomAttributesData(),
+    new (string, global::Serde.ISerdeInfo, System.Reflection.MemberInfo?)[] {
+        ("color", global::Serde.SerdeInfoProvider.GetDeserializeInfo<Color, ColorProxy>(), typeof(C).GetField("Color"))
+    }
+    );
+}

--- a/test/Serde.Generation.Test/test_output/FieldInitializerTests/FieldInitializerEnum#ColorProxy.IDeserialize.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/FieldInitializerTests/FieldInitializerEnum#ColorProxy.IDeserialize.g.verified.cs
@@ -1,0 +1,30 @@
+﻿//HintName: ColorProxy.IDeserialize.g.cs
+
+#nullable enable
+
+using System;
+using Serde;
+partial class ColorProxy : Serde.IDeserialize<Color>
+{
+    Color IDeserialize<Color>.Deserialize(IDeserializer deserializer)
+    {
+        var serdeInfo = global::Serde.SerdeInfoProvider.GetInfo(this);
+        using var de = deserializer.ReadType(serdeInfo);
+        var (index, errorName) = de.TryReadIndexWithName(serdeInfo);
+        if (index == ITypeDeserializer.IndexNotFound)
+        {
+            throw Serde.DeserializeException.UnknownMember(errorName!, serdeInfo);
+        }
+        if (index == ITypeDeserializer.EndOfType)
+        {
+            // Assume we want to read the underlying value
+            return (Color)de.ReadI32(serdeInfo, index);
+        }
+        return index switch {
+            0 => Color.Red,
+            1 => Color.Green,
+            2 => Color.Blue,
+            _ => throw new InvalidOperationException($"Unexpected index: {index}")
+        };
+    }
+}

--- a/test/Serde.Generation.Test/test_output/FieldInitializerTests/FieldInitializerEnum#ColorProxy.IDeserializeProvider.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/FieldInitializerTests/FieldInitializerEnum#ColorProxy.IDeserializeProvider.g.verified.cs
@@ -1,0 +1,6 @@
+﻿//HintName: ColorProxy.IDeserializeProvider.g.cs
+partial class ColorProxy : Serde.IDeserializeProvider<Color>
+{
+    static global::Serde.IDeserialize<Color> global::Serde.IDeserializeProvider<Color>.Instance { get; }
+        = new ColorProxy();
+}

--- a/test/Serde.Generation.Test/test_output/FieldInitializerTests/FieldInitializerEnum#ColorProxy.ISerdeInfoProvider.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/FieldInitializerTests/FieldInitializerEnum#ColorProxy.ISerdeInfoProvider.g.verified.cs
@@ -1,0 +1,16 @@
+﻿//HintName: ColorProxy.ISerdeInfoProvider.g.cs
+
+#nullable enable
+partial class ColorProxy : global::Serde.ISerdeInfoProvider
+{
+    global::Serde.ISerdeInfo global::Serde.ISerdeInfoProvider.SerdeInfo { get; } = Serde.SerdeInfo.MakeEnum(
+        "Color",
+    typeof(Color).GetCustomAttributesData(),
+    global::Serde.SerdeInfoProvider.GetDeserializeInfo<int, global::Serde.I32Proxy>(),
+    new (string, System.Reflection.MemberInfo?)[] {
+        ("red", typeof(Color).GetField("Red")),
+        ("green", typeof(Color).GetField("Green")),
+        ("blue", typeof(Color).GetField("Blue"))
+    }
+    );
+}

--- a/test/Serde.Generation.Test/test_output/FieldInitializerTests/FieldInitializerEnum#ColorProxy.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/FieldInitializerTests/FieldInitializerEnum#ColorProxy.g.verified.cs
@@ -1,0 +1,2 @@
+﻿//HintName: ColorProxy.g.cs
+sealed partial class ColorProxy;

--- a/test/Serde.Generation.Test/test_output/FieldInitializerTests/FieldInitializerEnumCast#Mine.C.IDeserialize.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/FieldInitializerTests/FieldInitializerEnumCast#Mine.C.IDeserialize.g.verified.cs
@@ -1,18 +1,22 @@
-﻿//HintName: Container.IDeserialize.g.cs
+﻿//HintName: Mine.C.IDeserialize.g.cs
 
 #nullable enable
 
 using System;
 using Serde;
-partial record Container
-{
-    sealed partial class _DeObj : Serde.IDeserialize<Container>
-    {
-        global::Serde.ISerdeInfo global::Serde.ISerdeInfoProvider.SerdeInfo => Container.s_serdeInfo;
 
-        Container Serde.IDeserialize<Container>.Deserialize(IDeserializer deserializer)
+namespace Mine;
+
+partial class C
+{
+    sealed partial class _DeObj : Serde.IDeserialize<Mine.C>
+    {
+        global::Serde.ISerdeInfo global::Serde.ISerdeInfoProvider.SerdeInfo => Mine.C.s_serdeInfo;
+
+        Mine.C Serde.IDeserialize<Mine.C>.Deserialize(IDeserializer deserializer)
         {
-            Original? _l_sdkdir = null;
+            Other.Color _l_field = (Other.Color)0;
+            int _l_y = default!;
 
             byte _r_assignedValid = 0;
 
@@ -30,8 +34,13 @@ partial record Container
                 {
                     case 0:
                         Serde.DeserializeException.ThrowIfDuplicate(_r_assignedValid, 0, _l_serdeInfo);
-                        _l_sdkdir = typeDeserialize.ReadBoxedValue<Original?, Serde.NullableProxy.De<Original, Proxy>>(_l_serdeInfo, _l_index_);
+                        _l_field = typeDeserialize.ReadBoxedValue<Other.Color, Other.ColorProxy>(_l_serdeInfo, _l_index_);
                         _r_assignedValid |= ((byte)1) << 0;
+                        break;
+                    case 1:
+                        Serde.DeserializeException.ThrowIfDuplicate(_r_assignedValid, 1, _l_serdeInfo);
+                        _l_y = typeDeserialize.ReadI32(_l_serdeInfo, _l_index_);
+                        _r_assignedValid |= ((byte)1) << 1;
                         break;
                     case Serde.ITypeDeserializer.IndexNotFound:
                         typeDeserialize.SkipValue(_l_serdeInfo, _l_index_);
@@ -40,12 +49,13 @@ partial record Container
                         throw new InvalidOperationException("Unexpected index: " + _l_index_);
                 }
             }
-            if ((_r_assignedValid & 0b0) != 0b0)
+            if ((_r_assignedValid & 0b11) != 0b11)
             {
                 throw Serde.DeserializeException.UnassignedMember();
             }
-            var newType = new Container() {
-                SdkDir = _l_sdkdir,
+            var newType = new Mine.C() {
+                Field = _l_field,
+                Y = _l_y,
             };
 
             return newType;

--- a/test/Serde.Generation.Test/test_output/FieldInitializerTests/FieldInitializerEnumCast#Mine.C.IDeserializeProvider.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/FieldInitializerTests/FieldInitializerEnumCast#Mine.C.IDeserializeProvider.g.verified.cs
@@ -1,0 +1,9 @@
+﻿//HintName: Mine.C.IDeserializeProvider.g.cs
+
+namespace Mine;
+
+partial class C : Serde.IDeserializeProvider<Mine.C>
+{
+    static global::Serde.IDeserialize<Mine.C> global::Serde.IDeserializeProvider<Mine.C>.Instance { get; }
+        = new Mine.C._DeObj();
+}

--- a/test/Serde.Generation.Test/test_output/FieldInitializerTests/FieldInitializerEnumCast#Mine.C.ISerdeInfoProvider.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/FieldInitializerTests/FieldInitializerEnumCast#Mine.C.ISerdeInfoProvider.g.verified.cs
@@ -1,0 +1,17 @@
+﻿//HintName: Mine.C.ISerdeInfoProvider.g.cs
+
+#nullable enable
+
+namespace Mine;
+
+partial class C
+{
+    private static global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
+        "C",
+    typeof(Mine.C).GetCustomAttributesData(),
+    new (string, global::Serde.ISerdeInfo, System.Reflection.MemberInfo?)[] {
+        ("field", global::Serde.SerdeInfoProvider.GetDeserializeInfo<Other.Color, Other.ColorProxy>(), typeof(Mine.C).GetField("Field")),
+        ("y", global::Serde.SerdeInfoProvider.GetDeserializeInfo<int, global::Serde.I32Proxy>(), typeof(Mine.C).GetField("Y"))
+    }
+    );
+}

--- a/test/Serde.Generation.Test/test_output/FieldInitializerTests/FieldInitializerEnumCast#Other.ColorProxy.IDeserialize.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/FieldInitializerTests/FieldInitializerEnumCast#Other.ColorProxy.IDeserialize.g.verified.cs
@@ -1,0 +1,32 @@
+﻿//HintName: Other.ColorProxy.IDeserialize.g.cs
+
+#nullable enable
+
+using System;
+using Serde;
+
+namespace Other;
+
+partial class ColorProxy : Serde.IDeserialize<Other.Color>
+{
+    Other.Color IDeserialize<Other.Color>.Deserialize(IDeserializer deserializer)
+    {
+        var serdeInfo = global::Serde.SerdeInfoProvider.GetInfo(this);
+        using var de = deserializer.ReadType(serdeInfo);
+        var (index, errorName) = de.TryReadIndexWithName(serdeInfo);
+        if (index == ITypeDeserializer.IndexNotFound)
+        {
+            throw Serde.DeserializeException.UnknownMember(errorName!, serdeInfo);
+        }
+        if (index == ITypeDeserializer.EndOfType)
+        {
+            // Assume we want to read the underlying value
+            return (Other.Color)de.ReadI32(serdeInfo, index);
+        }
+        return index switch {
+            0 => Other.Color.Red,
+            1 => Other.Color.Green,
+            _ => throw new InvalidOperationException($"Unexpected index: {index}")
+        };
+    }
+}

--- a/test/Serde.Generation.Test/test_output/FieldInitializerTests/FieldInitializerEnumCast#Other.ColorProxy.IDeserializeProvider.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/FieldInitializerTests/FieldInitializerEnumCast#Other.ColorProxy.IDeserializeProvider.g.verified.cs
@@ -1,0 +1,9 @@
+﻿//HintName: Other.ColorProxy.IDeserializeProvider.g.cs
+
+namespace Other;
+
+partial class ColorProxy : Serde.IDeserializeProvider<Other.Color>
+{
+    static global::Serde.IDeserialize<Other.Color> global::Serde.IDeserializeProvider<Other.Color>.Instance { get; }
+        = new Other.ColorProxy();
+}

--- a/test/Serde.Generation.Test/test_output/FieldInitializerTests/FieldInitializerEnumCast#Other.ColorProxy.ISerdeInfoProvider.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/FieldInitializerTests/FieldInitializerEnumCast#Other.ColorProxy.ISerdeInfoProvider.g.verified.cs
@@ -1,0 +1,18 @@
+﻿//HintName: Other.ColorProxy.ISerdeInfoProvider.g.cs
+
+#nullable enable
+
+namespace Other;
+
+partial class ColorProxy : global::Serde.ISerdeInfoProvider
+{
+    global::Serde.ISerdeInfo global::Serde.ISerdeInfoProvider.SerdeInfo { get; } = Serde.SerdeInfo.MakeEnum(
+        "Color",
+    typeof(Other.Color).GetCustomAttributesData(),
+    global::Serde.SerdeInfoProvider.GetDeserializeInfo<int, global::Serde.I32Proxy>(),
+    new (string, System.Reflection.MemberInfo?)[] {
+        ("red", typeof(Other.Color).GetField("Red")),
+        ("green", typeof(Other.Color).GetField("Green"))
+    }
+    );
+}

--- a/test/Serde.Generation.Test/test_output/FieldInitializerTests/FieldInitializerEnumCast#Other.ColorProxy.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/FieldInitializerTests/FieldInitializerEnumCast#Other.ColorProxy.g.verified.cs
@@ -1,0 +1,5 @@
+﻿//HintName: Other.ColorProxy.g.cs
+
+namespace Other;
+
+sealed partial class ColorProxy;

--- a/test/Serde.Generation.Test/test_output/FieldInitializerTests/FieldInitializerForeignTypeProxy#TargetProxy.IDeserialize.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/FieldInitializerTests/FieldInitializerForeignTypeProxy#TargetProxy.IDeserialize.g.verified.cs
@@ -1,18 +1,19 @@
-﻿//HintName: Container.IDeserialize.g.cs
+﻿//HintName: TargetProxy.IDeserialize.g.cs
 
 #nullable enable
 
 using System;
 using Serde;
-partial record Container
+partial struct TargetProxy
 {
-    sealed partial class _DeObj : Serde.IDeserialize<Container>
+    sealed partial class _DeObj : Serde.IDeserialize<Target>
     {
-        global::Serde.ISerdeInfo global::Serde.ISerdeInfoProvider.SerdeInfo => Container.s_serdeInfo;
+        global::Serde.ISerdeInfo global::Serde.ISerdeInfoProvider.SerdeInfo => TargetProxy.s_serdeInfo;
 
-        Container Serde.IDeserialize<Container>.Deserialize(IDeserializer deserializer)
+        Target Serde.IDeserialize<Target>.Deserialize(IDeserializer deserializer)
         {
-            Original? _l_sdkdir = null;
+            int _l_x = default!;
+            int _l_y = default!;
 
             byte _r_assignedValid = 0;
 
@@ -30,8 +31,13 @@ partial record Container
                 {
                     case 0:
                         Serde.DeserializeException.ThrowIfDuplicate(_r_assignedValid, 0, _l_serdeInfo);
-                        _l_sdkdir = typeDeserialize.ReadBoxedValue<Original?, Serde.NullableProxy.De<Original, Proxy>>(_l_serdeInfo, _l_index_);
+                        _l_x = typeDeserialize.ReadI32(_l_serdeInfo, _l_index_);
                         _r_assignedValid |= ((byte)1) << 0;
+                        break;
+                    case 1:
+                        Serde.DeserializeException.ThrowIfDuplicate(_r_assignedValid, 1, _l_serdeInfo);
+                        _l_y = typeDeserialize.ReadI32(_l_serdeInfo, _l_index_);
+                        _r_assignedValid |= ((byte)1) << 1;
                         break;
                     case Serde.ITypeDeserializer.IndexNotFound:
                         typeDeserialize.SkipValue(_l_serdeInfo, _l_index_);
@@ -40,12 +46,13 @@ partial record Container
                         throw new InvalidOperationException("Unexpected index: " + _l_index_);
                 }
             }
-            if ((_r_assignedValid & 0b0) != 0b0)
+            if ((_r_assignedValid & 0b11) != 0b11)
             {
                 throw Serde.DeserializeException.UnassignedMember();
             }
-            var newType = new Container() {
-                SdkDir = _l_sdkdir,
+            var newType = new Target() {
+                X = _l_x,
+                Y = _l_y,
             };
 
             return newType;

--- a/test/Serde.Generation.Test/test_output/FieldInitializerTests/FieldInitializerForeignTypeProxy#TargetProxy.IDeserializeProvider.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/FieldInitializerTests/FieldInitializerForeignTypeProxy#TargetProxy.IDeserializeProvider.g.verified.cs
@@ -1,0 +1,6 @@
+﻿//HintName: TargetProxy.IDeserializeProvider.g.cs
+partial struct TargetProxy : Serde.IDeserializeProvider<Target>
+{
+    static global::Serde.IDeserialize<Target> global::Serde.IDeserializeProvider<Target>.Instance { get; }
+        = new TargetProxy._DeObj();
+}

--- a/test/Serde.Generation.Test/test_output/FieldInitializerTests/FieldInitializerForeignTypeProxy#TargetProxy.ISerdeInfoProvider.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/FieldInitializerTests/FieldInitializerForeignTypeProxy#TargetProxy.ISerdeInfoProvider.g.verified.cs
@@ -1,0 +1,14 @@
+﻿//HintName: TargetProxy.ISerdeInfoProvider.g.cs
+
+#nullable enable
+partial struct TargetProxy
+{
+    private static global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
+        "Target",
+    typeof(Target).GetCustomAttributesData(),
+    new (string, global::Serde.ISerdeInfo, System.Reflection.MemberInfo?)[] {
+        ("x", global::Serde.SerdeInfoProvider.GetDeserializeInfo<int, global::Serde.I32Proxy>(), typeof(Target).GetField("X")),
+        ("y", global::Serde.SerdeInfoProvider.GetDeserializeInfo<int, global::Serde.I32Proxy>(), typeof(Target).GetField("Y"))
+    }
+    );
+}

--- a/test/Serde.Generation.Test/test_output/FieldInitializerTests/FieldInitializerNullForgiving#C.IDeserialize.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/FieldInitializerTests/FieldInitializerNullForgiving#C.IDeserialize.g.verified.cs
@@ -1,27 +1,20 @@
-﻿//HintName: ArgumentInfo.ISerde.g.cs
+﻿//HintName: C.IDeserialize.g.cs
 
 #nullable enable
 
 using System;
 using Serde;
-partial class ArgumentInfo
+partial class C
 {
-    sealed partial class _SerdeObj : global::Serde.ISerde<ArgumentInfo>
+    sealed partial class _DeObj : Serde.IDeserialize<C>
     {
-        global::Serde.ISerdeInfo global::Serde.ISerdeInfoProvider.SerdeInfo => ArgumentInfo.s_serdeInfo;
+        global::Serde.ISerdeInfo global::Serde.ISerdeInfoProvider.SerdeInfo => C.s_serdeInfo;
 
-        void global::Serde.ISerialize<ArgumentInfo>.Serialize(ArgumentInfo value, global::Serde.ISerializer serializer)
+        C Serde.IDeserialize<C>.Deserialize(IDeserializer deserializer)
         {
-            var _l_info = global::Serde.SerdeInfoProvider.GetInfo(this);
-            var _l_type = serializer.WriteType(_l_info);
-            _l_type.WriteString(_l_info, 0, value.Name);
-            _l_type.WriteString(_l_info, 1, value.Value);
-            _l_type.End(_l_info);
-        }
-        ArgumentInfo Serde.IDeserialize<ArgumentInfo>.Deserialize(IDeserializer deserializer)
-        {
-            string _l_name = string.Empty;
-            string _l_value = string.Empty;
+            string _l_s = null!;
+            int[] _l_arr = null!;
+            string? _l_n = null;
 
             byte _r_assignedValid = 0;
 
@@ -39,13 +32,18 @@ partial class ArgumentInfo
                 {
                     case 0:
                         Serde.DeserializeException.ThrowIfDuplicate(_r_assignedValid, 0, _l_serdeInfo);
-                        _l_name = typeDeserialize.ReadString(_l_serdeInfo, _l_index_);
+                        _l_s = typeDeserialize.ReadString(_l_serdeInfo, _l_index_);
                         _r_assignedValid |= ((byte)1) << 0;
                         break;
                     case 1:
                         Serde.DeserializeException.ThrowIfDuplicate(_r_assignedValid, 1, _l_serdeInfo);
-                        _l_value = typeDeserialize.ReadString(_l_serdeInfo, _l_index_);
+                        _l_arr = typeDeserialize.ReadValue<int[], Serde.ArrayProxy.De<int, global::Serde.I32Proxy>>(_l_serdeInfo, _l_index_);
                         _r_assignedValid |= ((byte)1) << 1;
+                        break;
+                    case 2:
+                        Serde.DeserializeException.ThrowIfDuplicate(_r_assignedValid, 2, _l_serdeInfo);
+                        _l_n = typeDeserialize.ReadValue<string?, Serde.NullableRefProxy.De<string, global::Serde.StringProxy>>(_l_serdeInfo, _l_index_);
+                        _r_assignedValid |= ((byte)1) << 2;
                         break;
                     case Serde.ITypeDeserializer.IndexNotFound:
                         typeDeserialize.SkipValue(_l_serdeInfo, _l_index_);
@@ -58,9 +56,10 @@ partial class ArgumentInfo
             {
                 throw Serde.DeserializeException.UnassignedMember();
             }
-            var newType = new ArgumentInfo() {
-                Name = _l_name,
-                Value = _l_value,
+            var newType = new C() {
+                S = _l_s,
+                Arr = _l_arr,
+                N = _l_n,
             };
 
             return newType;

--- a/test/Serde.Generation.Test/test_output/FieldInitializerTests/FieldInitializerNullForgiving#C.IDeserializeProvider.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/FieldInitializerTests/FieldInitializerNullForgiving#C.IDeserializeProvider.g.verified.cs
@@ -1,0 +1,6 @@
+﻿//HintName: C.IDeserializeProvider.g.cs
+partial class C : Serde.IDeserializeProvider<C>
+{
+    static global::Serde.IDeserialize<C> global::Serde.IDeserializeProvider<C>.Instance { get; }
+        = new C._DeObj();
+}

--- a/test/Serde.Generation.Test/test_output/FieldInitializerTests/FieldInitializerNullForgiving#C.ISerdeInfoProvider.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/FieldInitializerTests/FieldInitializerNullForgiving#C.ISerdeInfoProvider.g.verified.cs
@@ -1,0 +1,15 @@
+﻿//HintName: C.ISerdeInfoProvider.g.cs
+
+#nullable enable
+partial class C
+{
+    private static global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
+        "C",
+    typeof(C).GetCustomAttributesData(),
+    new (string, global::Serde.ISerdeInfo, System.Reflection.MemberInfo?)[] {
+        ("s", global::Serde.SerdeInfoProvider.GetDeserializeInfo<string, global::Serde.StringProxy>(), typeof(C).GetField("S")),
+        ("arr", global::Serde.SerdeInfoProvider.GetDeserializeInfo<int[], Serde.ArrayProxy.De<int, global::Serde.I32Proxy>>(), typeof(C).GetField("Arr")),
+        ("n", global::Serde.SerdeInfoProvider.GetDeserializeInfo<string?, Serde.NullableRefProxy.De<string, global::Serde.StringProxy>>(), typeof(C).GetField("N"))
+    }
+    );
+}

--- a/test/Serde.Generation.Test/test_output/FieldInitializerTests/FieldInitializerPrimaryCtorParam#C.IDeserialize.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/FieldInitializerTests/FieldInitializerPrimaryCtorParam#C.IDeserialize.g.verified.cs
@@ -1,18 +1,20 @@
-﻿//HintName: Container.IDeserialize.g.cs
+﻿//HintName: C.IDeserialize.g.cs
 
 #nullable enable
 
 using System;
 using Serde;
-partial record Container
+partial record C
 {
-    sealed partial class _DeObj : Serde.IDeserialize<Container>
+    sealed partial class _DeObj : Serde.IDeserialize<C>
     {
-        global::Serde.ISerdeInfo global::Serde.ISerdeInfoProvider.SerdeInfo => Container.s_serdeInfo;
+        global::Serde.ISerdeInfo global::Serde.ISerdeInfoProvider.SerdeInfo => C.s_serdeInfo;
 
-        Container Serde.IDeserialize<Container>.Deserialize(IDeserializer deserializer)
+        C Serde.IDeserialize<C>.Deserialize(IDeserializer deserializer)
         {
-            Original? _l_sdkdir = null;
+            int _l_x = default!;
+            int _l_extra = default!;
+            int _l_z = 100;
 
             byte _r_assignedValid = 0;
 
@@ -30,8 +32,18 @@ partial record Container
                 {
                     case 0:
                         Serde.DeserializeException.ThrowIfDuplicate(_r_assignedValid, 0, _l_serdeInfo);
-                        _l_sdkdir = typeDeserialize.ReadBoxedValue<Original?, Serde.NullableProxy.De<Original, Proxy>>(_l_serdeInfo, _l_index_);
+                        _l_x = typeDeserialize.ReadI32(_l_serdeInfo, _l_index_);
                         _r_assignedValid |= ((byte)1) << 0;
+                        break;
+                    case 1:
+                        Serde.DeserializeException.ThrowIfDuplicate(_r_assignedValid, 1, _l_serdeInfo);
+                        _l_extra = typeDeserialize.ReadI32(_l_serdeInfo, _l_index_);
+                        _r_assignedValid |= ((byte)1) << 1;
+                        break;
+                    case 2:
+                        Serde.DeserializeException.ThrowIfDuplicate(_r_assignedValid, 2, _l_serdeInfo);
+                        _l_z = typeDeserialize.ReadI32(_l_serdeInfo, _l_index_);
+                        _r_assignedValid |= ((byte)1) << 2;
                         break;
                     case Serde.ITypeDeserializer.IndexNotFound:
                         typeDeserialize.SkipValue(_l_serdeInfo, _l_index_);
@@ -40,12 +52,13 @@ partial record Container
                         throw new InvalidOperationException("Unexpected index: " + _l_index_);
                 }
             }
-            if ((_r_assignedValid & 0b0) != 0b0)
+            if ((_r_assignedValid & 0b111) != 0b111)
             {
                 throw Serde.DeserializeException.UnassignedMember();
             }
-            var newType = new Container() {
-                SdkDir = _l_sdkdir,
+            var newType = new C(_l_x) {
+                Extra = _l_extra,
+                Z = _l_z,
             };
 
             return newType;

--- a/test/Serde.Generation.Test/test_output/FieldInitializerTests/FieldInitializerPrimaryCtorParam#C.IDeserializeProvider.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/FieldInitializerTests/FieldInitializerPrimaryCtorParam#C.IDeserializeProvider.g.verified.cs
@@ -1,0 +1,6 @@
+﻿//HintName: C.IDeserializeProvider.g.cs
+partial record C : Serde.IDeserializeProvider<C>
+{
+    static global::Serde.IDeserialize<C> global::Serde.IDeserializeProvider<C>.Instance { get; }
+        = new C._DeObj();
+}

--- a/test/Serde.Generation.Test/test_output/FieldInitializerTests/FieldInitializerPrimaryCtorParam#C.ISerdeInfoProvider.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/FieldInitializerTests/FieldInitializerPrimaryCtorParam#C.ISerdeInfoProvider.g.verified.cs
@@ -1,0 +1,15 @@
+﻿//HintName: C.ISerdeInfoProvider.g.cs
+
+#nullable enable
+partial record C
+{
+    private static global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
+        "C",
+    typeof(C).GetCustomAttributesData(),
+    new (string, global::Serde.ISerdeInfo, System.Reflection.MemberInfo?)[] {
+        ("x", global::Serde.SerdeInfoProvider.GetDeserializeInfo<int, global::Serde.I32Proxy>(), typeof(C).GetProperty("X")),
+        ("extra", global::Serde.SerdeInfoProvider.GetDeserializeInfo<int, global::Serde.I32Proxy>(), typeof(C).GetField("Extra")),
+        ("z", global::Serde.SerdeInfoProvider.GetDeserializeInfo<int, global::Serde.I32Proxy>(), typeof(C).GetField("Z"))
+    }
+    );
+}

--- a/test/Serde.Generation.Test/test_output/FieldInitializerTests/FieldInitializerUnsafe#C.IDeserialize.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/FieldInitializerTests/FieldInitializerUnsafe#C.IDeserialize.g.verified.cs
@@ -1,27 +1,20 @@
-﻿//HintName: ArgumentInfo.ISerde.g.cs
+﻿//HintName: C.IDeserialize.g.cs
 
 #nullable enable
 
 using System;
 using Serde;
-partial class ArgumentInfo
+partial class C
 {
-    sealed partial class _SerdeObj : global::Serde.ISerde<ArgumentInfo>
+    sealed partial class _DeObj : Serde.IDeserialize<C>
     {
-        global::Serde.ISerdeInfo global::Serde.ISerdeInfoProvider.SerdeInfo => ArgumentInfo.s_serdeInfo;
+        global::Serde.ISerdeInfo global::Serde.ISerdeInfoProvider.SerdeInfo => C.s_serdeInfo;
 
-        void global::Serde.ISerialize<ArgumentInfo>.Serialize(ArgumentInfo value, global::Serde.ISerializer serializer)
+        C Serde.IDeserialize<C>.Deserialize(IDeserializer deserializer)
         {
-            var _l_info = global::Serde.SerdeInfoProvider.GetInfo(this);
-            var _l_type = serializer.WriteType(_l_info);
-            _l_type.WriteString(_l_info, 0, value.Name);
-            _l_type.WriteString(_l_info, 1, value.Value);
-            _l_type.End(_l_info);
-        }
-        ArgumentInfo Serde.IDeserialize<ArgumentInfo>.Deserialize(IDeserializer deserializer)
-        {
-            string _l_name = string.Empty;
-            string _l_value = string.Empty;
+            System.Collections.Generic.List<int> _l_items = default!;
+            int[] _l_arr = default!;
+            string _l_name = default!;
 
             byte _r_assignedValid = 0;
 
@@ -39,13 +32,18 @@ partial class ArgumentInfo
                 {
                     case 0:
                         Serde.DeserializeException.ThrowIfDuplicate(_r_assignedValid, 0, _l_serdeInfo);
-                        _l_name = typeDeserialize.ReadString(_l_serdeInfo, _l_index_);
+                        _l_items = typeDeserialize.ReadValue<System.Collections.Generic.List<int>, Serde.ListProxy.De<int, global::Serde.I32Proxy>>(_l_serdeInfo, _l_index_);
                         _r_assignedValid |= ((byte)1) << 0;
                         break;
                     case 1:
                         Serde.DeserializeException.ThrowIfDuplicate(_r_assignedValid, 1, _l_serdeInfo);
-                        _l_value = typeDeserialize.ReadString(_l_serdeInfo, _l_index_);
+                        _l_arr = typeDeserialize.ReadValue<int[], Serde.ArrayProxy.De<int, global::Serde.I32Proxy>>(_l_serdeInfo, _l_index_);
                         _r_assignedValid |= ((byte)1) << 1;
+                        break;
+                    case 2:
+                        Serde.DeserializeException.ThrowIfDuplicate(_r_assignedValid, 2, _l_serdeInfo);
+                        _l_name = typeDeserialize.ReadString(_l_serdeInfo, _l_index_);
+                        _r_assignedValid |= ((byte)1) << 2;
                         break;
                     case Serde.ITypeDeserializer.IndexNotFound:
                         typeDeserialize.SkipValue(_l_serdeInfo, _l_index_);
@@ -54,13 +52,14 @@ partial class ArgumentInfo
                         throw new InvalidOperationException("Unexpected index: " + _l_index_);
                 }
             }
-            if ((_r_assignedValid & 0b11) != 0b11)
+            if ((_r_assignedValid & 0b111) != 0b111)
             {
                 throw Serde.DeserializeException.UnassignedMember();
             }
-            var newType = new ArgumentInfo() {
+            var newType = new C() {
+                Items = _l_items,
+                Arr = _l_arr,
                 Name = _l_name,
-                Value = _l_value,
             };
 
             return newType;

--- a/test/Serde.Generation.Test/test_output/FieldInitializerTests/FieldInitializerUnsafe#C.IDeserializeProvider.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/FieldInitializerTests/FieldInitializerUnsafe#C.IDeserializeProvider.g.verified.cs
@@ -1,0 +1,6 @@
+﻿//HintName: C.IDeserializeProvider.g.cs
+partial class C : Serde.IDeserializeProvider<C>
+{
+    static global::Serde.IDeserialize<C> global::Serde.IDeserializeProvider<C>.Instance { get; }
+        = new C._DeObj();
+}

--- a/test/Serde.Generation.Test/test_output/FieldInitializerTests/FieldInitializerUnsafe#C.ISerdeInfoProvider.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/FieldInitializerTests/FieldInitializerUnsafe#C.ISerdeInfoProvider.g.verified.cs
@@ -1,0 +1,15 @@
+﻿//HintName: C.ISerdeInfoProvider.g.cs
+
+#nullable enable
+partial class C
+{
+    private static global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
+        "C",
+    typeof(C).GetCustomAttributesData(),
+    new (string, global::Serde.ISerdeInfo, System.Reflection.MemberInfo?)[] {
+        ("items", global::Serde.SerdeInfoProvider.GetDeserializeInfo<System.Collections.Generic.List<int>, Serde.ListProxy.De<int, global::Serde.I32Proxy>>(), typeof(C).GetField("Items")),
+        ("arr", global::Serde.SerdeInfoProvider.GetDeserializeInfo<int[], Serde.ArrayProxy.De<int, global::Serde.I32Proxy>>(), typeof(C).GetField("Arr")),
+        ("name", global::Serde.SerdeInfoProvider.GetDeserializeInfo<string, global::Serde.StringProxy>(), typeof(C).GetField("Name"))
+    }
+    );
+}

--- a/test/Serde.Generation.Test/test_output/FieldInitializerTests/FieldInitializers#C.IDeserialize.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/FieldInitializerTests/FieldInitializers#C.IDeserialize.g.verified.cs
@@ -1,0 +1,103 @@
+﻿//HintName: C.IDeserialize.g.cs
+
+#nullable enable
+
+using System;
+using Serde;
+partial class C
+{
+    sealed partial class _DeObj : Serde.IDeserialize<C>
+    {
+        global::Serde.ISerdeInfo global::Serde.ISerdeInfoProvider.SerdeInfo => C.s_serdeInfo;
+
+        C Serde.IDeserialize<C>.Deserialize(IDeserializer deserializer)
+        {
+            string _l_str = "hello";
+            int _l_num = 42;
+            bool _l_flag = true;
+            string? _l_nullable = null;
+            double _l_dbl = 3.14;
+            char _l_ch = 'x';
+            string _l_frommethod = string.Empty;
+            int _l_maxint = int.MaxValue;
+
+            byte _r_assignedValid = 0;
+
+            var _l_serdeInfo = global::Serde.SerdeInfoProvider.GetInfo(this);
+            var typeDeserialize = deserializer.ReadType(_l_serdeInfo);
+            while (true)
+            {
+                var (_l_index_, _) = typeDeserialize.TryReadIndexWithName(_l_serdeInfo);
+                if (_l_index_ == Serde.ITypeDeserializer.EndOfType)
+                {
+                    break;
+                }
+
+                switch (_l_index_)
+                {
+                    case 0:
+                        Serde.DeserializeException.ThrowIfDuplicate(_r_assignedValid, 0, _l_serdeInfo);
+                        _l_str = typeDeserialize.ReadString(_l_serdeInfo, _l_index_);
+                        _r_assignedValid |= ((byte)1) << 0;
+                        break;
+                    case 1:
+                        Serde.DeserializeException.ThrowIfDuplicate(_r_assignedValid, 1, _l_serdeInfo);
+                        _l_num = typeDeserialize.ReadI32(_l_serdeInfo, _l_index_);
+                        _r_assignedValid |= ((byte)1) << 1;
+                        break;
+                    case 2:
+                        Serde.DeserializeException.ThrowIfDuplicate(_r_assignedValid, 2, _l_serdeInfo);
+                        _l_flag = typeDeserialize.ReadBool(_l_serdeInfo, _l_index_);
+                        _r_assignedValid |= ((byte)1) << 2;
+                        break;
+                    case 3:
+                        Serde.DeserializeException.ThrowIfDuplicate(_r_assignedValid, 3, _l_serdeInfo);
+                        _l_nullable = typeDeserialize.ReadValue<string?, Serde.NullableRefProxy.De<string, global::Serde.StringProxy>>(_l_serdeInfo, _l_index_);
+                        _r_assignedValid |= ((byte)1) << 3;
+                        break;
+                    case 4:
+                        Serde.DeserializeException.ThrowIfDuplicate(_r_assignedValid, 4, _l_serdeInfo);
+                        _l_dbl = typeDeserialize.ReadF64(_l_serdeInfo, _l_index_);
+                        _r_assignedValid |= ((byte)1) << 4;
+                        break;
+                    case 5:
+                        Serde.DeserializeException.ThrowIfDuplicate(_r_assignedValid, 5, _l_serdeInfo);
+                        _l_ch = typeDeserialize.ReadChar(_l_serdeInfo, _l_index_);
+                        _r_assignedValid |= ((byte)1) << 5;
+                        break;
+                    case 6:
+                        Serde.DeserializeException.ThrowIfDuplicate(_r_assignedValid, 6, _l_serdeInfo);
+                        _l_frommethod = typeDeserialize.ReadString(_l_serdeInfo, _l_index_);
+                        _r_assignedValid |= ((byte)1) << 6;
+                        break;
+                    case 7:
+                        Serde.DeserializeException.ThrowIfDuplicate(_r_assignedValid, 7, _l_serdeInfo);
+                        _l_maxint = typeDeserialize.ReadI32(_l_serdeInfo, _l_index_);
+                        _r_assignedValid |= ((byte)1) << 7;
+                        break;
+                    case Serde.ITypeDeserializer.IndexNotFound:
+                        typeDeserialize.SkipValue(_l_serdeInfo, _l_index_);
+                        break;
+                    default:
+                        throw new InvalidOperationException("Unexpected index: " + _l_index_);
+                }
+            }
+            if ((_r_assignedValid & 0b11110111) != 0b11110111)
+            {
+                throw Serde.DeserializeException.UnassignedMember();
+            }
+            var newType = new C() {
+                Str = _l_str,
+                Num = _l_num,
+                Flag = _l_flag,
+                Nullable = _l_nullable,
+                Dbl = _l_dbl,
+                Ch = _l_ch,
+                FromMethod = _l_frommethod,
+                MaxInt = _l_maxint,
+            };
+
+            return newType;
+        }
+    }
+}

--- a/test/Serde.Generation.Test/test_output/FieldInitializerTests/FieldInitializers#C.IDeserializeProvider.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/FieldInitializerTests/FieldInitializers#C.IDeserializeProvider.g.verified.cs
@@ -1,0 +1,6 @@
+﻿//HintName: C.IDeserializeProvider.g.cs
+partial class C : Serde.IDeserializeProvider<C>
+{
+    static global::Serde.IDeserialize<C> global::Serde.IDeserializeProvider<C>.Instance { get; }
+        = new C._DeObj();
+}

--- a/test/Serde.Generation.Test/test_output/FieldInitializerTests/FieldInitializers#C.ISerdeInfoProvider.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/FieldInitializerTests/FieldInitializers#C.ISerdeInfoProvider.g.verified.cs
@@ -1,0 +1,20 @@
+﻿//HintName: C.ISerdeInfoProvider.g.cs
+
+#nullable enable
+partial class C
+{
+    private static global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
+        "C",
+    typeof(C).GetCustomAttributesData(),
+    new (string, global::Serde.ISerdeInfo, System.Reflection.MemberInfo?)[] {
+        ("str", global::Serde.SerdeInfoProvider.GetDeserializeInfo<string, global::Serde.StringProxy>(), typeof(C).GetField("Str")),
+        ("num", global::Serde.SerdeInfoProvider.GetDeserializeInfo<int, global::Serde.I32Proxy>(), typeof(C).GetField("Num")),
+        ("flag", global::Serde.SerdeInfoProvider.GetDeserializeInfo<bool, global::Serde.BoolProxy>(), typeof(C).GetField("Flag")),
+        ("nullable", global::Serde.SerdeInfoProvider.GetDeserializeInfo<string?, Serde.NullableRefProxy.De<string, global::Serde.StringProxy>>(), typeof(C).GetField("Nullable")),
+        ("dbl", global::Serde.SerdeInfoProvider.GetDeserializeInfo<double, global::Serde.F64Proxy>(), typeof(C).GetField("Dbl")),
+        ("ch", global::Serde.SerdeInfoProvider.GetDeserializeInfo<char, global::Serde.CharProxy>(), typeof(C).GetField("Ch")),
+        ("fromMethod", global::Serde.SerdeInfoProvider.GetDeserializeInfo<string, global::Serde.StringProxy>(), typeof(C).GetField("FromMethod")),
+        ("maxInt", global::Serde.SerdeInfoProvider.GetDeserializeInfo<int, global::Serde.I32Proxy>(), typeof(C).GetField("MaxInt"))
+    }
+    );
+}

--- a/test/Serde.Generation.Test/test_output/ProxyTests.ExplicitInvalidGenericWrapper/Container.IDeserialize.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/ProxyTests.ExplicitInvalidGenericWrapper/Container.IDeserialize.g.verified.cs
@@ -12,7 +12,7 @@ partial record Container
 
         Container Serde.IDeserialize<Container>.Deserialize(IDeserializer deserializer)
         {
-            Original? _l_sdkdir = default!;
+            Original? _l_sdkdir = null;
 
             byte _r_assignedValid = 0;
 

--- a/test/Serde.Generation.Test/test_output/SerdeTests.CommandResponseTest/CommandResponse.ISerde.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/SerdeTests.CommandResponseTest/CommandResponse.ISerde.g.verified.cs
@@ -24,7 +24,7 @@ partial class CommandResponse<TResult, TProxy>
         CommandResponse<TResult, TProxy> Serde.IDeserialize<CommandResponse<TResult, TProxy>>.Deserialize(IDeserializer deserializer)
         {
             int _l_status = default!;
-            string _l_message = default!;
+            string _l_message = string.Empty;
             System.Collections.Generic.List<ArgumentInfo>? _l_arguments = default!;
             TResult _l_results = default!;
             long _l_duration = default!;

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.AllInOne.IDeserialize.g.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.AllInOne.IDeserialize.g.cs
@@ -26,17 +26,17 @@ partial record AllInOne
             int _l_intfield = default!;
             long _l_longfield = default!;
             System.Int128 _l_int128field = default!;
-            string _l_stringfield = default!;
+            string _l_stringfield = "StringValue";
             System.DateTimeOffset _l_datetimeoffsetfield = default!;
             System.DateTime _l_datetimefield = default!;
             System.DateOnly _l_dateonlyfield = default!;
             System.TimeOnly _l_timeonlyfield = default!;
             System.Guid _l_guidfield = default!;
             string _l_escapedstringfield = default!;
-            string? _l_nullstringfield = default!;
-            uint[] _l_uintarr = default!;
-            int[][] _l_nestedarr = default!;
-            byte[] _l_bytearr = default!;
+            string? _l_nullstringfield = null;
+            uint[] _l_uintarr = null!;
+            int[][] _l_nestedarr = null!;
+            byte[] _l_bytearr = null!;
             System.Collections.Immutable.ImmutableArray<int> _l_intimm = default!;
             Serde.Test.AllInOne.ColorEnum _l_color = default!;
 

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonDeserializeTests.NullableFields.IDeserialize.g.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonDeserializeTests.NullableFields.IDeserialize.g.cs
@@ -16,7 +16,7 @@ partial class JsonDeserializeTests
 
             Serde.Test.JsonDeserializeTests.NullableFields Serde.IDeserialize<Serde.Test.JsonDeserializeTests.NullableFields>.Deserialize(IDeserializer deserializer)
             {
-                string? _l_s = default!;
+                string? _l_s = null;
                 System.Collections.Generic.Dictionary<string, string?> _l_dict = default!;
 
                 byte _r_assignedValid = 0;

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonDeserializeTests.ThrowMissingFalse.IDeserialize.g.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonDeserializeTests.ThrowMissingFalse.IDeserialize.g.cs
@@ -17,7 +17,7 @@ partial class JsonDeserializeTests
             Serde.Test.JsonDeserializeTests.ThrowMissingFalse Serde.IDeserialize<Serde.Test.JsonDeserializeTests.ThrowMissingFalse>.Deserialize(IDeserializer deserializer)
             {
                 string _l_present = default!;
-                bool _l_missing = default!;
+                bool _l_missing = false;
 
                 byte _r_assignedValid = 0;
 


### PR DESCRIPTION
This is another attempt to preserve default values provided in initializers. The core problem with this feature is that some initializers won't be legal when copied, but are legal in their original location. To try to cut down on potential problems here, I've narrowed the feature to only constants and static field/property accesses.