### PR TITLE
Update SerdePkgVersion from 0.12.0 to 0.13.0

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,6 +5,6 @@
     <Deterministic>true</Deterministic>
     <TestTfm>net10.0</TestTfm>
     <SerdeAssemblyVersion>0.10.1</SerdeAssemblyVersion>
-    <SerdePkgVersion>0.12.0</SerdePkgVersion>
+    <SerdePkgVersion>0.13.0</SerdePkgVersion>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Bumps the package version to 0.13.0 for the next release.

Changes since v0.12.0:
- Persist constant default values and most static accesses (#345)
- More docs fixes (#344)
- Docs: restructure guide and add self-contained deploy workflow (#343)