### PR TITLE
Add UTF8 bytes API to serialization

### DIFF
--- a/src/serde/json/JsonSerializer.cs
+++ b/src/serde/json/JsonSerializer.cs
@@ -16,7 +16,7 @@ namespace Serde.Json
         /// <summary>
         /// Serialize the given type as UTF-8 bytes and return them as a contiguous block of memory.
         /// </summary>
-        public static ReadOnlyMemory<byte> ToMemory<T>(T provider, ISerialize<T> ser)
+        public static ReadOnlyMemory<byte> ToBytes<T>(T provider, ISerialize<T> ser)
         {
             var bufferWriter = new ArrayBufferWriter<byte>();
             using var writer = new Utf8JsonWriter(bufferWriter, new JsonWriterOptions
@@ -30,13 +30,13 @@ namespace Serde.Json
             return bufferWriter.WrittenMemory;
         }
 
-        public static ReadOnlyMemory<byte> ToMemory<T, TProvider>(T s)
+        public static ReadOnlyMemory<byte> ToBytes<T, TProvider>(T s)
             where TProvider : ISerializeProvider<T>
-            => ToMemory(s, TProvider.Instance);
+            => ToBytes(s, TProvider.Instance);
 
-        public static ReadOnlyMemory<byte> ToMemory<T>(T s)
+        public static ReadOnlyMemory<byte> ToBytes<T>(T s)
             where T : ISerializeProvider<T>
-            => ToMemory(s, T.Instance);
+            => ToBytes(s, T.Instance);
 
         /// <summary>
         /// Serialize the given type to a string.

--- a/src/serde/json/JsonSerializer.cs
+++ b/src/serde/json/JsonSerializer.cs
@@ -1,5 +1,6 @@
 
 using System;
+using System.Buffers;
 using System.Buffers.Text;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -12,6 +13,31 @@ namespace Serde.Json
 
     public sealed partial class JsonSerializer : ISerializer
     {
+        /// <summary>
+        /// Serialize the given type as UTF-8 bytes and return them as a contiguous block of memory.
+        /// </summary>
+        public static ReadOnlyMemory<byte> ToMemory<T>(T provider, ISerialize<T> ser)
+        {
+            var bufferWriter = new ArrayBufferWriter<byte>();
+            using var writer = new Utf8JsonWriter(bufferWriter, new JsonWriterOptions
+            {
+                Indented = false,
+                SkipValidation = true
+            });
+            var serializer = new JsonSerializer(writer);
+            ser.Serialize(provider, serializer);
+            writer.Flush();
+            return bufferWriter.WrittenMemory;
+        }
+
+        public static ReadOnlyMemory<byte> ToMemory<T, TProvider>(T s)
+            where TProvider : ISerializeProvider<T>
+            => ToMemory(s, TProvider.Instance);
+
+        public static ReadOnlyMemory<byte> ToMemory<T>(T s)
+            where T : ISerializeProvider<T>
+            => ToMemory(s, T.Instance);
+
         /// <summary>
         /// Serialize the given type to a string.
         /// </summary>

--- a/src/serde/json/PooledByteBufferWriter.cs
+++ b/src/serde/json/PooledByteBufferWriter.cs
@@ -1,7 +1,7 @@
 
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
- 
+
 using System.Buffers;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
@@ -9,24 +9,25 @@ using System.IO;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
- 
+
 namespace System.Text.Json
 {
     internal sealed class PooledByteBufferWriter : IBufferWriter<byte>, IDisposable
     {
+        private readonly static ArrayPool<byte> s_arrayPool = ArrayPool<byte>.Create();
         private byte[] _rentedBuffer;
         private int _index;
- 
+
         private const int MinimumBufferSize = 256;
- 
+
         public PooledByteBufferWriter(int initialCapacity)
         {
             Debug.Assert(initialCapacity > 0);
- 
-            _rentedBuffer = ArrayPool<byte>.Shared.Rent(initialCapacity);
+
+            _rentedBuffer = s_arrayPool.Rent(initialCapacity);
             _index = 0;
         }
- 
+
         public ReadOnlyMemory<byte> WrittenMemory
         {
             get
@@ -36,7 +37,7 @@ namespace System.Text.Json
                 return _rentedBuffer.AsMemory(0, _index);
             }
         }
- 
+
         public int WrittenCount
         {
             get
@@ -45,7 +46,7 @@ namespace System.Text.Json
                 return _index;
             }
         }
- 
+
         public int Capacity
         {
             get
@@ -54,7 +55,7 @@ namespace System.Text.Json
                 return _rentedBuffer.Length;
             }
         }
- 
+
         public int FreeCapacity
         {
             get
@@ -63,21 +64,21 @@ namespace System.Text.Json
                 return _rentedBuffer.Length - _index;
             }
         }
- 
+
         public void Clear()
         {
             ClearHelper();
         }
- 
+
         private void ClearHelper()
         {
             Debug.Assert(_rentedBuffer != null);
             Debug.Assert(_index <= _rentedBuffer.Length);
- 
+
             _rentedBuffer.AsSpan(0, _index).Clear();
             _index = 0;
         }
- 
+
         // Returns the rented buffer back to the pool
         public void Dispose()
         {
@@ -85,33 +86,33 @@ namespace System.Text.Json
             {
                 return;
             }
- 
+
             ClearHelper();
-            ArrayPool<byte>.Shared.Return(_rentedBuffer);
+            s_arrayPool.Return(_rentedBuffer);
             _rentedBuffer = null!;
         }
- 
+
         public void Advance(int count)
         {
             Debug.Assert(_rentedBuffer != null);
             Debug.Assert(count >= 0);
             Debug.Assert(_index <= _rentedBuffer.Length - count);
- 
+
             _index += count;
         }
- 
+
         public Memory<byte> GetMemory(int sizeHint = 0)
         {
             CheckAndResizeBuffer(sizeHint);
             return _rentedBuffer.AsMemory(_index);
         }
- 
+
         public Span<byte> GetSpan(int sizeHint = 0)
         {
             CheckAndResizeBuffer(sizeHint);
             return _rentedBuffer.AsSpan(_index);
         }
- 
+
 #if BUILDING_INBOX_LIBRARY
         internal ValueTask WriteToStreamAsync(Stream destination, CancellationToken cancellationToken)
         {
@@ -123,26 +124,26 @@ namespace System.Text.Json
             return destination.WriteAsync(_rentedBuffer, 0, _index, cancellationToken);
         }
 #endif
- 
+
         private void CheckAndResizeBuffer(int sizeHint)
         {
             Debug.Assert(_rentedBuffer != null);
             Debug.Assert(sizeHint >= 0);
- 
+
             if (sizeHint == 0)
             {
                 sizeHint = MinimumBufferSize;
             }
- 
+
             int availableSpace = _rentedBuffer.Length - _index;
- 
+
             if (sizeHint > availableSpace)
             {
                 int currentLength = _rentedBuffer.Length;
                 int growBy = Math.Max(sizeHint, currentLength);
- 
+
                 int newSize = currentLength + growBy;
- 
+
                 if ((uint)newSize > int.MaxValue)
                 {
                     newSize = currentLength + sizeHint;
@@ -151,25 +152,25 @@ namespace System.Text.Json
                         ThrowHelper.ThrowOutOfMemoryException_BufferMaximumSizeExceeded((uint)newSize);
                     }
                 }
- 
+
                 byte[] oldBuffer = _rentedBuffer;
- 
-                _rentedBuffer = ArrayPool<byte>.Shared.Rent(newSize);
- 
+
+                _rentedBuffer = s_arrayPool.Rent(newSize);
+
                 Debug.Assert(oldBuffer.Length >= _index);
                 Debug.Assert(_rentedBuffer.Length >= _index);
- 
+
                 Span<byte> previousBuffer = oldBuffer.AsSpan(0, _index);
                 previousBuffer.CopyTo(_rentedBuffer);
                 previousBuffer.Clear();
-                ArrayPool<byte>.Shared.Return(oldBuffer);
+                s_arrayPool.Return(oldBuffer);
             }
- 
+
             Debug.Assert(_rentedBuffer.Length - _index > 0);
             Debug.Assert(_rentedBuffer.Length - _index >= sizeHint);
         }
     }
- 
+
     internal static partial class ThrowHelper
     {
         [DoesNotReturn]

--- a/test/Serde.Test/JsonSerializerTests.cs
+++ b/test/Serde.Test/JsonSerializerTests.cs
@@ -374,23 +374,23 @@ namespace Serde.Test
         private partial record BigData(List<int> Values);
 
         [Fact]
-        public void ToMemoryMatchesSerialize()
+        public void ToBytesMatchesSerialize()
         {
             var color = new Color { Red = 3, Green = 5, Blue = 7 };
-            var mem = Serde.Json.JsonSerializer.ToMemory(color);
+            var mem = Serde.Json.JsonSerializer.ToBytes(color);
             Assert.Equal(Serde.Json.JsonSerializer.Serialize(color), Encoding.UTF8.GetString(mem.Span));
         }
 
         [Fact]
-        public void ToMemoryWithProvider()
+        public void ToBytesWithProvider()
         {
             var color = new Color { Red = 9, Green = 8, Blue = 7 };
-            var mem = Serde.Json.JsonSerializer.ToMemory<Color>(color);
+            var mem = Serde.Json.JsonSerializer.ToBytes<Color>(color);
             Assert.Equal(Serde.Json.JsonSerializer.Serialize(color), Encoding.UTF8.GetString(mem.Span));
         }
 
         [Fact]
-        public void ToMemoryGrowsBufferForLargeOutput()
+        public void ToBytesGrowsBufferForLargeOutput()
         {
             var values = new List<int>();
             for (int i = 0; i < 5000; i++)
@@ -398,7 +398,7 @@ namespace Serde.Test
                 values.Add(i);
             }
             var data = new BigData(values);
-            var mem = Serde.Json.JsonSerializer.ToMemory(data);
+            var mem = Serde.Json.JsonSerializer.ToBytes(data);
             Assert.Equal(Serde.Json.JsonSerializer.Serialize(data), Encoding.UTF8.GetString(mem.Span));
         }
     }

--- a/test/Serde.Test/JsonSerializerTests.cs
+++ b/test/Serde.Test/JsonSerializerTests.cs
@@ -369,5 +369,37 @@ namespace Serde.Test
             {"tag":"B","y":"hello","z":"world"}
             """, Serde.Json.JsonSerializer.Serialize<BasicDUManualTag>(b));
         }
+
+        [GenerateSerialize]
+        private partial record BigData(List<int> Values);
+
+        [Fact]
+        public void ToMemoryMatchesSerialize()
+        {
+            var color = new Color { Red = 3, Green = 5, Blue = 7 };
+            var mem = Serde.Json.JsonSerializer.ToMemory(color);
+            Assert.Equal(Serde.Json.JsonSerializer.Serialize(color), Encoding.UTF8.GetString(mem.Span));
+        }
+
+        [Fact]
+        public void ToMemoryWithProvider()
+        {
+            var color = new Color { Red = 9, Green = 8, Blue = 7 };
+            var mem = Serde.Json.JsonSerializer.ToMemory<Color>(color);
+            Assert.Equal(Serde.Json.JsonSerializer.Serialize(color), Encoding.UTF8.GetString(mem.Span));
+        }
+
+        [Fact]
+        public void ToMemoryGrowsBufferForLargeOutput()
+        {
+            var values = new List<int>();
+            for (int i = 0; i < 5000; i++)
+            {
+                values.Add(i);
+            }
+            var data = new BigData(values);
+            var mem = Serde.Json.JsonSerializer.ToMemory(data);
+            Assert.Equal(Serde.Json.JsonSerializer.Serialize(data), Encoding.UTF8.GetString(mem.Span));
+        }
     }
 }

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonSerializerTests.BigData.ISerdeInfoProvider.g.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonSerializerTests.BigData.ISerdeInfoProvider.g.cs
@@ -1,0 +1,18 @@
+
+#nullable enable
+
+namespace Serde.Test;
+
+partial class JsonSerializerTests
+{
+    partial record BigData
+    {
+        private static global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
+            "BigData",
+        typeof(Serde.Test.JsonSerializerTests.BigData).GetCustomAttributesData(),
+        new (string, global::Serde.ISerdeInfo, System.Reflection.MemberInfo?)[] {
+            ("values", global::Serde.SerdeInfoProvider.GetSerializeInfo<System.Collections.Generic.List<int>, Serde.ListProxy.Ser<int, global::Serde.I32Proxy>>(), typeof(Serde.Test.JsonSerializerTests.BigData).GetProperty("Values"))
+        }
+        );
+    }
+}

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonSerializerTests.BigData.ISerialize.g.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonSerializerTests.BigData.ISerialize.g.cs
@@ -1,0 +1,27 @@
+
+#nullable enable
+
+using System;
+using Serde;
+
+namespace Serde.Test;
+
+partial class JsonSerializerTests
+{
+    partial record BigData
+    {
+        sealed partial class _SerObj : Serde.ISerialize<Serde.Test.JsonSerializerTests.BigData>
+        {
+            global::Serde.ISerdeInfo global::Serde.ISerdeInfoProvider.SerdeInfo => Serde.Test.JsonSerializerTests.BigData.s_serdeInfo;
+
+            void global::Serde.ISerialize<Serde.Test.JsonSerializerTests.BigData>.Serialize(Serde.Test.JsonSerializerTests.BigData value, global::Serde.ISerializer serializer)
+            {
+                var _l_info = global::Serde.SerdeInfoProvider.GetInfo(this);
+                var _l_type = serializer.WriteType(_l_info);
+                _l_type.WriteValue<System.Collections.Generic.List<int>, Serde.ListProxy.Ser<int, global::Serde.I32Proxy>>(_l_info, 0, value.Values);
+                _l_type.End(_l_info);
+            }
+
+        }
+    }
+}

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonSerializerTests.BigData.ISerializeProvider.g.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonSerializerTests.BigData.ISerializeProvider.g.cs
@@ -1,0 +1,11 @@
+
+namespace Serde.Test;
+
+partial class JsonSerializerTests
+{
+    partial record BigData : Serde.ISerializeProvider<Serde.Test.JsonSerializerTests.BigData>
+    {
+        static global::Serde.ISerialize<Serde.Test.JsonSerializerTests.BigData> global::Serde.ISerializeProvider<Serde.Test.JsonSerializerTests.BigData>.Instance { get; }
+            = new Serde.Test.JsonSerializerTests.BigData._SerObj();
+    }
+}


### PR DESCRIPTION
Callers can now get a ReadOnlyMemory of UTF-8 bytes instead of just a string.