### PR TITLE
Add support for tuples

### DIFF
--- a/src/generator/Proxies.cs
+++ b/src/generator/Proxies.cs
@@ -185,6 +185,17 @@ sealed partial class {{proxyName}};
                     inProgress,
                     proxyContext)),
 
+            // ValueTuples (tuple syntax, arity 2-7) are encoded as fixed-length heterogeneous
+            // sequences. Longer tuples (which use a nested TRest) are not supported.
+            INamedTypeSymbol { IsTupleType: true, TupleElements: { Length: >= 2 and <= 7 } tupleElements } =>
+                (type.ToDisplayString(s_fqnFormat), MakeProxyString(
+                    $"Serde.TupleProxy.{GetSingletonImplName(usage)}",
+                    tupleElements.Select(e => e.Type).ToImmutableArray(),
+                    context,
+                    usage,
+                    inProgress,
+                    proxyContext)),
+
             INamedTypeSymbol t when TryGetWrapperComponents(t, context, usage) is (var ConvertedType, var WrapperType, var Args)
                 => (ConvertedType, MakeProxyString(WrapperType, Args, context, usage, inProgress, proxyContext)),
 

--- a/src/generator/SerdeImplRoslynGenerator.cs
+++ b/src/generator/SerdeImplRoslynGenerator.cs
@@ -576,6 +576,48 @@ public class SerdeImplRoslynGenerator : IIncrementalGenerator
     }
 
     /// <summary>
+    /// When <paramref name="asType"/> is a tuple and <paramref name="receiverType"/> is a record
+    /// (or record struct), the record's primary constructor and compiler-generated
+    /// <c>Deconstruct</c> method already provide a bridge between the two, so explicit conversion
+    /// operators are unnecessary. This checks whether such a bridge exists and, if so, returns the
+    /// tuple element types along with which directions are available.
+    /// </summary>
+    private static (ImmutableArray<ITypeSymbol> Elements, bool HasCtor, bool HasDeconstruct)? TryGetRecordTupleBridge(
+        INamedTypeSymbol receiverType,
+        INamedTypeSymbol asType)
+    {
+        if (!receiverType.IsRecord || !asType.IsTupleType)
+        {
+            return null;
+        }
+
+        var elements = asType.TupleElements.Select(e => e.Type).ToImmutableArray();
+
+        bool Matches(IMethodSymbol method, RefKind paramRefKind)
+            => method.DeclaredAccessibility == Accessibility.Public
+               && method.Parameters.Length == elements.Length
+               && method.Parameters.All(p => p.RefKind == paramRefKind)
+               && method.Parameters
+                   .Select((p, i) => SymbolEqualityComparer.Default.Equals(p.Type, elements[i]))
+                   .All(matched => matched);
+
+        // Constructor maps a tuple back into the record (deserialize direction).
+        var hasCtor = receiverType.InstanceConstructors.Any(c => Matches(c, RefKind.None));
+
+        // Deconstruct maps the record into a tuple (serialize direction).
+        var hasDeconstruct = receiverType.GetMembers("Deconstruct")
+            .OfType<IMethodSymbol>()
+            .Any(m => m.MethodKind == MethodKind.Ordinary && Matches(m, RefKind.Out));
+
+        if (!hasCtor && !hasDeconstruct)
+        {
+            return null;
+        }
+
+        return (elements, hasCtor, hasDeconstruct);
+    }
+
+    /// <summary>
     /// Generates a serde object that serializes and deserializes <paramref name="receiverType"/> by
     /// converting to and from <paramref name="asType"/> through user-defined conversions. The
     /// generated object delegates the actual serialization to <paramref name="asType"/>'s proxy.
@@ -597,14 +639,21 @@ public class SerdeImplRoslynGenerator : IIncrementalGenerator
         string? serProxy = null;
         string? deProxy = null;
 
+        // Records whose primary constructor matches the tuple's element types can convert via the
+        // constructor and Deconstruct, so they don't need explicit conversion operators.
+        var recordTupleBridge = TryGetRecordTupleBridge(receiverType, asType);
+
         if (usage.HasFlag(SerdeUsage.Serialize))
         {
-            var conversion = context.Compilation.ClassifyConversion(receiverType, asType);
-            if (!conversion.Exists || !conversion.IsUserDefined)
+            if (recordTupleBridge is not { HasDeconstruct: true })
             {
-                context.ReportDiagnostic(CreateDiagnostic(
-                    DiagId.ERR_AsTypeNoConversion, location, receiverType, asType));
-                return false;
+                var conversion = context.Compilation.ClassifyConversion(receiverType, asType);
+                if (!conversion.Exists || !conversion.IsUserDefined)
+                {
+                    context.ReportDiagnostic(CreateDiagnostic(
+                        DiagId.ERR_AsTypeNoConversion, location, receiverType, asType));
+                    return false;
+                }
             }
             serProxy = Proxies.TryGetProxyString(null, asType, context, SerdeUsage.Serialize, inProgress, ProxyContext.Empty);
             if (serProxy is null)
@@ -617,12 +666,15 @@ public class SerdeImplRoslynGenerator : IIncrementalGenerator
 
         if (usage.HasFlag(SerdeUsage.Deserialize))
         {
-            var conversion = context.Compilation.ClassifyConversion(asType, receiverType);
-            if (!conversion.Exists || !conversion.IsUserDefined)
+            if (recordTupleBridge is not { HasCtor: true })
             {
-                context.ReportDiagnostic(CreateDiagnostic(
-                    DiagId.ERR_AsTypeNoConversion, location, asType, receiverType));
-                return false;
+                var conversion = context.Compilation.ClassifyConversion(asType, receiverType);
+                if (!conversion.Exists || !conversion.IsUserDefined)
+                {
+                    context.ReportDiagnostic(CreateDiagnostic(
+                        DiagId.ERR_AsTypeNoConversion, location, asType, receiverType));
+                    return false;
+                }
             }
             deProxy = Proxies.TryGetProxyString(null, asType, context, SerdeUsage.Deserialize, inProgress, ProxyContext.Empty);
             if (deProxy is null)
@@ -644,22 +696,52 @@ public class SerdeImplRoslynGenerator : IIncrementalGenerator
         if (serProxy is not null)
         {
             implMembers.AppendLine("");
-            implMembers.AppendLine($$"""
-            void global::Serde.ISerialize<{{receiverDisplay}}>.Serialize({{receiverDisplay}} value, global::Serde.ISerializer serializer)
+            if (recordTupleBridge is { HasDeconstruct: true } serBridge)
             {
-                global::Serde.SerializeProvider.GetSerialize<{{asTypeFqn}}, {{serProxy}}>().Serialize(({{asTypeFqn}})value, serializer);
+                var count = serBridge.Elements.Length;
+                var outArgs = string.Join(", ", Enumerable.Range(0, count).Select(i => $"out var __e{i}"));
+                var tupleArgs = string.Join(", ", Enumerable.Range(0, count).Select(i => $"__e{i}"));
+                implMembers.AppendLine($$"""
+                void global::Serde.ISerialize<{{receiverDisplay}}>.Serialize({{receiverDisplay}} value, global::Serde.ISerializer serializer)
+                {
+                    value.Deconstruct({{outArgs}});
+                    global::Serde.SerializeProvider.GetSerialize<{{asTypeFqn}}, {{serProxy}}>().Serialize(({{tupleArgs}}), serializer);
+                }
+                """);
             }
-            """);
+            else
+            {
+                implMembers.AppendLine($$"""
+                void global::Serde.ISerialize<{{receiverDisplay}}>.Serialize({{receiverDisplay}} value, global::Serde.ISerializer serializer)
+                {
+                    global::Serde.SerializeProvider.GetSerialize<{{asTypeFqn}}, {{serProxy}}>().Serialize(({{asTypeFqn}})value, serializer);
+                }
+                """);
+            }
         }
         if (deProxy is not null)
         {
             implMembers.AppendLine("");
-            implMembers.AppendLine($$"""
-            {{receiverDisplay}} global::Serde.IDeserialize<{{receiverDisplay}}>.Deserialize(global::Serde.IDeserializer deserializer)
+            if (recordTupleBridge is { HasCtor: true } deBridge)
             {
-                return ({{receiverDisplay}})global::Serde.DeserializeProvider.GetDeserialize<{{asTypeFqn}}, {{deProxy}}>().Deserialize(deserializer);
+                var ctorArgs = string.Join(", ", Enumerable.Range(0, deBridge.Elements.Length).Select(i => $"__t.Item{i + 1}"));
+                implMembers.AppendLine($$"""
+                {{receiverDisplay}} global::Serde.IDeserialize<{{receiverDisplay}}>.Deserialize(global::Serde.IDeserializer deserializer)
+                {
+                    var __t = global::Serde.DeserializeProvider.GetDeserialize<{{asTypeFqn}}, {{deProxy}}>().Deserialize(deserializer);
+                    return new {{receiverDisplay}}({{ctorArgs}});
+                }
+                """);
             }
-            """);
+            else
+            {
+                implMembers.AppendLine($$"""
+                {{receiverDisplay}} global::Serde.IDeserialize<{{receiverDisplay}}>.Deserialize(global::Serde.IDeserializer deserializer)
+                {
+                    return ({{receiverDisplay}})global::Serde.DeserializeProvider.GetDeserialize<{{asTypeFqn}}, {{deProxy}}>().Deserialize(deserializer);
+                }
+                """);
+            }
         }
 
         string baseList = usage switch

--- a/src/serde/ISerdeInfo.cs
+++ b/src/serde/ISerdeInfo.cs
@@ -75,6 +75,12 @@ public enum InfoKind
     /// cref="ISerdeInfo.Kind"/> must also implement <see cref="IUnionSerdeInfo"/>.
     /// </summary>
     Union,
+    /// <summary>
+    /// Represents a fixed-length, heterogeneous sequence of values, e.g. a
+    /// <see cref="System.ValueTuple"/>. Unlike <see cref="List"/>, each element may have a
+    /// distinct type. On most formats this is encoded the same as a list (e.g. a JSON array).
+    /// </summary>
+    Tuple,
 }
 
 public enum PrimitiveKind

--- a/src/serde/Proxies.Tuples.cs
+++ b/src/serde/Proxies.Tuples.cs
@@ -1,0 +1,777 @@
+
+using System;
+
+namespace Serde;
+
+/// <summary>
+/// Serialize and deserialize proxies for the built-in <see cref="System.ValueTuple"/> types.
+/// Tuples are represented in the data model as <see cref="InfoKind.Tuple"/>, a fixed-length
+/// heterogeneous sequence, and are encoded on self-describing formats as an array (e.g. JSON
+/// <c>[item1, item2, ...]</c>).
+/// </summary>
+public static class TupleProxy
+{
+
+    public class Ser<T1, TProvider1>()
+        : ISerializeProvider<ValueTuple<T1>>
+        where TProvider1 : ISerializeProvider<T1>
+    {
+        public static ISerialize<ValueTuple<T1>> Instance { get; } = new Impl();
+
+        private sealed class Impl : ISerialize<ValueTuple<T1>>
+        {
+            public ISerdeInfo SerdeInfo { get; } = global::Serde.SerdeInfo.MakeTuple([
+                TProvider1.Instance.SerdeInfo,
+            ]);
+
+            private readonly ITypeSerialize<T1> _ser1 = TypeSerialize.GetOrBox<T1, TProvider1>();
+
+            public void Serialize(ValueTuple<T1> value, ISerializer serializer)
+            {
+                var _l_info = SerdeInfo;
+                var _l_type = serializer.WriteCollection(_l_info, 1);
+                _ser1.Serialize(value.Item1, _l_type, _l_info, 0);
+                _l_type.End(_l_info);
+            }
+        }
+    }
+
+    public class De<T1, TProvider1>()
+        : IDeserializeProvider<ValueTuple<T1>>
+        where TProvider1 : IDeserializeProvider<T1>
+    {
+        public static IDeserialize<ValueTuple<T1>> Instance { get; } = new Impl();
+
+        private sealed class Impl : IDeserialize<ValueTuple<T1>>
+        {
+            public ISerdeInfo SerdeInfo { get; } = global::Serde.SerdeInfo.MakeTuple([
+                TProvider1.Instance.SerdeInfo,
+            ]);
+
+            private readonly ITypeDeserialize<T1> _de1 = TypeDeserialize.GetOrBox<T1, TProvider1>();
+
+            public ValueTuple<T1> Deserialize(IDeserializer deserializer)
+            {
+                var _l_info = SerdeInfo;
+                using var _l_type = deserializer.ReadType(_l_info);
+                T1 _l_item1 = default!;
+                byte _r_assigned = 0;
+                while (true)
+                {
+                    var _l_index = _l_type.TryReadIndex(_l_info);
+                    if (_l_index == ITypeDeserializer.EndOfType)
+                    {
+                        break;
+                    }
+                    switch (_l_index)
+                    {
+                        case 0:
+                            _l_item1 = _de1.Deserialize(_l_type, _l_info, _l_index);
+                            _r_assigned |= (byte)(1 << 0);
+                            break;
+                        case ITypeDeserializer.IndexNotFound:
+                            _l_type.SkipValue(_l_info, _l_index);
+                            break;
+                        default:
+                            throw new InvalidOperationException("Unexpected index: " + _l_index);
+                    }
+                }
+                if ((_r_assigned & 0b1) != 0b1)
+                {
+                    throw DeserializeException.UnassignedMember();
+                }
+                return new ValueTuple<T1>(_l_item1);
+            }
+        }
+    }
+
+    public class Ser<T1, T2, TProvider1, TProvider2>()
+        : ISerializeProvider<(T1, T2)>
+        where TProvider1 : ISerializeProvider<T1>
+        where TProvider2 : ISerializeProvider<T2>
+    {
+        public static ISerialize<(T1, T2)> Instance { get; } = new Impl();
+
+        private sealed class Impl : ISerialize<(T1, T2)>
+        {
+            public ISerdeInfo SerdeInfo { get; } = global::Serde.SerdeInfo.MakeTuple([
+                TProvider1.Instance.SerdeInfo,
+                TProvider2.Instance.SerdeInfo,
+            ]);
+
+            private readonly ITypeSerialize<T1> _ser1 = TypeSerialize.GetOrBox<T1, TProvider1>();
+            private readonly ITypeSerialize<T2> _ser2 = TypeSerialize.GetOrBox<T2, TProvider2>();
+
+            public void Serialize((T1, T2) value, ISerializer serializer)
+            {
+                var _l_info = SerdeInfo;
+                var _l_type = serializer.WriteCollection(_l_info, 2);
+                _ser1.Serialize(value.Item1, _l_type, _l_info, 0);
+                _ser2.Serialize(value.Item2, _l_type, _l_info, 1);
+                _l_type.End(_l_info);
+            }
+        }
+    }
+
+    public class De<T1, T2, TProvider1, TProvider2>()
+        : IDeserializeProvider<(T1, T2)>
+        where TProvider1 : IDeserializeProvider<T1>
+        where TProvider2 : IDeserializeProvider<T2>
+    {
+        public static IDeserialize<(T1, T2)> Instance { get; } = new Impl();
+
+        private sealed class Impl : IDeserialize<(T1, T2)>
+        {
+            public ISerdeInfo SerdeInfo { get; } = global::Serde.SerdeInfo.MakeTuple([
+                TProvider1.Instance.SerdeInfo,
+                TProvider2.Instance.SerdeInfo,
+            ]);
+
+            private readonly ITypeDeserialize<T1> _de1 = TypeDeserialize.GetOrBox<T1, TProvider1>();
+            private readonly ITypeDeserialize<T2> _de2 = TypeDeserialize.GetOrBox<T2, TProvider2>();
+
+            public (T1, T2) Deserialize(IDeserializer deserializer)
+            {
+                var _l_info = SerdeInfo;
+                using var _l_type = deserializer.ReadType(_l_info);
+                T1 _l_item1 = default!;
+                T2 _l_item2 = default!;
+                byte _r_assigned = 0;
+                while (true)
+                {
+                    var _l_index = _l_type.TryReadIndex(_l_info);
+                    if (_l_index == ITypeDeserializer.EndOfType)
+                    {
+                        break;
+                    }
+                    switch (_l_index)
+                    {
+                        case 0:
+                            _l_item1 = _de1.Deserialize(_l_type, _l_info, _l_index);
+                            _r_assigned |= (byte)(1 << 0);
+                            break;
+                        case 1:
+                            _l_item2 = _de2.Deserialize(_l_type, _l_info, _l_index);
+                            _r_assigned |= (byte)(1 << 1);
+                            break;
+                        case ITypeDeserializer.IndexNotFound:
+                            _l_type.SkipValue(_l_info, _l_index);
+                            break;
+                        default:
+                            throw new InvalidOperationException("Unexpected index: " + _l_index);
+                    }
+                }
+                if ((_r_assigned & 0b11) != 0b11)
+                {
+                    throw DeserializeException.UnassignedMember();
+                }
+                return (_l_item1, _l_item2);
+            }
+        }
+    }
+
+    public class Ser<T1, T2, T3, TProvider1, TProvider2, TProvider3>()
+        : ISerializeProvider<(T1, T2, T3)>
+        where TProvider1 : ISerializeProvider<T1>
+        where TProvider2 : ISerializeProvider<T2>
+        where TProvider3 : ISerializeProvider<T3>
+    {
+        public static ISerialize<(T1, T2, T3)> Instance { get; } = new Impl();
+
+        private sealed class Impl : ISerialize<(T1, T2, T3)>
+        {
+            public ISerdeInfo SerdeInfo { get; } = global::Serde.SerdeInfo.MakeTuple([
+                TProvider1.Instance.SerdeInfo,
+                TProvider2.Instance.SerdeInfo,
+                TProvider3.Instance.SerdeInfo,
+            ]);
+
+            private readonly ITypeSerialize<T1> _ser1 = TypeSerialize.GetOrBox<T1, TProvider1>();
+            private readonly ITypeSerialize<T2> _ser2 = TypeSerialize.GetOrBox<T2, TProvider2>();
+            private readonly ITypeSerialize<T3> _ser3 = TypeSerialize.GetOrBox<T3, TProvider3>();
+
+            public void Serialize((T1, T2, T3) value, ISerializer serializer)
+            {
+                var _l_info = SerdeInfo;
+                var _l_type = serializer.WriteCollection(_l_info, 3);
+                _ser1.Serialize(value.Item1, _l_type, _l_info, 0);
+                _ser2.Serialize(value.Item2, _l_type, _l_info, 1);
+                _ser3.Serialize(value.Item3, _l_type, _l_info, 2);
+                _l_type.End(_l_info);
+            }
+        }
+    }
+
+    public class De<T1, T2, T3, TProvider1, TProvider2, TProvider3>()
+        : IDeserializeProvider<(T1, T2, T3)>
+        where TProvider1 : IDeserializeProvider<T1>
+        where TProvider2 : IDeserializeProvider<T2>
+        where TProvider3 : IDeserializeProvider<T3>
+    {
+        public static IDeserialize<(T1, T2, T3)> Instance { get; } = new Impl();
+
+        private sealed class Impl : IDeserialize<(T1, T2, T3)>
+        {
+            public ISerdeInfo SerdeInfo { get; } = global::Serde.SerdeInfo.MakeTuple([
+                TProvider1.Instance.SerdeInfo,
+                TProvider2.Instance.SerdeInfo,
+                TProvider3.Instance.SerdeInfo,
+            ]);
+
+            private readonly ITypeDeserialize<T1> _de1 = TypeDeserialize.GetOrBox<T1, TProvider1>();
+            private readonly ITypeDeserialize<T2> _de2 = TypeDeserialize.GetOrBox<T2, TProvider2>();
+            private readonly ITypeDeserialize<T3> _de3 = TypeDeserialize.GetOrBox<T3, TProvider3>();
+
+            public (T1, T2, T3) Deserialize(IDeserializer deserializer)
+            {
+                var _l_info = SerdeInfo;
+                using var _l_type = deserializer.ReadType(_l_info);
+                T1 _l_item1 = default!;
+                T2 _l_item2 = default!;
+                T3 _l_item3 = default!;
+                byte _r_assigned = 0;
+                while (true)
+                {
+                    var _l_index = _l_type.TryReadIndex(_l_info);
+                    if (_l_index == ITypeDeserializer.EndOfType)
+                    {
+                        break;
+                    }
+                    switch (_l_index)
+                    {
+                        case 0:
+                            _l_item1 = _de1.Deserialize(_l_type, _l_info, _l_index);
+                            _r_assigned |= (byte)(1 << 0);
+                            break;
+                        case 1:
+                            _l_item2 = _de2.Deserialize(_l_type, _l_info, _l_index);
+                            _r_assigned |= (byte)(1 << 1);
+                            break;
+                        case 2:
+                            _l_item3 = _de3.Deserialize(_l_type, _l_info, _l_index);
+                            _r_assigned |= (byte)(1 << 2);
+                            break;
+                        case ITypeDeserializer.IndexNotFound:
+                            _l_type.SkipValue(_l_info, _l_index);
+                            break;
+                        default:
+                            throw new InvalidOperationException("Unexpected index: " + _l_index);
+                    }
+                }
+                if ((_r_assigned & 0b111) != 0b111)
+                {
+                    throw DeserializeException.UnassignedMember();
+                }
+                return (_l_item1, _l_item2, _l_item3);
+            }
+        }
+    }
+
+    public class Ser<T1, T2, T3, T4, TProvider1, TProvider2, TProvider3, TProvider4>()
+        : ISerializeProvider<(T1, T2, T3, T4)>
+        where TProvider1 : ISerializeProvider<T1>
+        where TProvider2 : ISerializeProvider<T2>
+        where TProvider3 : ISerializeProvider<T3>
+        where TProvider4 : ISerializeProvider<T4>
+    {
+        public static ISerialize<(T1, T2, T3, T4)> Instance { get; } = new Impl();
+
+        private sealed class Impl : ISerialize<(T1, T2, T3, T4)>
+        {
+            public ISerdeInfo SerdeInfo { get; } = global::Serde.SerdeInfo.MakeTuple([
+                TProvider1.Instance.SerdeInfo,
+                TProvider2.Instance.SerdeInfo,
+                TProvider3.Instance.SerdeInfo,
+                TProvider4.Instance.SerdeInfo,
+            ]);
+
+            private readonly ITypeSerialize<T1> _ser1 = TypeSerialize.GetOrBox<T1, TProvider1>();
+            private readonly ITypeSerialize<T2> _ser2 = TypeSerialize.GetOrBox<T2, TProvider2>();
+            private readonly ITypeSerialize<T3> _ser3 = TypeSerialize.GetOrBox<T3, TProvider3>();
+            private readonly ITypeSerialize<T4> _ser4 = TypeSerialize.GetOrBox<T4, TProvider4>();
+
+            public void Serialize((T1, T2, T3, T4) value, ISerializer serializer)
+            {
+                var _l_info = SerdeInfo;
+                var _l_type = serializer.WriteCollection(_l_info, 4);
+                _ser1.Serialize(value.Item1, _l_type, _l_info, 0);
+                _ser2.Serialize(value.Item2, _l_type, _l_info, 1);
+                _ser3.Serialize(value.Item3, _l_type, _l_info, 2);
+                _ser4.Serialize(value.Item4, _l_type, _l_info, 3);
+                _l_type.End(_l_info);
+            }
+        }
+    }
+
+    public class De<T1, T2, T3, T4, TProvider1, TProvider2, TProvider3, TProvider4>()
+        : IDeserializeProvider<(T1, T2, T3, T4)>
+        where TProvider1 : IDeserializeProvider<T1>
+        where TProvider2 : IDeserializeProvider<T2>
+        where TProvider3 : IDeserializeProvider<T3>
+        where TProvider4 : IDeserializeProvider<T4>
+    {
+        public static IDeserialize<(T1, T2, T3, T4)> Instance { get; } = new Impl();
+
+        private sealed class Impl : IDeserialize<(T1, T2, T3, T4)>
+        {
+            public ISerdeInfo SerdeInfo { get; } = global::Serde.SerdeInfo.MakeTuple([
+                TProvider1.Instance.SerdeInfo,
+                TProvider2.Instance.SerdeInfo,
+                TProvider3.Instance.SerdeInfo,
+                TProvider4.Instance.SerdeInfo,
+            ]);
+
+            private readonly ITypeDeserialize<T1> _de1 = TypeDeserialize.GetOrBox<T1, TProvider1>();
+            private readonly ITypeDeserialize<T2> _de2 = TypeDeserialize.GetOrBox<T2, TProvider2>();
+            private readonly ITypeDeserialize<T3> _de3 = TypeDeserialize.GetOrBox<T3, TProvider3>();
+            private readonly ITypeDeserialize<T4> _de4 = TypeDeserialize.GetOrBox<T4, TProvider4>();
+
+            public (T1, T2, T3, T4) Deserialize(IDeserializer deserializer)
+            {
+                var _l_info = SerdeInfo;
+                using var _l_type = deserializer.ReadType(_l_info);
+                T1 _l_item1 = default!;
+                T2 _l_item2 = default!;
+                T3 _l_item3 = default!;
+                T4 _l_item4 = default!;
+                byte _r_assigned = 0;
+                while (true)
+                {
+                    var _l_index = _l_type.TryReadIndex(_l_info);
+                    if (_l_index == ITypeDeserializer.EndOfType)
+                    {
+                        break;
+                    }
+                    switch (_l_index)
+                    {
+                        case 0:
+                            _l_item1 = _de1.Deserialize(_l_type, _l_info, _l_index);
+                            _r_assigned |= (byte)(1 << 0);
+                            break;
+                        case 1:
+                            _l_item2 = _de2.Deserialize(_l_type, _l_info, _l_index);
+                            _r_assigned |= (byte)(1 << 1);
+                            break;
+                        case 2:
+                            _l_item3 = _de3.Deserialize(_l_type, _l_info, _l_index);
+                            _r_assigned |= (byte)(1 << 2);
+                            break;
+                        case 3:
+                            _l_item4 = _de4.Deserialize(_l_type, _l_info, _l_index);
+                            _r_assigned |= (byte)(1 << 3);
+                            break;
+                        case ITypeDeserializer.IndexNotFound:
+                            _l_type.SkipValue(_l_info, _l_index);
+                            break;
+                        default:
+                            throw new InvalidOperationException("Unexpected index: " + _l_index);
+                    }
+                }
+                if ((_r_assigned & 0b1111) != 0b1111)
+                {
+                    throw DeserializeException.UnassignedMember();
+                }
+                return (_l_item1, _l_item2, _l_item3, _l_item4);
+            }
+        }
+    }
+
+    public class Ser<T1, T2, T3, T4, T5, TProvider1, TProvider2, TProvider3, TProvider4, TProvider5>()
+        : ISerializeProvider<(T1, T2, T3, T4, T5)>
+        where TProvider1 : ISerializeProvider<T1>
+        where TProvider2 : ISerializeProvider<T2>
+        where TProvider3 : ISerializeProvider<T3>
+        where TProvider4 : ISerializeProvider<T4>
+        where TProvider5 : ISerializeProvider<T5>
+    {
+        public static ISerialize<(T1, T2, T3, T4, T5)> Instance { get; } = new Impl();
+
+        private sealed class Impl : ISerialize<(T1, T2, T3, T4, T5)>
+        {
+            public ISerdeInfo SerdeInfo { get; } = global::Serde.SerdeInfo.MakeTuple([
+                TProvider1.Instance.SerdeInfo,
+                TProvider2.Instance.SerdeInfo,
+                TProvider3.Instance.SerdeInfo,
+                TProvider4.Instance.SerdeInfo,
+                TProvider5.Instance.SerdeInfo,
+            ]);
+
+            private readonly ITypeSerialize<T1> _ser1 = TypeSerialize.GetOrBox<T1, TProvider1>();
+            private readonly ITypeSerialize<T2> _ser2 = TypeSerialize.GetOrBox<T2, TProvider2>();
+            private readonly ITypeSerialize<T3> _ser3 = TypeSerialize.GetOrBox<T3, TProvider3>();
+            private readonly ITypeSerialize<T4> _ser4 = TypeSerialize.GetOrBox<T4, TProvider4>();
+            private readonly ITypeSerialize<T5> _ser5 = TypeSerialize.GetOrBox<T5, TProvider5>();
+
+            public void Serialize((T1, T2, T3, T4, T5) value, ISerializer serializer)
+            {
+                var _l_info = SerdeInfo;
+                var _l_type = serializer.WriteCollection(_l_info, 5);
+                _ser1.Serialize(value.Item1, _l_type, _l_info, 0);
+                _ser2.Serialize(value.Item2, _l_type, _l_info, 1);
+                _ser3.Serialize(value.Item3, _l_type, _l_info, 2);
+                _ser4.Serialize(value.Item4, _l_type, _l_info, 3);
+                _ser5.Serialize(value.Item5, _l_type, _l_info, 4);
+                _l_type.End(_l_info);
+            }
+        }
+    }
+
+    public class De<T1, T2, T3, T4, T5, TProvider1, TProvider2, TProvider3, TProvider4, TProvider5>()
+        : IDeserializeProvider<(T1, T2, T3, T4, T5)>
+        where TProvider1 : IDeserializeProvider<T1>
+        where TProvider2 : IDeserializeProvider<T2>
+        where TProvider3 : IDeserializeProvider<T3>
+        where TProvider4 : IDeserializeProvider<T4>
+        where TProvider5 : IDeserializeProvider<T5>
+    {
+        public static IDeserialize<(T1, T2, T3, T4, T5)> Instance { get; } = new Impl();
+
+        private sealed class Impl : IDeserialize<(T1, T2, T3, T4, T5)>
+        {
+            public ISerdeInfo SerdeInfo { get; } = global::Serde.SerdeInfo.MakeTuple([
+                TProvider1.Instance.SerdeInfo,
+                TProvider2.Instance.SerdeInfo,
+                TProvider3.Instance.SerdeInfo,
+                TProvider4.Instance.SerdeInfo,
+                TProvider5.Instance.SerdeInfo,
+            ]);
+
+            private readonly ITypeDeserialize<T1> _de1 = TypeDeserialize.GetOrBox<T1, TProvider1>();
+            private readonly ITypeDeserialize<T2> _de2 = TypeDeserialize.GetOrBox<T2, TProvider2>();
+            private readonly ITypeDeserialize<T3> _de3 = TypeDeserialize.GetOrBox<T3, TProvider3>();
+            private readonly ITypeDeserialize<T4> _de4 = TypeDeserialize.GetOrBox<T4, TProvider4>();
+            private readonly ITypeDeserialize<T5> _de5 = TypeDeserialize.GetOrBox<T5, TProvider5>();
+
+            public (T1, T2, T3, T4, T5) Deserialize(IDeserializer deserializer)
+            {
+                var _l_info = SerdeInfo;
+                using var _l_type = deserializer.ReadType(_l_info);
+                T1 _l_item1 = default!;
+                T2 _l_item2 = default!;
+                T3 _l_item3 = default!;
+                T4 _l_item4 = default!;
+                T5 _l_item5 = default!;
+                byte _r_assigned = 0;
+                while (true)
+                {
+                    var _l_index = _l_type.TryReadIndex(_l_info);
+                    if (_l_index == ITypeDeserializer.EndOfType)
+                    {
+                        break;
+                    }
+                    switch (_l_index)
+                    {
+                        case 0:
+                            _l_item1 = _de1.Deserialize(_l_type, _l_info, _l_index);
+                            _r_assigned |= (byte)(1 << 0);
+                            break;
+                        case 1:
+                            _l_item2 = _de2.Deserialize(_l_type, _l_info, _l_index);
+                            _r_assigned |= (byte)(1 << 1);
+                            break;
+                        case 2:
+                            _l_item3 = _de3.Deserialize(_l_type, _l_info, _l_index);
+                            _r_assigned |= (byte)(1 << 2);
+                            break;
+                        case 3:
+                            _l_item4 = _de4.Deserialize(_l_type, _l_info, _l_index);
+                            _r_assigned |= (byte)(1 << 3);
+                            break;
+                        case 4:
+                            _l_item5 = _de5.Deserialize(_l_type, _l_info, _l_index);
+                            _r_assigned |= (byte)(1 << 4);
+                            break;
+                        case ITypeDeserializer.IndexNotFound:
+                            _l_type.SkipValue(_l_info, _l_index);
+                            break;
+                        default:
+                            throw new InvalidOperationException("Unexpected index: " + _l_index);
+                    }
+                }
+                if ((_r_assigned & 0b11111) != 0b11111)
+                {
+                    throw DeserializeException.UnassignedMember();
+                }
+                return (_l_item1, _l_item2, _l_item3, _l_item4, _l_item5);
+            }
+        }
+    }
+
+    public class Ser<T1, T2, T3, T4, T5, T6, TProvider1, TProvider2, TProvider3, TProvider4, TProvider5, TProvider6>()
+        : ISerializeProvider<(T1, T2, T3, T4, T5, T6)>
+        where TProvider1 : ISerializeProvider<T1>
+        where TProvider2 : ISerializeProvider<T2>
+        where TProvider3 : ISerializeProvider<T3>
+        where TProvider4 : ISerializeProvider<T4>
+        where TProvider5 : ISerializeProvider<T5>
+        where TProvider6 : ISerializeProvider<T6>
+    {
+        public static ISerialize<(T1, T2, T3, T4, T5, T6)> Instance { get; } = new Impl();
+
+        private sealed class Impl : ISerialize<(T1, T2, T3, T4, T5, T6)>
+        {
+            public ISerdeInfo SerdeInfo { get; } = global::Serde.SerdeInfo.MakeTuple([
+                TProvider1.Instance.SerdeInfo,
+                TProvider2.Instance.SerdeInfo,
+                TProvider3.Instance.SerdeInfo,
+                TProvider4.Instance.SerdeInfo,
+                TProvider5.Instance.SerdeInfo,
+                TProvider6.Instance.SerdeInfo,
+            ]);
+
+            private readonly ITypeSerialize<T1> _ser1 = TypeSerialize.GetOrBox<T1, TProvider1>();
+            private readonly ITypeSerialize<T2> _ser2 = TypeSerialize.GetOrBox<T2, TProvider2>();
+            private readonly ITypeSerialize<T3> _ser3 = TypeSerialize.GetOrBox<T3, TProvider3>();
+            private readonly ITypeSerialize<T4> _ser4 = TypeSerialize.GetOrBox<T4, TProvider4>();
+            private readonly ITypeSerialize<T5> _ser5 = TypeSerialize.GetOrBox<T5, TProvider5>();
+            private readonly ITypeSerialize<T6> _ser6 = TypeSerialize.GetOrBox<T6, TProvider6>();
+
+            public void Serialize((T1, T2, T3, T4, T5, T6) value, ISerializer serializer)
+            {
+                var _l_info = SerdeInfo;
+                var _l_type = serializer.WriteCollection(_l_info, 6);
+                _ser1.Serialize(value.Item1, _l_type, _l_info, 0);
+                _ser2.Serialize(value.Item2, _l_type, _l_info, 1);
+                _ser3.Serialize(value.Item3, _l_type, _l_info, 2);
+                _ser4.Serialize(value.Item4, _l_type, _l_info, 3);
+                _ser5.Serialize(value.Item5, _l_type, _l_info, 4);
+                _ser6.Serialize(value.Item6, _l_type, _l_info, 5);
+                _l_type.End(_l_info);
+            }
+        }
+    }
+
+    public class De<T1, T2, T3, T4, T5, T6, TProvider1, TProvider2, TProvider3, TProvider4, TProvider5, TProvider6>()
+        : IDeserializeProvider<(T1, T2, T3, T4, T5, T6)>
+        where TProvider1 : IDeserializeProvider<T1>
+        where TProvider2 : IDeserializeProvider<T2>
+        where TProvider3 : IDeserializeProvider<T3>
+        where TProvider4 : IDeserializeProvider<T4>
+        where TProvider5 : IDeserializeProvider<T5>
+        where TProvider6 : IDeserializeProvider<T6>
+    {
+        public static IDeserialize<(T1, T2, T3, T4, T5, T6)> Instance { get; } = new Impl();
+
+        private sealed class Impl : IDeserialize<(T1, T2, T3, T4, T5, T6)>
+        {
+            public ISerdeInfo SerdeInfo { get; } = global::Serde.SerdeInfo.MakeTuple([
+                TProvider1.Instance.SerdeInfo,
+                TProvider2.Instance.SerdeInfo,
+                TProvider3.Instance.SerdeInfo,
+                TProvider4.Instance.SerdeInfo,
+                TProvider5.Instance.SerdeInfo,
+                TProvider6.Instance.SerdeInfo,
+            ]);
+
+            private readonly ITypeDeserialize<T1> _de1 = TypeDeserialize.GetOrBox<T1, TProvider1>();
+            private readonly ITypeDeserialize<T2> _de2 = TypeDeserialize.GetOrBox<T2, TProvider2>();
+            private readonly ITypeDeserialize<T3> _de3 = TypeDeserialize.GetOrBox<T3, TProvider3>();
+            private readonly ITypeDeserialize<T4> _de4 = TypeDeserialize.GetOrBox<T4, TProvider4>();
+            private readonly ITypeDeserialize<T5> _de5 = TypeDeserialize.GetOrBox<T5, TProvider5>();
+            private readonly ITypeDeserialize<T6> _de6 = TypeDeserialize.GetOrBox<T6, TProvider6>();
+
+            public (T1, T2, T3, T4, T5, T6) Deserialize(IDeserializer deserializer)
+            {
+                var _l_info = SerdeInfo;
+                using var _l_type = deserializer.ReadType(_l_info);
+                T1 _l_item1 = default!;
+                T2 _l_item2 = default!;
+                T3 _l_item3 = default!;
+                T4 _l_item4 = default!;
+                T5 _l_item5 = default!;
+                T6 _l_item6 = default!;
+                byte _r_assigned = 0;
+                while (true)
+                {
+                    var _l_index = _l_type.TryReadIndex(_l_info);
+                    if (_l_index == ITypeDeserializer.EndOfType)
+                    {
+                        break;
+                    }
+                    switch (_l_index)
+                    {
+                        case 0:
+                            _l_item1 = _de1.Deserialize(_l_type, _l_info, _l_index);
+                            _r_assigned |= (byte)(1 << 0);
+                            break;
+                        case 1:
+                            _l_item2 = _de2.Deserialize(_l_type, _l_info, _l_index);
+                            _r_assigned |= (byte)(1 << 1);
+                            break;
+                        case 2:
+                            _l_item3 = _de3.Deserialize(_l_type, _l_info, _l_index);
+                            _r_assigned |= (byte)(1 << 2);
+                            break;
+                        case 3:
+                            _l_item4 = _de4.Deserialize(_l_type, _l_info, _l_index);
+                            _r_assigned |= (byte)(1 << 3);
+                            break;
+                        case 4:
+                            _l_item5 = _de5.Deserialize(_l_type, _l_info, _l_index);
+                            _r_assigned |= (byte)(1 << 4);
+                            break;
+                        case 5:
+                            _l_item6 = _de6.Deserialize(_l_type, _l_info, _l_index);
+                            _r_assigned |= (byte)(1 << 5);
+                            break;
+                        case ITypeDeserializer.IndexNotFound:
+                            _l_type.SkipValue(_l_info, _l_index);
+                            break;
+                        default:
+                            throw new InvalidOperationException("Unexpected index: " + _l_index);
+                    }
+                }
+                if ((_r_assigned & 0b111111) != 0b111111)
+                {
+                    throw DeserializeException.UnassignedMember();
+                }
+                return (_l_item1, _l_item2, _l_item3, _l_item4, _l_item5, _l_item6);
+            }
+        }
+    }
+
+    public class Ser<T1, T2, T3, T4, T5, T6, T7, TProvider1, TProvider2, TProvider3, TProvider4, TProvider5, TProvider6, TProvider7>()
+        : ISerializeProvider<(T1, T2, T3, T4, T5, T6, T7)>
+        where TProvider1 : ISerializeProvider<T1>
+        where TProvider2 : ISerializeProvider<T2>
+        where TProvider3 : ISerializeProvider<T3>
+        where TProvider4 : ISerializeProvider<T4>
+        where TProvider5 : ISerializeProvider<T5>
+        where TProvider6 : ISerializeProvider<T6>
+        where TProvider7 : ISerializeProvider<T7>
+    {
+        public static ISerialize<(T1, T2, T3, T4, T5, T6, T7)> Instance { get; } = new Impl();
+
+        private sealed class Impl : ISerialize<(T1, T2, T3, T4, T5, T6, T7)>
+        {
+            public ISerdeInfo SerdeInfo { get; } = global::Serde.SerdeInfo.MakeTuple([
+                TProvider1.Instance.SerdeInfo,
+                TProvider2.Instance.SerdeInfo,
+                TProvider3.Instance.SerdeInfo,
+                TProvider4.Instance.SerdeInfo,
+                TProvider5.Instance.SerdeInfo,
+                TProvider6.Instance.SerdeInfo,
+                TProvider7.Instance.SerdeInfo,
+            ]);
+
+            private readonly ITypeSerialize<T1> _ser1 = TypeSerialize.GetOrBox<T1, TProvider1>();
+            private readonly ITypeSerialize<T2> _ser2 = TypeSerialize.GetOrBox<T2, TProvider2>();
+            private readonly ITypeSerialize<T3> _ser3 = TypeSerialize.GetOrBox<T3, TProvider3>();
+            private readonly ITypeSerialize<T4> _ser4 = TypeSerialize.GetOrBox<T4, TProvider4>();
+            private readonly ITypeSerialize<T5> _ser5 = TypeSerialize.GetOrBox<T5, TProvider5>();
+            private readonly ITypeSerialize<T6> _ser6 = TypeSerialize.GetOrBox<T6, TProvider6>();
+            private readonly ITypeSerialize<T7> _ser7 = TypeSerialize.GetOrBox<T7, TProvider7>();
+
+            public void Serialize((T1, T2, T3, T4, T5, T6, T7) value, ISerializer serializer)
+            {
+                var _l_info = SerdeInfo;
+                var _l_type = serializer.WriteCollection(_l_info, 7);
+                _ser1.Serialize(value.Item1, _l_type, _l_info, 0);
+                _ser2.Serialize(value.Item2, _l_type, _l_info, 1);
+                _ser3.Serialize(value.Item3, _l_type, _l_info, 2);
+                _ser4.Serialize(value.Item4, _l_type, _l_info, 3);
+                _ser5.Serialize(value.Item5, _l_type, _l_info, 4);
+                _ser6.Serialize(value.Item6, _l_type, _l_info, 5);
+                _ser7.Serialize(value.Item7, _l_type, _l_info, 6);
+                _l_type.End(_l_info);
+            }
+        }
+    }
+
+    public class De<T1, T2, T3, T4, T5, T6, T7, TProvider1, TProvider2, TProvider3, TProvider4, TProvider5, TProvider6, TProvider7>()
+        : IDeserializeProvider<(T1, T2, T3, T4, T5, T6, T7)>
+        where TProvider1 : IDeserializeProvider<T1>
+        where TProvider2 : IDeserializeProvider<T2>
+        where TProvider3 : IDeserializeProvider<T3>
+        where TProvider4 : IDeserializeProvider<T4>
+        where TProvider5 : IDeserializeProvider<T5>
+        where TProvider6 : IDeserializeProvider<T6>
+        where TProvider7 : IDeserializeProvider<T7>
+    {
+        public static IDeserialize<(T1, T2, T3, T4, T5, T6, T7)> Instance { get; } = new Impl();
+
+        private sealed class Impl : IDeserialize<(T1, T2, T3, T4, T5, T6, T7)>
+        {
+            public ISerdeInfo SerdeInfo { get; } = global::Serde.SerdeInfo.MakeTuple([
+                TProvider1.Instance.SerdeInfo,
+                TProvider2.Instance.SerdeInfo,
+                TProvider3.Instance.SerdeInfo,
+                TProvider4.Instance.SerdeInfo,
+                TProvider5.Instance.SerdeInfo,
+                TProvider6.Instance.SerdeInfo,
+                TProvider7.Instance.SerdeInfo,
+            ]);
+
+            private readonly ITypeDeserialize<T1> _de1 = TypeDeserialize.GetOrBox<T1, TProvider1>();
+            private readonly ITypeDeserialize<T2> _de2 = TypeDeserialize.GetOrBox<T2, TProvider2>();
+            private readonly ITypeDeserialize<T3> _de3 = TypeDeserialize.GetOrBox<T3, TProvider3>();
+            private readonly ITypeDeserialize<T4> _de4 = TypeDeserialize.GetOrBox<T4, TProvider4>();
+            private readonly ITypeDeserialize<T5> _de5 = TypeDeserialize.GetOrBox<T5, TProvider5>();
+            private readonly ITypeDeserialize<T6> _de6 = TypeDeserialize.GetOrBox<T6, TProvider6>();
+            private readonly ITypeDeserialize<T7> _de7 = TypeDeserialize.GetOrBox<T7, TProvider7>();
+
+            public (T1, T2, T3, T4, T5, T6, T7) Deserialize(IDeserializer deserializer)
+            {
+                var _l_info = SerdeInfo;
+                using var _l_type = deserializer.ReadType(_l_info);
+                T1 _l_item1 = default!;
+                T2 _l_item2 = default!;
+                T3 _l_item3 = default!;
+                T4 _l_item4 = default!;
+                T5 _l_item5 = default!;
+                T6 _l_item6 = default!;
+                T7 _l_item7 = default!;
+                byte _r_assigned = 0;
+                while (true)
+                {
+                    var _l_index = _l_type.TryReadIndex(_l_info);
+                    if (_l_index == ITypeDeserializer.EndOfType)
+                    {
+                        break;
+                    }
+                    switch (_l_index)
+                    {
+                        case 0:
+                            _l_item1 = _de1.Deserialize(_l_type, _l_info, _l_index);
+                            _r_assigned |= (byte)(1 << 0);
+                            break;
+                        case 1:
+                            _l_item2 = _de2.Deserialize(_l_type, _l_info, _l_index);
+                            _r_assigned |= (byte)(1 << 1);
+                            break;
+                        case 2:
+                            _l_item3 = _de3.Deserialize(_l_type, _l_info, _l_index);
+                            _r_assigned |= (byte)(1 << 2);
+                            break;
+                        case 3:
+                            _l_item4 = _de4.Deserialize(_l_type, _l_info, _l_index);
+                            _r_assigned |= (byte)(1 << 3);
+                            break;
+                        case 4:
+                            _l_item5 = _de5.Deserialize(_l_type, _l_info, _l_index);
+                            _r_assigned |= (byte)(1 << 4);
+                            break;
+                        case 5:
+                            _l_item6 = _de6.Deserialize(_l_type, _l_info, _l_index);
+                            _r_assigned |= (byte)(1 << 5);
+                            break;
+                        case 6:
+                            _l_item7 = _de7.Deserialize(_l_type, _l_info, _l_index);
+                            _r_assigned |= (byte)(1 << 6);
+                            break;
+                        case ITypeDeserializer.IndexNotFound:
+                            _l_type.SkipValue(_l_info, _l_index);
+                            break;
+                        default:
+                            throw new InvalidOperationException("Unexpected index: " + _l_index);
+                    }
+                }
+                if ((_r_assigned & 0b1111111) != 0b1111111)
+                {
+                    throw DeserializeException.UnassignedMember();
+                }
+                return (_l_item1, _l_item2, _l_item3, _l_item4, _l_item5, _l_item6, _l_item7);
+            }
+        }
+    }
+}

--- a/src/serde/SerdeInfo.cs
+++ b/src/serde/SerdeInfo.cs
@@ -88,6 +88,37 @@ public static class SerdeInfo
         string typeName,
         ISerdeInfo elementInfo)
         => new CollectionInfo(typeName, InfoKind.List, [elementInfo]);
+
+    /// <summary>
+    /// Create an <see cref="ISerdeInfo"/> for a fixed-length, heterogeneous tuple. Each element
+    /// becomes a field named <c>Item1</c>, <c>Item2</c>, ... in order. The ordering corresponds to
+    /// the index returned by <see cref="ITypeDeserializer.TryReadIndex" />.
+    /// </summary>
+    public static ISerdeInfo MakeTuple(ReadOnlySpan<ISerdeInfo> itemInfos)
+    {
+        var sb = new System.Text.StringBuilder("ValueTuple<");
+        for (int i = 0; i < itemInfos.Length; i++)
+        {
+            if (i > 0)
+            {
+                sb.Append(", ");
+            }
+            sb.Append(itemInfos[i].Name);
+        }
+        sb.Append('>');
+
+        var fields = new (string, ISerdeInfo, IList<CustomAttributeData>)[itemInfos.Length];
+        for (int i = 0; i < itemInfos.Length; i++)
+        {
+            fields[i] = ($"Item{i + 1}", itemInfos[i], Array.Empty<CustomAttributeData>());
+        }
+        return TypeWithFieldsInfo.Create(
+            sb.ToString(),
+            InfoKind.Tuple,
+            Array.Empty<CustomAttributeData>(),
+            fields);
+    }
+
     public static ISerdeInfo MakeDictionary(
         string typeName,
         ISerdeInfo keyInfo,

--- a/src/serde/json/JsonDeserializer.Collection.cs
+++ b/src/serde/json/JsonDeserializer.Collection.cs
@@ -30,6 +30,7 @@ partial class JsonDeserializer<TReader>
             switch (info.Kind)
             {
                 case InfoKind.List:
+                case InfoKind.Tuple:
                     return (TryReadIndexEnumerable(out errorName), errorName);
                 case InfoKind.Dictionary:
                     return (TryReadIndexDictionary(out errorName), errorName);

--- a/src/serde/json/JsonDeserializer.cs
+++ b/src/serde/json/JsonDeserializer.cs
@@ -150,6 +150,7 @@ internal sealed partial class JsonDeserializer<TReader> : BaseJsonDeserializer, 
             case InfoKind.Enum:
                 return new DeType(this);
             case InfoKind.List:
+            case InfoKind.Tuple:
             {
                 var peek = Reader.SkipWhitespace();
                 if (peek != (byte)'[')

--- a/src/serde/json/JsonSerializer.Serialize.cs
+++ b/src/serde/json/JsonSerializer.Serialize.cs
@@ -100,6 +100,9 @@ partial class JsonSerializer : ISerializer
             case InfoKind.List:
                 _writer.WriteStartArray();
                 return new EnumerableImpl(this);
+            case InfoKind.Tuple:
+                _writer.WriteStartArray();
+                return new EnumerableImpl(this);
             default:
                 throw new ArgumentException($"TypeKind is {info.Kind}, expected Enumerable or Dictionary");
         }

--- a/test/Serde.Generation.Test/SerdeTests.cs
+++ b/test/Serde.Generation.Test/SerdeTests.cs
@@ -188,6 +188,32 @@ public partial class InvalidProxyTest<T>
     }
 
     [Fact]
+    public Task AsTupleOverSevenMembersReportsError()
+    {
+        // ValueTuple proxies only support arities up to 7, so an 8-tuple target has no proxy.
+        var src = """
+using Serde;
+
+[GenerateSerde(As = typeof((int, int, int, int, int, int, int, int)))]
+public partial record Holder(int A, int B, int C, int D, int E, int F, int G, int H);
+""";
+        return VerifyDiagnostics(src);
+    }
+
+    [Fact]
+    public Task AsPlainValueTupleReportsError()
+    {
+        // The non-generic ValueTuple isn't a tuple type and has no conversion from the record.
+        var src = """
+using Serde;
+
+[GenerateSerde(As = typeof(System.ValueTuple))]
+public partial record struct Holder();
+""";
+        return VerifyDiagnostics(src);
+    }
+
+    [Fact]
     public Task DictionaryWithEqArrayKey()
     {
         var src = """

--- a/test/Serde.Generation.Test/test_output/SerdeTests.AsPlainValueTupleReportsError/target.verified.txt
+++ b/test/Serde.Generation.Test/test_output/SerdeTests.AsPlainValueTupleReportsError/target.verified.txt
@@ -1,0 +1,22 @@
+﻿{
+  Diagnostics: [
+    {
+      Location: /*
+[GenerateSerde(As = typeof(System.ValueTuple))]
+public partial record struct Holder();
+                             ^^^^^^
+*/
+ : (3,29)-(3,35),
+      Message: Cannot represent 'Holder' as 'System.ValueTuple' because no user-defined conversion from 'Holder' to 'System.ValueTuple' was found. Define an explicit or implicit conversion operator between the types.,
+      Severity: Error,
+      Descriptor: {
+        Id: ERR_AsTypeNoConversion,
+        Title: ,
+        MessageFormat: Cannot represent 'Holder' as 'System.ValueTuple' because no user-defined conversion from 'Holder' to 'System.ValueTuple' was found. Define an explicit or implicit conversion operator between the types.,
+        Category: Serde,
+        DefaultSeverity: Error,
+        IsEnabledByDefault: true
+      }
+    }
+  ]
+}

--- a/test/Serde.Generation.Test/test_output/SerdeTests.AsTupleOverSevenMembersReportsError/target.verified.txt
+++ b/test/Serde.Generation.Test/test_output/SerdeTests.AsTupleOverSevenMembersReportsError/target.verified.txt
@@ -1,0 +1,22 @@
+﻿{
+  Diagnostics: [
+    {
+      Location: /*
+[GenerateSerde(As = typeof((int, int, int, int, int, int, int, int)))]
+public partial record Holder(int A, int B, int C, int D, int E, int F, int G, int H);
+                      ^^^^^^
+*/
+ : (3,22)-(3,28),
+      Message: The member '(int, int, int, int, int, int, int, int)'s return type '(int, int, int, int, int, int, int, int)' doesn't implement Serde.ISerializeProvider<T>. Either implement 'Serde.ISerializeProvider<T>' on (int, int, int, int, int, int, int, int), or specify a proxy type.,
+      Severity: Error,
+      Descriptor: {
+        Id: ERR_DoesntImplementInterface,
+        Title: ,
+        MessageFormat: The member '(int, int, int, int, int, int, int, int)'s return type '(int, int, int, int, int, int, int, int)' doesn't implement Serde.ISerializeProvider<T>. Either implement 'Serde.ISerializeProvider<T>' on (int, int, int, int, int, int, int, int), or specify a proxy type.,
+        Category: Serde,
+        DefaultSeverity: Error,
+        IsEnabledByDefault: true
+      }
+    }
+  ]
+}

--- a/test/Serde.Test/AsTests.cs
+++ b/test/Serde.Test/AsTests.cs
@@ -82,4 +82,18 @@ public partial class AsTests
         var id = JsonSerializer.Deserialize<DeOnlyId, DeOnlyId>("\"42\"");
         Assert.Equal(42, id.Value);
     }
+
+    [GenerateSerde(As = typeof(System.ValueTuple<int, string>))]
+    public readonly partial record struct TupleWrapper(int Item1, string Item2);
+
+    [Fact]
+    public void RoundTripTupleWrapper()
+    {
+        var w = new TupleWrapper(1, "hello");
+        var json = JsonSerializer.Serialize(w);
+        Assert.Equal("""[1,"hello"]""", json);
+
+        var back = JsonSerializer.Deserialize<TupleWrapper>(json);
+        Assert.Equal(w, back);
+    }
 }

--- a/test/Serde.Test/TupleTests.cs
+++ b/test/Serde.Test/TupleTests.cs
@@ -1,0 +1,129 @@
+using Serde;
+using Serde.Json;
+using System.Collections.Generic;
+using Xunit;
+using Point = Serde.Test.RoundtripTests.Point;
+
+namespace Serde.Test;
+
+public sealed partial class TupleTests
+{
+    [Fact]
+    public void OneTuple()
+    {
+        var v = new System.ValueTuple<int>(42);
+        var json = JsonSerializer.Serialize<System.ValueTuple<int>>(
+            v, TupleProxy.Ser<int, I32Proxy>.Instance);
+        Assert.Equal("[42]", json);
+
+        var back = JsonSerializer.Deserialize<System.ValueTuple<int>>(
+            json, TupleProxy.De<int, I32Proxy>.Instance);
+        Assert.Equal(v, back);
+    }
+
+    [Fact]
+    public void TwoTuple()
+    {
+        var v = (1, "hi");
+        var json = JsonSerializer.Serialize<(int, string)>(
+            v, TupleProxy.Ser<int, string, I32Proxy, StringProxy>.Instance);
+        Assert.Equal("""[1,"hi"]""", json);
+
+        var back = JsonSerializer.Deserialize<(int, string)>(
+            json, TupleProxy.De<int, string, I32Proxy, StringProxy>.Instance);
+        Assert.Equal(v, back);
+    }
+
+    [Fact]
+    public void SevenTuple()
+    {
+        var v = (1, 2, 3, 4, 5, 6, 7);
+        var ser = TupleProxy.Ser<int, int, int, int, int, int, int,
+            I32Proxy, I32Proxy, I32Proxy, I32Proxy, I32Proxy, I32Proxy, I32Proxy>.Instance;
+        var json = JsonSerializer.Serialize<(int, int, int, int, int, int, int)>(v, ser);
+        Assert.Equal("[1,2,3,4,5,6,7]", json);
+
+        var de = TupleProxy.De<int, int, int, int, int, int, int,
+            I32Proxy, I32Proxy, I32Proxy, I32Proxy, I32Proxy, I32Proxy, I32Proxy>.Instance;
+        var back = JsonSerializer.Deserialize<(int, int, int, int, int, int, int)>(json, de);
+        Assert.Equal(v, back);
+    }
+
+    [Fact]
+    public void TupleWithComplexElement()
+    {
+        var v = (5, new Point { X = 1, Y = 2 });
+        var json = JsonSerializer.Serialize<(int, Point)>(
+            v, TupleProxy.Ser<int, Point, I32Proxy, Point>.Instance);
+        Assert.Equal("""[5,{"X":1,"Y":2}]""", json);
+
+        var back = JsonSerializer.Deserialize<(int, Point)>(
+            json, TupleProxy.De<int, Point, I32Proxy, Point>.Instance);
+        Assert.Equal(v, back);
+    }
+
+    [Fact]
+    public void NestedTuple()
+    {
+        var v = (1, (2, 3));
+        var ser = TupleProxy.Ser<int, (int, int), I32Proxy,
+            TupleProxy.Ser<int, int, I32Proxy, I32Proxy>>.Instance;
+        var json = JsonSerializer.Serialize<(int, (int, int))>(v, ser);
+        Assert.Equal("[1,[2,3]]", json);
+
+        var de = TupleProxy.De<int, (int, int), I32Proxy,
+            TupleProxy.De<int, int, I32Proxy, I32Proxy>>.Instance;
+        var back = JsonSerializer.Deserialize<(int, (int, int))>(json, de);
+        Assert.Equal(v, back);
+    }
+
+    [Fact]
+    public void TupleInList()
+    {
+        var v = new List<(int, int)> { (1, 2), (3, 4) };
+        var ser = ListProxy.Ser<(int, int), TupleProxy.Ser<int, int, I32Proxy, I32Proxy>>.Instance;
+        var json = JsonSerializer.Serialize<List<(int, int)>>(v, ser);
+        Assert.Equal("[[1,2],[3,4]]", json);
+
+        var de = ListProxy.De<(int, int), TupleProxy.De<int, int, I32Proxy, I32Proxy>>.Instance;
+        var back = JsonSerializer.Deserialize<List<(int, int)>>(json, de);
+        Assert.Equal(v, back);
+    }
+
+    [Fact]
+    public void TooFewElementsThrows()
+    {
+        var de = TupleProxy.De<int, int, I32Proxy, I32Proxy>.Instance;
+        Assert.Throws<DeserializeException>(
+            () => JsonSerializer.Deserialize<(int, int)>("[1]", de));
+    }
+
+    [GenerateSerde]
+    [SerdeTypeOptions(MemberFormat = MemberFormat.None)]
+    public partial record TupleHolder
+    {
+        public (int, string) Pair { get; init; }
+        public (int, (string, bool)) Nested { get; init; }
+        public List<(int, int)> Points { get; init; } = new();
+    }
+
+    [Fact]
+    public void GeneratedTupleMembersRoundtrip()
+    {
+        var v = new TupleHolder
+        {
+            Pair = (1, "a"),
+            Nested = (2, ("b", true)),
+            Points = new List<(int, int)> { (3, 4), (5, 6) },
+        };
+        var json = JsonSerializer.Serialize(v);
+        Assert.Equal(
+            """{"Pair":[1,"a"],"Nested":[2,["b",true]],"Points":[[3,4],[5,6]]}""",
+            json);
+
+        var back = JsonSerializer.Deserialize<TupleHolder>(json);
+        Assert.Equal(v.Pair, back.Pair);
+        Assert.Equal(v.Nested, back.Nested);
+        Assert.Equal(v.Points, back.Points);
+    }
+}

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.AsTests.TupleWrapper.ISerde.g.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.AsTests.TupleWrapper.ISerde.g.cs
@@ -1,0 +1,30 @@
+
+#nullable enable
+
+using System;
+using Serde;
+
+namespace Serde.Test;
+
+partial class AsTests
+{
+    partial record struct TupleWrapper
+    {
+        sealed partial class _SerdeObj : global::Serde.ISerde<Serde.Test.AsTests.TupleWrapper>
+        {
+            global::Serde.ISerdeInfo global::Serde.ISerdeInfoProvider.SerdeInfo { get; } = global::Serde.SerdeInfoExtensions.WithName(global::Serde.SerdeInfoProvider.GetSerializeInfo<(int, string), Serde.TupleProxy.Ser<int, string, global::Serde.I32Proxy, global::Serde.StringProxy>>(), "TupleWrapper");
+            void global::Serde.ISerialize<Serde.Test.AsTests.TupleWrapper>.Serialize(Serde.Test.AsTests.TupleWrapper value, global::Serde.ISerializer serializer)
+            {
+                value.Deconstruct(out var __e0, out var __e1);
+                global::Serde.SerializeProvider.GetSerialize<(int, string), Serde.TupleProxy.Ser<int, string, global::Serde.I32Proxy, global::Serde.StringProxy>>().Serialize((__e0, __e1), serializer);
+            }
+
+            Serde.Test.AsTests.TupleWrapper global::Serde.IDeserialize<Serde.Test.AsTests.TupleWrapper>.Deserialize(global::Serde.IDeserializer deserializer)
+            {
+                var __t = global::Serde.DeserializeProvider.GetDeserialize<(int, string), Serde.TupleProxy.De<int, string, global::Serde.I32Proxy, global::Serde.StringProxy>>().Deserialize(deserializer);
+                return new Serde.Test.AsTests.TupleWrapper(__t.Item1, __t.Item2);
+            }
+
+        }
+    }
+}

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.AsTests.TupleWrapper.ISerdeProvider.g.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.AsTests.TupleWrapper.ISerdeProvider.g.cs
@@ -1,0 +1,11 @@
+
+namespace Serde.Test;
+
+partial class AsTests
+{
+    partial record struct TupleWrapper : Serde.ISerdeProvider<Serde.Test.AsTests.TupleWrapper, Serde.Test.AsTests.TupleWrapper._SerdeObj, Serde.Test.AsTests.TupleWrapper>
+    {
+        static Serde.Test.AsTests.TupleWrapper._SerdeObj global::Serde.ISerdeProvider<Serde.Test.AsTests.TupleWrapper, Serde.Test.AsTests.TupleWrapper._SerdeObj, Serde.Test.AsTests.TupleWrapper>.Instance { get; }
+            = new Serde.Test.AsTests.TupleWrapper._SerdeObj();
+    }
+}

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.TupleTests.TupleHolder.ISerde.g.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.TupleTests.TupleHolder.ISerde.g.cs
@@ -1,0 +1,82 @@
+
+#nullable enable
+
+using System;
+using Serde;
+
+namespace Serde.Test;
+
+partial class TupleTests
+{
+    partial record TupleHolder
+    {
+        sealed partial class _SerdeObj : global::Serde.ISerde<Serde.Test.TupleTests.TupleHolder>
+        {
+            global::Serde.ISerdeInfo global::Serde.ISerdeInfoProvider.SerdeInfo => Serde.Test.TupleTests.TupleHolder.s_serdeInfo;
+
+            void global::Serde.ISerialize<Serde.Test.TupleTests.TupleHolder>.Serialize(Serde.Test.TupleTests.TupleHolder value, global::Serde.ISerializer serializer)
+            {
+                var _l_info = global::Serde.SerdeInfoProvider.GetInfo(this);
+                var _l_type = serializer.WriteType(_l_info);
+                _l_type.WriteBoxedValue<(int, string), Serde.TupleProxy.Ser<int, string, global::Serde.I32Proxy, global::Serde.StringProxy>>(_l_info, 0, value.Pair);
+                _l_type.WriteBoxedValue<(int, (string, bool)), Serde.TupleProxy.Ser<int, (string, bool), global::Serde.I32Proxy, Serde.TupleProxy.Ser<string, bool, global::Serde.StringProxy, global::Serde.BoolProxy>>>(_l_info, 1, value.Nested);
+                _l_type.WriteValue<System.Collections.Generic.List<(int, int)>, Serde.ListProxy.Ser<(int, int), Serde.TupleProxy.Ser<int, int, global::Serde.I32Proxy, global::Serde.I32Proxy>>>(_l_info, 2, value.Points);
+                _l_type.End(_l_info);
+            }
+            Serde.Test.TupleTests.TupleHolder Serde.IDeserialize<Serde.Test.TupleTests.TupleHolder>.Deserialize(IDeserializer deserializer)
+            {
+                (int, string) _l_pair = default!;
+                (int, (string, bool)) _l_nested = default!;
+                System.Collections.Generic.List<(int, int)> _l_points = default!;
+
+                byte _r_assignedValid = 0;
+
+                var _l_serdeInfo = global::Serde.SerdeInfoProvider.GetInfo(this);
+                var typeDeserialize = deserializer.ReadType(_l_serdeInfo);
+                while (true)
+                {
+                    var (_l_index_, _) = typeDeserialize.TryReadIndexWithName(_l_serdeInfo);
+                    if (_l_index_ == Serde.ITypeDeserializer.EndOfType)
+                    {
+                        break;
+                    }
+
+                    switch (_l_index_)
+                    {
+                        case 0:
+                            Serde.DeserializeException.ThrowIfDuplicate(_r_assignedValid, 0, _l_serdeInfo);
+                            _l_pair = typeDeserialize.ReadBoxedValue<(int, string), Serde.TupleProxy.De<int, string, global::Serde.I32Proxy, global::Serde.StringProxy>>(_l_serdeInfo, _l_index_);
+                            _r_assignedValid |= ((byte)1) << 0;
+                            break;
+                        case 1:
+                            Serde.DeserializeException.ThrowIfDuplicate(_r_assignedValid, 1, _l_serdeInfo);
+                            _l_nested = typeDeserialize.ReadBoxedValue<(int, (string, bool)), Serde.TupleProxy.De<int, (string, bool), global::Serde.I32Proxy, Serde.TupleProxy.De<string, bool, global::Serde.StringProxy, global::Serde.BoolProxy>>>(_l_serdeInfo, _l_index_);
+                            _r_assignedValid |= ((byte)1) << 1;
+                            break;
+                        case 2:
+                            Serde.DeserializeException.ThrowIfDuplicate(_r_assignedValid, 2, _l_serdeInfo);
+                            _l_points = typeDeserialize.ReadValue<System.Collections.Generic.List<(int, int)>, Serde.ListProxy.De<(int, int), Serde.TupleProxy.De<int, int, global::Serde.I32Proxy, global::Serde.I32Proxy>>>(_l_serdeInfo, _l_index_);
+                            _r_assignedValid |= ((byte)1) << 2;
+                            break;
+                        case Serde.ITypeDeserializer.IndexNotFound:
+                            typeDeserialize.SkipValue(_l_serdeInfo, _l_index_);
+                            break;
+                        default:
+                            throw new InvalidOperationException("Unexpected index: " + _l_index_);
+                    }
+                }
+                if ((_r_assignedValid & 0b111) != 0b111)
+                {
+                    throw Serde.DeserializeException.UnassignedMember();
+                }
+                var newType = new Serde.Test.TupleTests.TupleHolder() {
+                    Pair = _l_pair,
+                    Nested = _l_nested,
+                    Points = _l_points,
+                };
+
+                return newType;
+            }
+        }
+    }
+}

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.TupleTests.TupleHolder.ISerdeInfoProvider.g.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.TupleTests.TupleHolder.ISerdeInfoProvider.g.cs
@@ -1,0 +1,20 @@
+
+#nullable enable
+
+namespace Serde.Test;
+
+partial class TupleTests
+{
+    partial record TupleHolder
+    {
+        private static global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
+            "TupleHolder",
+        typeof(Serde.Test.TupleTests.TupleHolder).GetCustomAttributesData(),
+        new (string, global::Serde.ISerdeInfo, System.Reflection.MemberInfo?)[] {
+            ("Pair", global::Serde.SerdeInfoProvider.GetSerializeInfo<(int, string), Serde.TupleProxy.Ser<int, string, global::Serde.I32Proxy, global::Serde.StringProxy>>(), typeof(Serde.Test.TupleTests.TupleHolder).GetProperty("Pair")),
+            ("Nested", global::Serde.SerdeInfoProvider.GetSerializeInfo<(int, (string, bool)), Serde.TupleProxy.Ser<int, (string, bool), global::Serde.I32Proxy, Serde.TupleProxy.Ser<string, bool, global::Serde.StringProxy, global::Serde.BoolProxy>>>(), typeof(Serde.Test.TupleTests.TupleHolder).GetProperty("Nested")),
+            ("Points", global::Serde.SerdeInfoProvider.GetSerializeInfo<System.Collections.Generic.List<(int, int)>, Serde.ListProxy.Ser<(int, int), Serde.TupleProxy.Ser<int, int, global::Serde.I32Proxy, global::Serde.I32Proxy>>>(), typeof(Serde.Test.TupleTests.TupleHolder).GetProperty("Points"))
+        }
+        );
+    }
+}

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.TupleTests.TupleHolder.ISerdeProvider.g.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.TupleTests.TupleHolder.ISerdeProvider.g.cs
@@ -1,0 +1,11 @@
+
+namespace Serde.Test;
+
+partial class TupleTests
+{
+    partial record TupleHolder : Serde.ISerdeProvider<Serde.Test.TupleTests.TupleHolder, Serde.Test.TupleTests.TupleHolder._SerdeObj, Serde.Test.TupleTests.TupleHolder>
+    {
+        static Serde.Test.TupleTests.TupleHolder._SerdeObj global::Serde.ISerdeProvider<Serde.Test.TupleTests.TupleHolder, Serde.Test.TupleTests.TupleHolder._SerdeObj, Serde.Test.TupleTests.TupleHolder>.Instance { get; }
+            = new Serde.Test.TupleTests.TupleHolder._SerdeObj();
+    }
+}


### PR DESCRIPTION
Tuples (like in Serde Rust) are fixed-length heterogenous collections. They go through the same path as types/collections, but there is a new InfoKind enum to represent them.