### PR TITLE
Bump version to 0.15.0 and remove NuGetizer

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,6 +5,6 @@
     <Deterministic>true</Deterministic>
     <TestTfm>net10.0</TestTfm>
     <SerdeAssemblyVersion>0.10.1</SerdeAssemblyVersion>
-    <SerdePkgVersion>0.14.0</SerdePkgVersion>
+    <SerdePkgVersion>0.15.0</SerdePkgVersion>
   </PropertyGroup>
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -7,7 +7,6 @@
     <PackageVersion Include="Antlr4.Runtime.Standard" Version="4.9.3" />
     <PackageVersion Include="BenchmarkDotNet" Version="0.15.8" />
     <PackageVersion Include="CsCheck" Version="4.7.0" />
-    <PackageVersion Include="NuGetizer" Version="1.4.7" />
     <PackageVersion Include="StaticCs" Version="0.3.1" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="5.3.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="5.3.0" />

--- a/src/generator/SerdeGenerator.csproj
+++ b/src/generator/SerdeGenerator.csproj
@@ -5,9 +5,8 @@
     <Nullable>enable</Nullable>
     <LangVersion>12</LangVersion>
     <Version>$(SerdeAssemblyVersion)</Version>
+    <IsPackable>false</IsPackable>
 
-    <PackFolder>analyzers/dotnet/cs</PackFolder>
-    <PackSymbols>false</PackSymbols>
     <DefineConstants>$(DefineConstants);SRCGEN</DefineConstants>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <NoWarn>$(NoWarn);CS1591;RS1035</NoWarn>
@@ -17,10 +16,6 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp">
       <Pack>false</Pack>
-    </PackageReference>
-    <PackageReference Include="NuGetizer">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="PolyKit.Embedded">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
## Summary
Prep for the 0.15.0 release.

- Bump \`SerdePkgVersion\` from 0.14.0 to 0.15.0 in \`Directory.Build.props\`.
- Remove the unused \`NuGetizer\` dependency. The Serde package is built from \`pack/Serde.Pkg.nuspec\` (which directly bundles \`SerdeGenerator.dll\`); NuGetizer was only suppressing a standalone SerdeGenerator package, now handled with \`IsPackable=false\`.

### Changes since v0.14.0
- Add support for tuples (#352)
- Fix utf8 deserializing (#351)

## Verification
- \`dotnet pack -c Release\` produces only \`Serde.0.15.0.nupkg\`; package contents are byte-identical to before the NuGetizer removal.
- \`dotnet build -warnaserror serde-dn.sln\` succeeds with 0 warnings.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>