### PR TITLE
Add End to ITypeDeserializer

### DIFF
--- a/perf/bench/SampleTypes.cs
+++ b/perf/bench/SampleTypes.cs
@@ -150,6 +150,7 @@ public partial record LocationWrap : IDeserialize<Location>, IDeserializeProvide
             throw Serde.DeserializeException.UnassignedMember();
         }
 
+        typeDeserialize.End(_l_serdeInfo);
         var newType = new Benchmarks.Location()
         {
             Id = _l_id,

--- a/src/generator/DeserializeImplGen.cs
+++ b/src/generator/DeserializeImplGen.cs
@@ -77,7 +77,7 @@ namespace Serde
 {{typeFqn}} IDeserialize<{{typeFqn}}>.Deserialize(IDeserializer deserializer)
 {
     var _l_serdeInfo = global::Serde.SerdeInfoProvider.GetInfo(this);
-    using var de = deserializer.ReadType(_l_serdeInfo);
+    var de = deserializer.ReadType(_l_serdeInfo);
     var (index, errorName) = de.TryReadIndexWithName(_l_serdeInfo);
     if (index == ITypeDeserializer.IndexNotFound)
     {
@@ -92,6 +92,7 @@ namespace Serde
     {
         throw Serde.DeserializeException.ExpectedEndOfType(index);
     }
+    de.End(_l_serdeInfo);
     return _l_result;
 }
 """);
@@ -141,22 +142,28 @@ namespace Serde
 {{typeFqn}} IDeserialize<{{typeFqn}}>.Deserialize(IDeserializer deserializer)
 {
     var serdeInfo = global::Serde.SerdeInfoProvider.GetInfo(this);
-    using var de = deserializer.ReadType(serdeInfo);
+    var de = deserializer.ReadType(serdeInfo);
     var (index, errorName) = de.TryReadIndexWithName(serdeInfo);
     if (index == ITypeDeserializer.IndexNotFound)
     {
         throw Serde.DeserializeException.UnknownMember(errorName!, serdeInfo);
     }
+    {{typeFqn}} _l_result;
     if (index == ITypeDeserializer.EndOfType)
     {
         // Assume we want to read the underlying value
-        return ({{typeFqn}})de.Read{{primName}}(serdeInfo, index);
+        _l_result = ({{typeFqn}})de.Read{{primName}}(serdeInfo, index);
     }
-    return index switch {
-        {{string.Join("," + Utilities.NewLine, members
-            .Select((m, i) => $"{i} => {typeSyntax}.{m.Name}")) }},
-        _ => throw new InvalidOperationException($"Unexpected index: {index}")
-    };
+    else
+    {
+        _l_result = index switch {
+            {{string.Join("," + Utilities.NewLine, members
+                .Select((m, i) => $"{i} => {typeSyntax}.{m.Name}")) }},
+            _ => throw new InvalidOperationException($"Unexpected index: {index}")
+        };
+    }
+    de.End(serdeInfo);
+    return _l_result;
 }
 """);
             return src;
@@ -250,6 +257,7 @@ namespace Serde
             {{cases}}
         }
     }
+    typeDeserialize.End({{typeInfoLocalName}});
     {{typeCreationExpr}}
     return {{foreignTypeConversionOpt}}newType;
 }

--- a/src/serde/IDeserializer.cs
+++ b/src/serde/IDeserializer.cs
@@ -61,7 +61,7 @@ public static class IDeserializerExt
         => deserializer.ReadValue<T, T>();
 }
 
-public interface ITypeDeserializer : IDisposable
+public interface ITypeDeserializer
 {
     public const int EndOfType = -1;
     public const int IndexNotFound = -2;
@@ -172,7 +172,13 @@ public interface ITypeDeserializer : IDisposable
     }
     void ReadBytes(ISerdeInfo info, int index, IBufferWriter<byte> writer);
 
-    void IDisposable.Dispose() { }
+    /// <summary>
+    /// Finish deserializing the type. This method should be called when the type is fully
+    /// deserialized, after the end of the type has been reached (i.e. <see cref="TryReadIndex" />
+    /// has returned <see cref="EndOfType" />). After this method is called, the <see
+    /// cref="ITypeDeserializer" /> should not be used again.
+    /// </summary>
+    void End(ISerdeInfo info) { }
 }
 
 public static class ITypeDeserializerExt

--- a/src/serde/Proxies.Dictionary.cs
+++ b/src/serde/Proxies.Dictionary.cs
@@ -94,6 +94,7 @@ public abstract class DeDictBase<
         {
             throw new DeserializeException($"Expected {size} items, found {builder.Count}");
         }
+        deCollection.End(typeInfo);
         return Create(builder);
     }
 

--- a/src/serde/Proxies.List.cs
+++ b/src/serde/Proxies.List.cs
@@ -72,6 +72,7 @@ public abstract class DeListBase<
             {
                 FixAdd(builder, _de.Deserialize(deCollection, info, i));
             }
+            deCollection.End(info);
             return FromFix(builder);
         }
         else
@@ -88,6 +89,7 @@ public abstract class DeListBase<
 
                 VarAdd(builder, _de.Deserialize(deCollection, info, index));
             }
+            deCollection.End(info);
             return FromVar(builder);
         }
     }

--- a/src/serde/Proxies.Tuples.cs
+++ b/src/serde/Proxies.Tuples.cs
@@ -53,7 +53,7 @@ public static class TupleProxy
             public ValueTuple<T1> Deserialize(IDeserializer deserializer)
             {
                 var _l_info = SerdeInfo;
-                using var _l_type = deserializer.ReadType(_l_info);
+                var _l_type = deserializer.ReadType(_l_info);
                 T1 _l_item1 = default!;
                 byte _r_assigned = 0;
                 while (true)
@@ -80,6 +80,7 @@ public static class TupleProxy
                 {
                     throw DeserializeException.UnassignedMember();
                 }
+                _l_type.End(_l_info);
                 return new ValueTuple<T1>(_l_item1);
             }
         }
@@ -133,7 +134,7 @@ public static class TupleProxy
             public (T1, T2) Deserialize(IDeserializer deserializer)
             {
                 var _l_info = SerdeInfo;
-                using var _l_type = deserializer.ReadType(_l_info);
+                var _l_type = deserializer.ReadType(_l_info);
                 T1 _l_item1 = default!;
                 T2 _l_item2 = default!;
                 byte _r_assigned = 0;
@@ -165,6 +166,7 @@ public static class TupleProxy
                 {
                     throw DeserializeException.UnassignedMember();
                 }
+                _l_type.End(_l_info);
                 return (_l_item1, _l_item2);
             }
         }
@@ -225,7 +227,7 @@ public static class TupleProxy
             public (T1, T2, T3) Deserialize(IDeserializer deserializer)
             {
                 var _l_info = SerdeInfo;
-                using var _l_type = deserializer.ReadType(_l_info);
+                var _l_type = deserializer.ReadType(_l_info);
                 T1 _l_item1 = default!;
                 T2 _l_item2 = default!;
                 T3 _l_item3 = default!;
@@ -262,6 +264,7 @@ public static class TupleProxy
                 {
                     throw DeserializeException.UnassignedMember();
                 }
+                _l_type.End(_l_info);
                 return (_l_item1, _l_item2, _l_item3);
             }
         }
@@ -329,7 +332,7 @@ public static class TupleProxy
             public (T1, T2, T3, T4) Deserialize(IDeserializer deserializer)
             {
                 var _l_info = SerdeInfo;
-                using var _l_type = deserializer.ReadType(_l_info);
+                var _l_type = deserializer.ReadType(_l_info);
                 T1 _l_item1 = default!;
                 T2 _l_item2 = default!;
                 T3 _l_item3 = default!;
@@ -371,6 +374,7 @@ public static class TupleProxy
                 {
                     throw DeserializeException.UnassignedMember();
                 }
+                _l_type.End(_l_info);
                 return (_l_item1, _l_item2, _l_item3, _l_item4);
             }
         }
@@ -445,7 +449,7 @@ public static class TupleProxy
             public (T1, T2, T3, T4, T5) Deserialize(IDeserializer deserializer)
             {
                 var _l_info = SerdeInfo;
-                using var _l_type = deserializer.ReadType(_l_info);
+                var _l_type = deserializer.ReadType(_l_info);
                 T1 _l_item1 = default!;
                 T2 _l_item2 = default!;
                 T3 _l_item3 = default!;
@@ -492,6 +496,7 @@ public static class TupleProxy
                 {
                     throw DeserializeException.UnassignedMember();
                 }
+                _l_type.End(_l_info);
                 return (_l_item1, _l_item2, _l_item3, _l_item4, _l_item5);
             }
         }
@@ -573,7 +578,7 @@ public static class TupleProxy
             public (T1, T2, T3, T4, T5, T6) Deserialize(IDeserializer deserializer)
             {
                 var _l_info = SerdeInfo;
-                using var _l_type = deserializer.ReadType(_l_info);
+                var _l_type = deserializer.ReadType(_l_info);
                 T1 _l_item1 = default!;
                 T2 _l_item2 = default!;
                 T3 _l_item3 = default!;
@@ -625,6 +630,7 @@ public static class TupleProxy
                 {
                     throw DeserializeException.UnassignedMember();
                 }
+                _l_type.End(_l_info);
                 return (_l_item1, _l_item2, _l_item3, _l_item4, _l_item5, _l_item6);
             }
         }
@@ -713,7 +719,7 @@ public static class TupleProxy
             public (T1, T2, T3, T4, T5, T6, T7) Deserialize(IDeserializer deserializer)
             {
                 var _l_info = SerdeInfo;
-                using var _l_type = deserializer.ReadType(_l_info);
+                var _l_type = deserializer.ReadType(_l_info);
                 T1 _l_item1 = default!;
                 T2 _l_item2 = default!;
                 T3 _l_item3 = default!;
@@ -770,6 +776,7 @@ public static class TupleProxy
                 {
                     throw DeserializeException.UnassignedMember();
                 }
+                _l_type.End(_l_info);
                 return (_l_item1, _l_item2, _l_item3, _l_item4, _l_item5, _l_item6, _l_item7);
             }
         }

--- a/src/serde/json/JsonDeserializer.Collection.cs
+++ b/src/serde/json/JsonDeserializer.Collection.cs
@@ -281,5 +281,10 @@ partial class JsonDeserializer<TReader>
             _deserializer.ReadBytes(writer);
             _index++;
         }
+
+        public void End(ISerdeInfo info)
+        {
+            // Nothing to do; the closing delimiter is consumed when the end of the type is reached.
+        }
     }
 }

--- a/src/serde/json/JsonDeserializer.Type.cs
+++ b/src/serde/json/JsonDeserializer.Type.cs
@@ -222,9 +222,9 @@ partial class JsonDeserializer<TReader>
             _deserializer.Reader.Skip();
         }
 
-        void IDisposable.Dispose()
+        void ITypeDeserializer.End(ISerdeInfo info)
         {
-            // Nothing to dispose
+            // Nothing to do; the closing delimiter is consumed when the end of the type is reached.
         }
     }
 }

--- a/test/Serde.Generation.Test/test_output/AllInOneTest.GeneratorTest/Serde.Test.AllInOne.ColorEnumProxy.ISerde.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/AllInOneTest.GeneratorTest/Serde.Test.AllInOne.ColorEnumProxy.ISerde.g.verified.cs
@@ -28,23 +28,29 @@ partial record AllInOne
         Serde.Test.AllInOne.ColorEnum IDeserialize<Serde.Test.AllInOne.ColorEnum>.Deserialize(IDeserializer deserializer)
         {
             var serdeInfo = global::Serde.SerdeInfoProvider.GetInfo(this);
-            using var de = deserializer.ReadType(serdeInfo);
+            var de = deserializer.ReadType(serdeInfo);
             var (index, errorName) = de.TryReadIndexWithName(serdeInfo);
             if (index == ITypeDeserializer.IndexNotFound)
             {
                 throw Serde.DeserializeException.UnknownMember(errorName!, serdeInfo);
             }
+            Serde.Test.AllInOne.ColorEnum _l_result;
             if (index == ITypeDeserializer.EndOfType)
             {
                 // Assume we want to read the underlying value
-                return (Serde.Test.AllInOne.ColorEnum)de.ReadI32(serdeInfo, index);
+                _l_result = (Serde.Test.AllInOne.ColorEnum)de.ReadI32(serdeInfo, index);
             }
-            return index switch {
-                0 => Serde.Test.AllInOne.ColorEnum.Red,
-                1 => Serde.Test.AllInOne.ColorEnum.Blue,
-                2 => Serde.Test.AllInOne.ColorEnum.Green,
-                _ => throw new InvalidOperationException($"Unexpected index: {index}")
-            };
+            else
+            {
+                _l_result = index switch {
+                    0 => Serde.Test.AllInOne.ColorEnum.Red,
+                    1 => Serde.Test.AllInOne.ColorEnum.Blue,
+                    2 => Serde.Test.AllInOne.ColorEnum.Green,
+                    _ => throw new InvalidOperationException($"Unexpected index: {index}")
+                };
+            }
+            de.End(serdeInfo);
+            return _l_result;
         }
     }
 }

--- a/test/Serde.Generation.Test/test_output/AllInOneTest.GeneratorTest/Serde.Test.AllInOne.IDeserialize.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/AllInOneTest.GeneratorTest/Serde.Test.AllInOne.IDeserialize.g.verified.cs
@@ -187,6 +187,7 @@ partial record AllInOne
                         throw new InvalidOperationException("Unexpected index: " + _l_index_);
                 }
             }
+            typeDeserialize.End(_l_serdeInfo);
             if ((_r_assignedValid & 0b1111101111111111111111111) != 0b1111101111111111111111111)
             {
                 throw Serde.DeserializeException.UnassignedMember();

--- a/test/Serde.Generation.Test/test_output/DeserializeTests.BasicDU/Some.Nested.Namespace.Base.IDeserialize.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/DeserializeTests.BasicDU/Some.Nested.Namespace.Base.IDeserialize.g.verified.cs
@@ -16,7 +16,7 @@ partial record Base
         Some.Nested.Namespace.Base IDeserialize<Some.Nested.Namespace.Base>.Deserialize(IDeserializer deserializer)
         {
             var _l_serdeInfo = global::Serde.SerdeInfoProvider.GetInfo(this);
-            using var de = deserializer.ReadType(_l_serdeInfo);
+            var de = deserializer.ReadType(_l_serdeInfo);
             var (index, errorName) = de.TryReadIndexWithName(_l_serdeInfo);
             if (index == ITypeDeserializer.IndexNotFound)
             {
@@ -33,6 +33,7 @@ partial record Base
             {
                 throw Serde.DeserializeException.ExpectedEndOfType(index);
             }
+            de.End(_l_serdeInfo);
             return _l_result;
         }
     }

--- a/test/Serde.Generation.Test/test_output/DeserializeTests.BasicDU/Some.Nested.Namespace.Base._m_AProxy.IDeserialize.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/DeserializeTests.BasicDU/Some.Nested.Namespace.Base._m_AProxy.IDeserialize.g.verified.cs
@@ -45,6 +45,7 @@ partial record Base
                             throw new InvalidOperationException("Unexpected index: " + _l_index_);
                     }
                 }
+                typeDeserialize.End(_l_serdeInfo);
                 if ((_r_assignedValid & 0b1) != 0b1)
                 {
                     throw Serde.DeserializeException.UnassignedMember();

--- a/test/Serde.Generation.Test/test_output/DeserializeTests.BasicDU/Some.Nested.Namespace.Base._m_BProxy.IDeserialize.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/DeserializeTests.BasicDU/Some.Nested.Namespace.Base._m_BProxy.IDeserialize.g.verified.cs
@@ -45,6 +45,7 @@ partial record Base
                             throw new InvalidOperationException("Unexpected index: " + _l_index_);
                     }
                 }
+                typeDeserialize.End(_l_serdeInfo);
                 if ((_r_assignedValid & 0b1) != 0b1)
                 {
                     throw Serde.DeserializeException.UnassignedMember();

--- a/test/Serde.Generation.Test/test_output/DeserializeTests.BasicDUGenerateSerde/Some.Nested.Namespace.Base.ISerde.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/DeserializeTests.BasicDUGenerateSerde/Some.Nested.Namespace.Base.ISerde.g.verified.cs
@@ -31,7 +31,7 @@ partial record Base
         }Some.Nested.Namespace.Base IDeserialize<Some.Nested.Namespace.Base>.Deserialize(IDeserializer deserializer)
         {
             var _l_serdeInfo = global::Serde.SerdeInfoProvider.GetInfo(this);
-            using var de = deserializer.ReadType(_l_serdeInfo);
+            var de = deserializer.ReadType(_l_serdeInfo);
             var (index, errorName) = de.TryReadIndexWithName(_l_serdeInfo);
             if (index == ITypeDeserializer.IndexNotFound)
             {
@@ -48,6 +48,7 @@ partial record Base
             {
                 throw Serde.DeserializeException.ExpectedEndOfType(index);
             }
+            de.End(_l_serdeInfo);
             return _l_result;
         }
     }

--- a/test/Serde.Generation.Test/test_output/DeserializeTests.BasicDUGenerateSerde/Some.Nested.Namespace.Base._m_AProxy.ISerde.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/DeserializeTests.BasicDUGenerateSerde/Some.Nested.Namespace.Base._m_AProxy.ISerde.g.verified.cs
@@ -52,6 +52,7 @@ partial record Base
                             throw new InvalidOperationException("Unexpected index: " + _l_index_);
                     }
                 }
+                typeDeserialize.End(_l_serdeInfo);
                 if ((_r_assignedValid & 0b1) != 0b1)
                 {
                     throw Serde.DeserializeException.UnassignedMember();

--- a/test/Serde.Generation.Test/test_output/DeserializeTests.BasicDUGenerateSerde/Some.Nested.Namespace.Base._m_BProxy.ISerde.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/DeserializeTests.BasicDUGenerateSerde/Some.Nested.Namespace.Base._m_BProxy.ISerde.g.verified.cs
@@ -52,6 +52,7 @@ partial record Base
                             throw new InvalidOperationException("Unexpected index: " + _l_index_);
                     }
                 }
+                typeDeserialize.End(_l_serdeInfo);
                 if ((_r_assignedValid & 0b1) != 0b1)
                 {
                     throw Serde.DeserializeException.UnassignedMember();

--- a/test/Serde.Generation.Test/test_output/DeserializeTests.BasicDUGenerateSerializeAndDeserialize/Some.Nested.Namespace.Base.IDeserialize.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/DeserializeTests.BasicDUGenerateSerializeAndDeserialize/Some.Nested.Namespace.Base.IDeserialize.g.verified.cs
@@ -16,7 +16,7 @@ partial record Base
         Some.Nested.Namespace.Base IDeserialize<Some.Nested.Namespace.Base>.Deserialize(IDeserializer deserializer)
         {
             var _l_serdeInfo = global::Serde.SerdeInfoProvider.GetInfo(this);
-            using var de = deserializer.ReadType(_l_serdeInfo);
+            var de = deserializer.ReadType(_l_serdeInfo);
             var (index, errorName) = de.TryReadIndexWithName(_l_serdeInfo);
             if (index == ITypeDeserializer.IndexNotFound)
             {
@@ -33,6 +33,7 @@ partial record Base
             {
                 throw Serde.DeserializeException.ExpectedEndOfType(index);
             }
+            de.End(_l_serdeInfo);
             return _l_result;
         }
     }

--- a/test/Serde.Generation.Test/test_output/DeserializeTests.BasicDUGenerateSerializeAndDeserialize/Some.Nested.Namespace.Base._m_AProxy.IDeserialize.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/DeserializeTests.BasicDUGenerateSerializeAndDeserialize/Some.Nested.Namespace.Base._m_AProxy.IDeserialize.g.verified.cs
@@ -45,6 +45,7 @@ partial record Base
                             throw new InvalidOperationException("Unexpected index: " + _l_index_);
                     }
                 }
+                typeDeserialize.End(_l_serdeInfo);
                 if ((_r_assignedValid & 0b1) != 0b1)
                 {
                     throw Serde.DeserializeException.UnassignedMember();

--- a/test/Serde.Generation.Test/test_output/DeserializeTests.BasicDUGenerateSerializeAndDeserialize/Some.Nested.Namespace.Base._m_BProxy.IDeserialize.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/DeserializeTests.BasicDUGenerateSerializeAndDeserialize/Some.Nested.Namespace.Base._m_BProxy.IDeserialize.g.verified.cs
@@ -45,6 +45,7 @@ partial record Base
                             throw new InvalidOperationException("Unexpected index: " + _l_index_);
                     }
                 }
+                typeDeserialize.End(_l_serdeInfo);
                 if ((_r_assignedValid & 0b1) != 0b1)
                 {
                     throw Serde.DeserializeException.UnassignedMember();

--- a/test/Serde.Generation.Test/test_output/DeserializeTests.CtorParamMismatch/MyForeignTypeProxy.ISerde.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/DeserializeTests.CtorParamMismatch/MyForeignTypeProxy.ISerde.g.verified.cs
@@ -54,6 +54,7 @@ partial struct MyForeignTypeProxy
                         throw new InvalidOperationException("Unexpected index: " + _l_index_);
                 }
             }
+            typeDeserialize.End(_l_serdeInfo);
             var newType = new MyForeignType();
             return newType;
         }

--- a/test/Serde.Generation.Test/test_output/DeserializeTests.EnumMember/C.IDeserialize.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/DeserializeTests.EnumMember/C.IDeserialize.g.verified.cs
@@ -58,6 +58,7 @@ partial class C
                         throw new InvalidOperationException("Unexpected index: " + _l_index_);
                 }
             }
+            typeDeserialize.End(_l_serdeInfo);
             if ((_r_assignedValid & 0b1111) != 0b1111)
             {
                 throw Serde.DeserializeException.UnassignedMember();

--- a/test/Serde.Generation.Test/test_output/DeserializeTests.EnumMember/ColorByteProxy.IDeserialize.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/DeserializeTests.EnumMember/ColorByteProxy.IDeserialize.g.verified.cs
@@ -9,22 +9,28 @@ partial class ColorByteProxy : Serde.IDeserialize<ColorByte>
     ColorByte IDeserialize<ColorByte>.Deserialize(IDeserializer deserializer)
     {
         var serdeInfo = global::Serde.SerdeInfoProvider.GetInfo(this);
-        using var de = deserializer.ReadType(serdeInfo);
+        var de = deserializer.ReadType(serdeInfo);
         var (index, errorName) = de.TryReadIndexWithName(serdeInfo);
         if (index == ITypeDeserializer.IndexNotFound)
         {
             throw Serde.DeserializeException.UnknownMember(errorName!, serdeInfo);
         }
+        ColorByte _l_result;
         if (index == ITypeDeserializer.EndOfType)
         {
             // Assume we want to read the underlying value
-            return (ColorByte)de.ReadU8(serdeInfo, index);
+            _l_result = (ColorByte)de.ReadU8(serdeInfo, index);
         }
-        return index switch {
-            0 => ColorByte.Red,
-            1 => ColorByte.Green,
-            2 => ColorByte.Blue,
-            _ => throw new InvalidOperationException($"Unexpected index: {index}")
-        };
+        else
+        {
+            _l_result = index switch {
+                0 => ColorByte.Red,
+                1 => ColorByte.Green,
+                2 => ColorByte.Blue,
+                _ => throw new InvalidOperationException($"Unexpected index: {index}")
+            };
+        }
+        de.End(serdeInfo);
+        return _l_result;
     }
 }

--- a/test/Serde.Generation.Test/test_output/DeserializeTests.EnumMember/ColorIntProxy.IDeserialize.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/DeserializeTests.EnumMember/ColorIntProxy.IDeserialize.g.verified.cs
@@ -9,22 +9,28 @@ partial class ColorIntProxy : Serde.IDeserialize<ColorInt>
     ColorInt IDeserialize<ColorInt>.Deserialize(IDeserializer deserializer)
     {
         var serdeInfo = global::Serde.SerdeInfoProvider.GetInfo(this);
-        using var de = deserializer.ReadType(serdeInfo);
+        var de = deserializer.ReadType(serdeInfo);
         var (index, errorName) = de.TryReadIndexWithName(serdeInfo);
         if (index == ITypeDeserializer.IndexNotFound)
         {
             throw Serde.DeserializeException.UnknownMember(errorName!, serdeInfo);
         }
+        ColorInt _l_result;
         if (index == ITypeDeserializer.EndOfType)
         {
             // Assume we want to read the underlying value
-            return (ColorInt)de.ReadI32(serdeInfo, index);
+            _l_result = (ColorInt)de.ReadI32(serdeInfo, index);
         }
-        return index switch {
-            0 => ColorInt.Red,
-            1 => ColorInt.Green,
-            2 => ColorInt.Blue,
-            _ => throw new InvalidOperationException($"Unexpected index: {index}")
-        };
+        else
+        {
+            _l_result = index switch {
+                0 => ColorInt.Red,
+                1 => ColorInt.Green,
+                2 => ColorInt.Blue,
+                _ => throw new InvalidOperationException($"Unexpected index: {index}")
+            };
+        }
+        de.End(serdeInfo);
+        return _l_result;
     }
 }

--- a/test/Serde.Generation.Test/test_output/DeserializeTests.EnumMember/ColorLongProxy.IDeserialize.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/DeserializeTests.EnumMember/ColorLongProxy.IDeserialize.g.verified.cs
@@ -9,22 +9,28 @@ partial class ColorLongProxy : Serde.IDeserialize<ColorLong>
     ColorLong IDeserialize<ColorLong>.Deserialize(IDeserializer deserializer)
     {
         var serdeInfo = global::Serde.SerdeInfoProvider.GetInfo(this);
-        using var de = deserializer.ReadType(serdeInfo);
+        var de = deserializer.ReadType(serdeInfo);
         var (index, errorName) = de.TryReadIndexWithName(serdeInfo);
         if (index == ITypeDeserializer.IndexNotFound)
         {
             throw Serde.DeserializeException.UnknownMember(errorName!, serdeInfo);
         }
+        ColorLong _l_result;
         if (index == ITypeDeserializer.EndOfType)
         {
             // Assume we want to read the underlying value
-            return (ColorLong)de.ReadI64(serdeInfo, index);
+            _l_result = (ColorLong)de.ReadI64(serdeInfo, index);
         }
-        return index switch {
-            0 => ColorLong.Red,
-            1 => ColorLong.Green,
-            2 => ColorLong.Blue,
-            _ => throw new InvalidOperationException($"Unexpected index: {index}")
-        };
+        else
+        {
+            _l_result = index switch {
+                0 => ColorLong.Red,
+                1 => ColorLong.Green,
+                2 => ColorLong.Blue,
+                _ => throw new InvalidOperationException($"Unexpected index: {index}")
+            };
+        }
+        de.End(serdeInfo);
+        return _l_result;
     }
 }

--- a/test/Serde.Generation.Test/test_output/DeserializeTests.EnumMember/ColorULongProxy.IDeserialize.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/DeserializeTests.EnumMember/ColorULongProxy.IDeserialize.g.verified.cs
@@ -9,22 +9,28 @@ partial class ColorULongProxy : Serde.IDeserialize<ColorULong>
     ColorULong IDeserialize<ColorULong>.Deserialize(IDeserializer deserializer)
     {
         var serdeInfo = global::Serde.SerdeInfoProvider.GetInfo(this);
-        using var de = deserializer.ReadType(serdeInfo);
+        var de = deserializer.ReadType(serdeInfo);
         var (index, errorName) = de.TryReadIndexWithName(serdeInfo);
         if (index == ITypeDeserializer.IndexNotFound)
         {
             throw Serde.DeserializeException.UnknownMember(errorName!, serdeInfo);
         }
+        ColorULong _l_result;
         if (index == ITypeDeserializer.EndOfType)
         {
             // Assume we want to read the underlying value
-            return (ColorULong)de.ReadU64(serdeInfo, index);
+            _l_result = (ColorULong)de.ReadU64(serdeInfo, index);
         }
-        return index switch {
-            0 => ColorULong.Red,
-            1 => ColorULong.Green,
-            2 => ColorULong.Blue,
-            _ => throw new InvalidOperationException($"Unexpected index: {index}")
-        };
+        else
+        {
+            _l_result = index switch {
+                0 => ColorULong.Red,
+                1 => ColorULong.Green,
+                2 => ColorULong.Blue,
+                _ => throw new InvalidOperationException($"Unexpected index: {index}")
+            };
+        }
+        de.End(serdeInfo);
+        return _l_result;
     }
 }

--- a/test/Serde.Generation.Test/test_output/DeserializeTests.NestedExplicitDeserializeWrapper/OptsWrap.IDeserialize.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/DeserializeTests.NestedExplicitDeserializeWrapper/OptsWrap.IDeserialize.g.verified.cs
@@ -58,6 +58,7 @@ partial record struct OptsWrap
                         throw new InvalidOperationException("Unexpected index: " + _l_index_);
                 }
             }
+            typeDeserialize.End(_l_serdeInfo);
             if ((_r_assignedValid & 0b1111) != 0b1111)
             {
                 throw Serde.DeserializeException.UnassignedMember();

--- a/test/Serde.Generation.Test/test_output/DeserializeTests.NestedExplicitDeserializeWrapper/S.IDeserialize.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/DeserializeTests.NestedExplicitDeserializeWrapper/S.IDeserialize.g.verified.cs
@@ -40,6 +40,7 @@ partial struct S
                         throw new InvalidOperationException("Unexpected index: " + _l_index_);
                 }
             }
+            typeDeserialize.End(_l_serdeInfo);
             if ((_r_assignedValid & 0b1) != 0b1)
             {
                 throw Serde.DeserializeException.UnassignedMember();

--- a/test/Serde.Generation.Test/test_output/DeserializeTests/Array#ArrayField.IDeserialize.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/DeserializeTests/Array#ArrayField.IDeserialize.g.verified.cs
@@ -40,6 +40,7 @@ partial class ArrayField
                         throw new InvalidOperationException("Unexpected index: " + _l_index_);
                 }
             }
+            typeDeserialize.End(_l_serdeInfo);
             if ((_r_assignedValid & 0b1) != 0b1)
             {
                 throw Serde.DeserializeException.UnassignedMember();

--- a/test/Serde.Generation.Test/test_output/DeserializeTests/DeserializeMissing#SetToNull.IDeserialize.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/DeserializeTests/DeserializeMissing#SetToNull.IDeserialize.g.verified.cs
@@ -52,6 +52,7 @@ partial record struct SetToNull
                         throw new InvalidOperationException("Unexpected index: " + _l_index_);
                 }
             }
+            typeDeserialize.End(_l_serdeInfo);
             if ((_r_assignedValid & 0b101) != 0b101)
             {
                 throw Serde.DeserializeException.UnassignedMember();

--- a/test/Serde.Generation.Test/test_output/DeserializeTests/DeserializeOnlyWrap#Wrap.IDeserialize.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/DeserializeTests/DeserializeOnlyWrap#Wrap.IDeserialize.g.verified.cs
@@ -58,6 +58,7 @@ partial record struct Wrap
                         throw new InvalidOperationException("Unexpected index: " + _l_index_);
                 }
             }
+            typeDeserialize.End(_l_serdeInfo);
             if ((_r_assignedValid & 0b1111) != 0b1111)
             {
                 throw Serde.DeserializeException.UnassignedMember();

--- a/test/Serde.Generation.Test/test_output/DeserializeTests/Inheritance#A.IDeserialize.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/DeserializeTests/Inheritance#A.IDeserialize.g.verified.cs
@@ -40,6 +40,7 @@ partial class A
                         throw new InvalidOperationException("Unexpected index: " + _l_index_);
                 }
             }
+            typeDeserialize.End(_l_serdeInfo);
             if ((_r_assignedValid & 0b1) != 0b1)
             {
                 throw Serde.DeserializeException.UnassignedMember();

--- a/test/Serde.Generation.Test/test_output/DeserializeTests/Inheritance#B.IDeserialize.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/DeserializeTests/Inheritance#B.IDeserialize.g.verified.cs
@@ -46,6 +46,7 @@ partial class B
                         throw new InvalidOperationException("Unexpected index: " + _l_index_);
                 }
             }
+            typeDeserialize.End(_l_serdeInfo);
             if ((_r_assignedValid & 0b11) != 0b11)
             {
                 throw Serde.DeserializeException.UnassignedMember();

--- a/test/Serde.Generation.Test/test_output/DeserializeTests/Inheritance#C.IDeserialize.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/DeserializeTests/Inheritance#C.IDeserialize.g.verified.cs
@@ -52,6 +52,7 @@ partial class C
                         throw new InvalidOperationException("Unexpected index: " + _l_index_);
                 }
             }
+            typeDeserialize.End(_l_serdeInfo);
             if ((_r_assignedValid & 0b111) != 0b111)
             {
                 throw Serde.DeserializeException.UnassignedMember();

--- a/test/Serde.Generation.Test/test_output/DeserializeTests/MemberOverrides#A.IDeserialize.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/DeserializeTests/MemberOverrides#A.IDeserialize.g.verified.cs
@@ -40,6 +40,7 @@ partial record A
                         throw new InvalidOperationException("Unexpected index: " + _l_index_);
                 }
             }
+            typeDeserialize.End(_l_serdeInfo);
             if ((_r_assignedValid & 0b1) != 0b1)
             {
                 throw Serde.DeserializeException.UnassignedMember();

--- a/test/Serde.Generation.Test/test_output/DeserializeTests/MemberOverrides#B.IDeserialize.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/DeserializeTests/MemberOverrides#B.IDeserialize.g.verified.cs
@@ -46,6 +46,7 @@ partial record B
                         throw new InvalidOperationException("Unexpected index: " + _l_index_);
                 }
             }
+            typeDeserialize.End(_l_serdeInfo);
             if ((_r_assignedValid & 0b11) != 0b11)
             {
                 throw Serde.DeserializeException.UnassignedMember();

--- a/test/Serde.Generation.Test/test_output/DeserializeTests/MemberSkip#Rgb.IDeserialize.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/DeserializeTests/MemberSkip#Rgb.IDeserialize.g.verified.cs
@@ -46,6 +46,7 @@ partial struct Rgb
                         throw new InvalidOperationException("Unexpected index: " + _l_index_);
                 }
             }
+            typeDeserialize.End(_l_serdeInfo);
             if ((_r_assignedValid & 0b11) != 0b11)
             {
                 throw Serde.DeserializeException.UnassignedMember();

--- a/test/Serde.Generation.Test/test_output/DeserializeTests/MemberSkipDeserialize#Rgb.IDeserialize.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/DeserializeTests/MemberSkipDeserialize#Rgb.IDeserialize.g.verified.cs
@@ -47,6 +47,7 @@ partial struct Rgb
                         throw new InvalidOperationException("Unexpected index: " + _l_index_);
                 }
             }
+            typeDeserialize.End(_l_serdeInfo);
             if ((_r_assignedValid & 0b101) != 0b101)
             {
                 throw Serde.DeserializeException.UnassignedMember();

--- a/test/Serde.Generation.Test/test_output/DeserializeTests/MemberSkipSerialize#Rgb.IDeserialize.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/DeserializeTests/MemberSkipSerialize#Rgb.IDeserialize.g.verified.cs
@@ -52,6 +52,7 @@ partial struct Rgb
                         throw new InvalidOperationException("Unexpected index: " + _l_index_);
                 }
             }
+            typeDeserialize.End(_l_serdeInfo);
             if ((_r_assignedValid & 0b111) != 0b111)
             {
                 throw Serde.DeserializeException.UnassignedMember();

--- a/test/Serde.Generation.Test/test_output/DeserializeTests/NestedPartialClasses#A.B.C.D.IDeserialize.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/DeserializeTests/NestedPartialClasses#A.B.C.D.IDeserialize.g.verified.cs
@@ -46,6 +46,7 @@ partial class A
                                     throw new InvalidOperationException("Unexpected index: " + _l_index_);
                             }
                         }
+                        typeDeserialize.End(_l_serdeInfo);
                         if ((_r_assignedValid & 0b1) != 0b1)
                         {
                             throw Serde.DeserializeException.UnassignedMember();

--- a/test/Serde.Generation.Test/test_output/DeserializeTests/NoParameterlessOrPrimaryCtor#C.IDeserialize.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/DeserializeTests/NoParameterlessOrPrimaryCtor#C.IDeserialize.g.verified.cs
@@ -40,6 +40,7 @@ partial class C
                         throw new InvalidOperationException("Unexpected index: " + _l_index_);
                 }
             }
+            typeDeserialize.End(_l_serdeInfo);
             var newType = new C();
             return newType;
         }

--- a/test/Serde.Generation.Test/test_output/DeserializeTests/NoParameterlessOrPrimaryCtor#FinalDiagnostics.verified.txt
+++ b/test/Serde.Generation.Test/test_output/DeserializeTests/NoParameterlessOrPrimaryCtor#FinalDiagnostics.verified.txt
@@ -4,7 +4,7 @@
     "Title": "",
     "Severity": "Error",
     "WarningLevel": "0",
-    "Location": "SerdeGenerator/Serde.SerdeImplRoslynGenerator/C.IDeserialize.g.cs: (41,30)-(41,31)",
+    "Location": "SerdeGenerator/Serde.SerdeImplRoslynGenerator/C.IDeserialize.g.cs: (42,30)-(42,31)",
     "HelpLink": "https://msdn.microsoft.com/query/roslyn.query?appId=roslyn&k=k(CS7036)",
     "MessageFormat": "There is no argument given that corresponds to the required parameter '{0}' of '{1}'",
     "Message": "There is no argument given that corresponds to the required parameter 'A' of 'C.C(int)'",

--- a/test/Serde.Generation.Test/test_output/DeserializeTests/NullableRefField#S.IDeserialize.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/DeserializeTests/NullableRefField#S.IDeserialize.g.verified.cs
@@ -40,6 +40,7 @@ partial struct S
                         throw new InvalidOperationException("Unexpected index: " + _l_index_);
                 }
             }
+            typeDeserialize.End(_l_serdeInfo);
             if ((_r_assignedValid & 0b0) != 0b0)
             {
                 throw Serde.DeserializeException.UnassignedMember();

--- a/test/Serde.Generation.Test/test_output/DeserializeTests/Rgb#Rgb.IDeserialize.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/DeserializeTests/Rgb#Rgb.IDeserialize.g.verified.cs
@@ -52,6 +52,7 @@ partial struct Rgb
                         throw new InvalidOperationException("Unexpected index: " + _l_index_);
                 }
             }
+            typeDeserialize.End(_l_serdeInfo);
             if ((_r_assignedValid & 0b111) != 0b111)
             {
                 throw Serde.DeserializeException.UnassignedMember();

--- a/test/Serde.Generation.Test/test_output/FieldInitializerTests/FieldInitializerEnum#C.IDeserialize.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/FieldInitializerTests/FieldInitializerEnum#C.IDeserialize.g.verified.cs
@@ -40,6 +40,7 @@ partial class C
                         throw new InvalidOperationException("Unexpected index: " + _l_index_);
                 }
             }
+            typeDeserialize.End(_l_serdeInfo);
             if ((_r_assignedValid & 0b1) != 0b1)
             {
                 throw Serde.DeserializeException.UnassignedMember();

--- a/test/Serde.Generation.Test/test_output/FieldInitializerTests/FieldInitializerEnum#ColorProxy.IDeserialize.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/FieldInitializerTests/FieldInitializerEnum#ColorProxy.IDeserialize.g.verified.cs
@@ -9,22 +9,28 @@ partial class ColorProxy : Serde.IDeserialize<Color>
     Color IDeserialize<Color>.Deserialize(IDeserializer deserializer)
     {
         var serdeInfo = global::Serde.SerdeInfoProvider.GetInfo(this);
-        using var de = deserializer.ReadType(serdeInfo);
+        var de = deserializer.ReadType(serdeInfo);
         var (index, errorName) = de.TryReadIndexWithName(serdeInfo);
         if (index == ITypeDeserializer.IndexNotFound)
         {
             throw Serde.DeserializeException.UnknownMember(errorName!, serdeInfo);
         }
+        Color _l_result;
         if (index == ITypeDeserializer.EndOfType)
         {
             // Assume we want to read the underlying value
-            return (Color)de.ReadI32(serdeInfo, index);
+            _l_result = (Color)de.ReadI32(serdeInfo, index);
         }
-        return index switch {
-            0 => Color.Red,
-            1 => Color.Green,
-            2 => Color.Blue,
-            _ => throw new InvalidOperationException($"Unexpected index: {index}")
-        };
+        else
+        {
+            _l_result = index switch {
+                0 => Color.Red,
+                1 => Color.Green,
+                2 => Color.Blue,
+                _ => throw new InvalidOperationException($"Unexpected index: {index}")
+            };
+        }
+        de.End(serdeInfo);
+        return _l_result;
     }
 }

--- a/test/Serde.Generation.Test/test_output/FieldInitializerTests/FieldInitializerEnumCast#Mine.C.IDeserialize.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/FieldInitializerTests/FieldInitializerEnumCast#Mine.C.IDeserialize.g.verified.cs
@@ -49,6 +49,7 @@ partial class C
                         throw new InvalidOperationException("Unexpected index: " + _l_index_);
                 }
             }
+            typeDeserialize.End(_l_serdeInfo);
             if ((_r_assignedValid & 0b11) != 0b11)
             {
                 throw Serde.DeserializeException.UnassignedMember();

--- a/test/Serde.Generation.Test/test_output/FieldInitializerTests/FieldInitializerEnumCast#Other.ColorProxy.IDeserialize.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/FieldInitializerTests/FieldInitializerEnumCast#Other.ColorProxy.IDeserialize.g.verified.cs
@@ -12,21 +12,27 @@ partial class ColorProxy : Serde.IDeserialize<Other.Color>
     Other.Color IDeserialize<Other.Color>.Deserialize(IDeserializer deserializer)
     {
         var serdeInfo = global::Serde.SerdeInfoProvider.GetInfo(this);
-        using var de = deserializer.ReadType(serdeInfo);
+        var de = deserializer.ReadType(serdeInfo);
         var (index, errorName) = de.TryReadIndexWithName(serdeInfo);
         if (index == ITypeDeserializer.IndexNotFound)
         {
             throw Serde.DeserializeException.UnknownMember(errorName!, serdeInfo);
         }
+        Other.Color _l_result;
         if (index == ITypeDeserializer.EndOfType)
         {
             // Assume we want to read the underlying value
-            return (Other.Color)de.ReadI32(serdeInfo, index);
+            _l_result = (Other.Color)de.ReadI32(serdeInfo, index);
         }
-        return index switch {
-            0 => Other.Color.Red,
-            1 => Other.Color.Green,
-            _ => throw new InvalidOperationException($"Unexpected index: {index}")
-        };
+        else
+        {
+            _l_result = index switch {
+                0 => Other.Color.Red,
+                1 => Other.Color.Green,
+                _ => throw new InvalidOperationException($"Unexpected index: {index}")
+            };
+        }
+        de.End(serdeInfo);
+        return _l_result;
     }
 }

--- a/test/Serde.Generation.Test/test_output/FieldInitializerTests/FieldInitializerForeignTypeProxy#TargetProxy.IDeserialize.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/FieldInitializerTests/FieldInitializerForeignTypeProxy#TargetProxy.IDeserialize.g.verified.cs
@@ -46,6 +46,7 @@ partial struct TargetProxy
                         throw new InvalidOperationException("Unexpected index: " + _l_index_);
                 }
             }
+            typeDeserialize.End(_l_serdeInfo);
             if ((_r_assignedValid & 0b11) != 0b11)
             {
                 throw Serde.DeserializeException.UnassignedMember();

--- a/test/Serde.Generation.Test/test_output/FieldInitializerTests/FieldInitializerNullForgiving#C.IDeserialize.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/FieldInitializerTests/FieldInitializerNullForgiving#C.IDeserialize.g.verified.cs
@@ -52,6 +52,7 @@ partial class C
                         throw new InvalidOperationException("Unexpected index: " + _l_index_);
                 }
             }
+            typeDeserialize.End(_l_serdeInfo);
             if ((_r_assignedValid & 0b11) != 0b11)
             {
                 throw Serde.DeserializeException.UnassignedMember();

--- a/test/Serde.Generation.Test/test_output/FieldInitializerTests/FieldInitializerPrimaryCtorParam#C.IDeserialize.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/FieldInitializerTests/FieldInitializerPrimaryCtorParam#C.IDeserialize.g.verified.cs
@@ -52,6 +52,7 @@ partial record C
                         throw new InvalidOperationException("Unexpected index: " + _l_index_);
                 }
             }
+            typeDeserialize.End(_l_serdeInfo);
             if ((_r_assignedValid & 0b111) != 0b111)
             {
                 throw Serde.DeserializeException.UnassignedMember();

--- a/test/Serde.Generation.Test/test_output/FieldInitializerTests/FieldInitializerUnsafe#C.IDeserialize.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/FieldInitializerTests/FieldInitializerUnsafe#C.IDeserialize.g.verified.cs
@@ -52,6 +52,7 @@ partial class C
                         throw new InvalidOperationException("Unexpected index: " + _l_index_);
                 }
             }
+            typeDeserialize.End(_l_serdeInfo);
             if ((_r_assignedValid & 0b111) != 0b111)
             {
                 throw Serde.DeserializeException.UnassignedMember();

--- a/test/Serde.Generation.Test/test_output/FieldInitializerTests/FieldInitializers#C.IDeserialize.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/FieldInitializerTests/FieldInitializers#C.IDeserialize.g.verified.cs
@@ -82,6 +82,7 @@ partial class C
                         throw new InvalidOperationException("Unexpected index: " + _l_index_);
                 }
             }
+            typeDeserialize.End(_l_serdeInfo);
             if ((_r_assignedValid & 0b11110111) != 0b11110111)
             {
                 throw Serde.DeserializeException.UnassignedMember();

--- a/test/Serde.Generation.Test/test_output/MemberFormatTests.EnumFormat/ColorEnumProxy.ISerde.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/MemberFormatTests.EnumFormat/ColorEnumProxy.ISerde.g.verified.cs
@@ -23,22 +23,28 @@ partial class ColorEnumProxy : Serde.ISerde<ColorEnum>
     ColorEnum IDeserialize<ColorEnum>.Deserialize(IDeserializer deserializer)
     {
         var serdeInfo = global::Serde.SerdeInfoProvider.GetInfo(this);
-        using var de = deserializer.ReadType(serdeInfo);
+        var de = deserializer.ReadType(serdeInfo);
         var (index, errorName) = de.TryReadIndexWithName(serdeInfo);
         if (index == ITypeDeserializer.IndexNotFound)
         {
             throw Serde.DeserializeException.UnknownMember(errorName!, serdeInfo);
         }
+        ColorEnum _l_result;
         if (index == ITypeDeserializer.EndOfType)
         {
             // Assume we want to read the underlying value
-            return (ColorEnum)de.ReadI32(serdeInfo, index);
+            _l_result = (ColorEnum)de.ReadI32(serdeInfo, index);
         }
-        return index switch {
-            0 => ColorEnum.Red,
-            1 => ColorEnum.Green,
-            2 => ColorEnum.Blue,
-            _ => throw new InvalidOperationException($"Unexpected index: {index}")
-        };
+        else
+        {
+            _l_result = index switch {
+                0 => ColorEnum.Red,
+                1 => ColorEnum.Green,
+                2 => ColorEnum.Blue,
+                _ => throw new InvalidOperationException($"Unexpected index: {index}")
+            };
+        }
+        de.End(serdeInfo);
+        return _l_result;
     }
 }

--- a/test/Serde.Generation.Test/test_output/MemberFormatTests.EnumValues/ColorEnumProxy.ISerde.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/MemberFormatTests.EnumValues/ColorEnumProxy.ISerde.g.verified.cs
@@ -23,22 +23,28 @@ partial class ColorEnumProxy : Serde.ISerde<ColorEnum>
     ColorEnum IDeserialize<ColorEnum>.Deserialize(IDeserializer deserializer)
     {
         var serdeInfo = global::Serde.SerdeInfoProvider.GetInfo(this);
-        using var de = deserializer.ReadType(serdeInfo);
+        var de = deserializer.ReadType(serdeInfo);
         var (index, errorName) = de.TryReadIndexWithName(serdeInfo);
         if (index == ITypeDeserializer.IndexNotFound)
         {
             throw Serde.DeserializeException.UnknownMember(errorName!, serdeInfo);
         }
+        ColorEnum _l_result;
         if (index == ITypeDeserializer.EndOfType)
         {
             // Assume we want to read the underlying value
-            return (ColorEnum)de.ReadI32(serdeInfo, index);
+            _l_result = (ColorEnum)de.ReadI32(serdeInfo, index);
         }
-        return index switch {
-            0 => ColorEnum.Red,
-            1 => ColorEnum.Green,
-            2 => ColorEnum.Blue,
-            _ => throw new InvalidOperationException($"Unexpected index: {index}")
-        };
+        else
+        {
+            _l_result = index switch {
+                0 => ColorEnum.Red,
+                1 => ColorEnum.Green,
+                2 => ColorEnum.Blue,
+                _ => throw new InvalidOperationException($"Unexpected index: {index}")
+            };
+        }
+        de.End(serdeInfo);
+        return _l_result;
     }
 }

--- a/test/Serde.Generation.Test/test_output/MemberFormatTests.EnumValues/S.IDeserialize.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/MemberFormatTests.EnumValues/S.IDeserialize.g.verified.cs
@@ -40,6 +40,7 @@ partial struct S
                         throw new InvalidOperationException("Unexpected index: " + _l_index_);
                 }
             }
+            typeDeserialize.End(_l_serdeInfo);
             if ((_r_assignedValid & 0b1) != 0b1)
             {
                 throw Serde.DeserializeException.UnassignedMember();

--- a/test/Serde.Generation.Test/test_output/MemberFormatTests.EnumValues/S2.IDeserialize.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/MemberFormatTests.EnumValues/S2.IDeserialize.g.verified.cs
@@ -40,6 +40,7 @@ partial struct S2
                         throw new InvalidOperationException("Unexpected index: " + _l_index_);
                 }
             }
+            typeDeserialize.End(_l_serdeInfo);
             if ((_r_assignedValid & 0b1) != 0b1)
             {
                 throw Serde.DeserializeException.UnassignedMember();

--- a/test/Serde.Generation.Test/test_output/MemberFormatTests.KebabCase/S.ISerde.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/MemberFormatTests.KebabCase/S.ISerde.g.verified.cs
@@ -54,6 +54,7 @@ partial struct S
                         throw new InvalidOperationException("Unexpected index: " + _l_index_);
                 }
             }
+            typeDeserialize.End(_l_serdeInfo);
             if ((_r_assignedValid & 0b11) != 0b11)
             {
                 throw Serde.DeserializeException.UnassignedMember();

--- a/test/Serde.Generation.Test/test_output/MemberFormatTests.SnakeCase/S.ISerde.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/MemberFormatTests.SnakeCase/S.ISerde.g.verified.cs
@@ -54,6 +54,7 @@ partial struct S
                         throw new InvalidOperationException("Unexpected index: " + _l_index_);
                 }
             }
+            typeDeserialize.End(_l_serdeInfo);
             if ((_r_assignedValid & 0b11) != 0b11)
             {
                 throw Serde.DeserializeException.UnassignedMember();

--- a/test/Serde.Generation.Test/test_output/ProxyTests.AsGeneratedType/Point.ISerde.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/ProxyTests.AsGeneratedType/Point.ISerde.g.verified.cs
@@ -54,6 +54,7 @@ partial record Point
                         throw new InvalidOperationException("Unexpected index: " + _l_index_);
                 }
             }
+            typeDeserialize.End(_l_serdeInfo);
             if ((_r_assignedValid & 0b11) != 0b11)
             {
                 throw Serde.DeserializeException.UnassignedMember();

--- a/test/Serde.Generation.Test/test_output/ProxyTests.ExplicitInvalidGenericWrapper/Container.IDeserialize.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/ProxyTests.ExplicitInvalidGenericWrapper/Container.IDeserialize.g.verified.cs
@@ -40,6 +40,7 @@ partial record Container
                         throw new InvalidOperationException("Unexpected index: " + _l_index_);
                 }
             }
+            typeDeserialize.End(_l_serdeInfo);
             if ((_r_assignedValid & 0b0) != 0b0)
             {
                 throw Serde.DeserializeException.UnassignedMember();

--- a/test/Serde.Generation.Test/test_output/ProxyTests.ExplicitInvalidGenericWrapper/Original.IDeserialize.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/ProxyTests.ExplicitInvalidGenericWrapper/Original.IDeserialize.g.verified.cs
@@ -40,6 +40,7 @@ partial record struct Original
                         throw new InvalidOperationException("Unexpected index: " + _l_index_);
                 }
             }
+            typeDeserialize.End(_l_serdeInfo);
             if ((_r_assignedValid & 0b1) != 0b1)
             {
                 throw Serde.DeserializeException.UnassignedMember();

--- a/test/Serde.Generation.Test/test_output/ProxyTests.ExplicitNullableProxy/Container.IDeserialize.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/ProxyTests.ExplicitNullableProxy/Container.IDeserialize.g.verified.cs
@@ -40,6 +40,7 @@ partial record Container
                         throw new InvalidOperationException("Unexpected index: " + _l_index_);
                 }
             }
+            typeDeserialize.End(_l_serdeInfo);
             if ((_r_assignedValid & 0b0) != 0b0)
             {
                 throw Serde.DeserializeException.UnassignedMember();

--- a/test/Serde.Generation.Test/test_output/ProxyTests.ExplicitNullableProxy/Original.IDeserialize.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/ProxyTests.ExplicitNullableProxy/Original.IDeserialize.g.verified.cs
@@ -40,6 +40,7 @@ partial record struct Original
                         throw new InvalidOperationException("Unexpected index: " + _l_index_);
                 }
             }
+            typeDeserialize.End(_l_serdeInfo);
             if ((_r_assignedValid & 0b1) != 0b1)
             {
                 throw Serde.DeserializeException.UnassignedMember();

--- a/test/Serde.Generation.Test/test_output/ProxyTests.GenerateSerdeWrap/OPTSWrap.ISerde.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/ProxyTests.GenerateSerdeWrap/OPTSWrap.ISerde.g.verified.cs
@@ -68,6 +68,7 @@ partial record struct OPTSWrap
                         throw new InvalidOperationException("Unexpected index: " + _l_index_);
                 }
             }
+            typeDeserialize.End(_l_serdeInfo);
             if ((_r_assignedValid & 0b1111) != 0b1111)
             {
                 throw Serde.DeserializeException.UnassignedMember();

--- a/test/Serde.Generation.Test/test_output/ProxyTests.ImmutableArrayEnumDeserialize/Test.ChannelList.IDeserialize.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/ProxyTests.ImmutableArrayEnumDeserialize/Test.ChannelList.IDeserialize.g.verified.cs
@@ -43,6 +43,7 @@ partial record struct ChannelList
                         throw new InvalidOperationException("Unexpected index: " + _l_index_);
                 }
             }
+            typeDeserialize.End(_l_serdeInfo);
             if ((_r_assignedValid & 0b1) != 0b1)
             {
                 throw Serde.DeserializeException.UnassignedMember();

--- a/test/Serde.Generation.Test/test_output/ProxyTests.ImmutableArrayEnumDeserialize/Test.ChannelProxy.IDeserialize.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/ProxyTests.ImmutableArrayEnumDeserialize/Test.ChannelProxy.IDeserialize.g.verified.cs
@@ -12,22 +12,28 @@ partial class ChannelProxy : Serde.IDeserialize<Test.Channel>
     Test.Channel IDeserialize<Test.Channel>.Deserialize(IDeserializer deserializer)
     {
         var serdeInfo = global::Serde.SerdeInfoProvider.GetInfo(this);
-        using var de = deserializer.ReadType(serdeInfo);
+        var de = deserializer.ReadType(serdeInfo);
         var (index, errorName) = de.TryReadIndexWithName(serdeInfo);
         if (index == ITypeDeserializer.IndexNotFound)
         {
             throw Serde.DeserializeException.UnknownMember(errorName!, serdeInfo);
         }
+        Test.Channel _l_result;
         if (index == ITypeDeserializer.EndOfType)
         {
             // Assume we want to read the underlying value
-            return (Test.Channel)de.ReadI32(serdeInfo, index);
+            _l_result = (Test.Channel)de.ReadI32(serdeInfo, index);
         }
-        return index switch {
-            0 => Test.Channel.A,
-            1 => Test.Channel.B,
-            2 => Test.Channel.C,
-            _ => throw new InvalidOperationException($"Unexpected index: {index}")
-        };
+        else
+        {
+            _l_result = index switch {
+                0 => Test.Channel.A,
+                1 => Test.Channel.B,
+                2 => Test.Channel.C,
+                _ => throw new InvalidOperationException($"Unexpected index: {index}")
+            };
+        }
+        de.End(serdeInfo);
+        return _l_result;
     }
 }

--- a/test/Serde.Generation.Test/test_output/ProxyTests.NestedDeserializeWrap/C.IDeserialize.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/ProxyTests.NestedDeserializeWrap/C.IDeserialize.g.verified.cs
@@ -40,6 +40,7 @@ partial class C
                         throw new InvalidOperationException("Unexpected index: " + _l_index_);
                 }
             }
+            typeDeserialize.End(_l_serdeInfo);
             if ((_r_assignedValid & 0b1) != 0b1)
             {
                 throw Serde.DeserializeException.UnassignedMember();

--- a/test/Serde.Generation.Test/test_output/ProxyTests.NestedDeserializeWrap/OPTSWrap.ISerde.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/ProxyTests.NestedDeserializeWrap/OPTSWrap.ISerde.g.verified.cs
@@ -68,6 +68,7 @@ partial class OPTSWrap
                         throw new InvalidOperationException("Unexpected index: " + _l_index_);
                 }
             }
+            typeDeserialize.End(_l_serdeInfo);
             if ((_r_assignedValid & 0b1111) != 0b1111)
             {
                 throw Serde.DeserializeException.UnassignedMember();

--- a/test/Serde.Generation.Test/test_output/ProxyTests.NonEmptyProxyAsMemberProxy/Container.ISerde.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/ProxyTests.NonEmptyProxyAsMemberProxy/Container.ISerde.g.verified.cs
@@ -47,6 +47,7 @@ partial class Container
                         throw new InvalidOperationException("Unexpected index: " + _l_index_);
                 }
             }
+            typeDeserialize.End(_l_serdeInfo);
             if ((_r_assignedValid & 0b1) != 0b1)
             {
                 throw Serde.DeserializeException.UnassignedMember();

--- a/test/Serde.Generation.Test/test_output/ProxyTests.NonEmptyProxyAsMemberProxy/ForeignPointProxy.ISerde.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/ProxyTests.NonEmptyProxyAsMemberProxy/ForeignPointProxy.ISerde.g.verified.cs
@@ -55,6 +55,7 @@ partial struct ForeignPointProxy
                         throw new InvalidOperationException("Unexpected index: " + _l_index_);
                 }
             }
+            typeDeserialize.End(_l_serdeInfo);
             if ((_r_assignedValid & 0b11) != 0b11)
             {
                 throw Serde.DeserializeException.UnassignedMember();

--- a/test/Serde.Generation.Test/test_output/ProxyTests.NonEmptyProxyWithExplicitConversion/ForeignPointProxy.ISerde.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/ProxyTests.NonEmptyProxyWithExplicitConversion/ForeignPointProxy.ISerde.g.verified.cs
@@ -55,6 +55,7 @@ partial struct ForeignPointProxy
                         throw new InvalidOperationException("Unexpected index: " + _l_index_);
                 }
             }
+            typeDeserialize.End(_l_serdeInfo);
             if ((_r_assignedValid & 0b11) != 0b11)
             {
                 throw Serde.DeserializeException.UnassignedMember();

--- a/test/Serde.Generation.Test/test_output/ProxyTests.PointWrap/PointWrap.ISerde.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/ProxyTests.PointWrap/PointWrap.ISerde.g.verified.cs
@@ -54,6 +54,7 @@ partial struct PointWrap
                         throw new InvalidOperationException("Unexpected index: " + _l_index_);
                 }
             }
+            typeDeserialize.End(_l_serdeInfo);
             if ((_r_assignedValid & 0b11) != 0b11)
             {
                 throw Serde.DeserializeException.UnassignedMember();

--- a/test/Serde.Generation.Test/test_output/ProxyTests.PositionalRecordDeserialize/R.IDeserialize.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/ProxyTests.PositionalRecordDeserialize/R.IDeserialize.g.verified.cs
@@ -46,6 +46,7 @@ partial record R
                         throw new InvalidOperationException("Unexpected index: " + _l_index_);
                 }
             }
+            typeDeserialize.End(_l_serdeInfo);
             if ((_r_assignedValid & 0b11) != 0b11)
             {
                 throw Serde.DeserializeException.UnassignedMember();

--- a/test/Serde.Generation.Test/test_output/ProxyTests.RecursiveType/Test.Parent.ISerde.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/ProxyTests.RecursiveType/Test.Parent.ISerde.g.verified.cs
@@ -50,6 +50,7 @@ partial record Parent
                         throw new InvalidOperationException("Unexpected index: " + _l_index_);
                 }
             }
+            typeDeserialize.End(_l_serdeInfo);
             if ((_r_assignedValid & 0b1) != 0b1)
             {
                 throw Serde.DeserializeException.UnassignedMember();

--- a/test/Serde.Generation.Test/test_output/ProxyTests.RecursiveType/Test.RecursiveWrap.ISerde.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/ProxyTests.RecursiveType/Test.RecursiveWrap.ISerde.g.verified.cs
@@ -50,6 +50,7 @@ partial class RecursiveWrap
                         throw new InvalidOperationException("Unexpected index: " + _l_index_);
                 }
             }
+            typeDeserialize.End(_l_serdeInfo);
             if ((_r_assignedValid & 0b0) != 0b0)
             {
                 throw Serde.DeserializeException.UnassignedMember();

--- a/test/Serde.Generation.Test/test_output/ProxyTests.SerdeMemberOptionsTakesPrecedenceOverUseProxy/C.ISerde.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/ProxyTests.SerdeMemberOptionsTakesPrecedenceOverUseProxy/C.ISerde.g.verified.cs
@@ -47,6 +47,7 @@ partial class C
                         throw new InvalidOperationException("Unexpected index: " + _l_index_);
                 }
             }
+            typeDeserialize.End(_l_serdeInfo);
             if ((_r_assignedValid & 0b1) != 0b1)
             {
                 throw Serde.DeserializeException.UnassignedMember();

--- a/test/Serde.Generation.Test/test_output/ProxyTests.SerdeMemberOptionsTakesPrecedenceOverUseProxy/Proxy1.ISerde.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/ProxyTests.SerdeMemberOptionsTakesPrecedenceOverUseProxy/Proxy1.ISerde.g.verified.cs
@@ -68,6 +68,7 @@ partial class Proxy1
                         throw new InvalidOperationException("Unexpected index: " + _l_index_);
                 }
             }
+            typeDeserialize.End(_l_serdeInfo);
             if ((_r_assignedValid & 0b1111) != 0b1111)
             {
                 throw Serde.DeserializeException.UnassignedMember();

--- a/test/Serde.Generation.Test/test_output/ProxyTests.SerdeMemberOptionsTakesPrecedenceOverUseProxy/Proxy2.ISerde.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/ProxyTests.SerdeMemberOptionsTakesPrecedenceOverUseProxy/Proxy2.ISerde.g.verified.cs
@@ -68,6 +68,7 @@ partial class Proxy2
                         throw new InvalidOperationException("Unexpected index: " + _l_index_);
                 }
             }
+            typeDeserialize.End(_l_serdeInfo);
             if ((_r_assignedValid & 0b1111) != 0b1111)
             {
                 throw Serde.DeserializeException.UnassignedMember();

--- a/test/Serde.Generation.Test/test_output/SerdeTests.CommandResponseTest/ArgumentInfo.ISerde.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/SerdeTests.CommandResponseTest/ArgumentInfo.ISerde.g.verified.cs
@@ -54,6 +54,7 @@ partial class ArgumentInfo
                         throw new InvalidOperationException("Unexpected index: " + _l_index_);
                 }
             }
+            typeDeserialize.End(_l_serdeInfo);
             if ((_r_assignedValid & 0b11) != 0b11)
             {
                 throw Serde.DeserializeException.UnassignedMember();

--- a/test/Serde.Generation.Test/test_output/SerdeTests.CommandResponseTest/CommandResponse.ISerde.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/SerdeTests.CommandResponseTest/CommandResponse.ISerde.g.verified.cs
@@ -75,6 +75,7 @@ partial class CommandResponse<TResult, TProxy>
                         throw new InvalidOperationException("Unexpected index: " + _l_index_);
                 }
             }
+            typeDeserialize.End(_l_serdeInfo);
             if ((_r_assignedValid & 0b11011) != 0b11011)
             {
                 throw Serde.DeserializeException.UnassignedMember();

--- a/test/Serde.Generation.Test/test_output/SerdeTests.DuplicateMemberOrdinalReportsError/Dupe.ISerde.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/SerdeTests.DuplicateMemberOrdinalReportsError/Dupe.ISerde.g.verified.cs
@@ -54,6 +54,7 @@ partial record Dupe
                         throw new InvalidOperationException("Unexpected index: " + _l_index_);
                 }
             }
+            typeDeserialize.End(_l_serdeInfo);
             if ((_r_assignedValid & 0b11) != 0b11)
             {
                 throw Serde.DeserializeException.UnassignedMember();

--- a/test/Serde.Generation.Test/test_output/SerdeTests.ExplicitMemberOrdinal/Reordered.ISerde.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/SerdeTests.ExplicitMemberOrdinal/Reordered.ISerde.g.verified.cs
@@ -61,6 +61,7 @@ partial record Reordered
                         throw new InvalidOperationException("Unexpected index: " + _l_index_);
                 }
             }
+            typeDeserialize.End(_l_serdeInfo);
             if ((_r_assignedValid & 0b111) != 0b111)
             {
                 throw Serde.DeserializeException.UnassignedMember();

--- a/test/Serde.Generation.Test/test_output/SerdeTests.InvalidTypeParameterProxyTest/InvalidProxyTest.ISerde.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/SerdeTests.InvalidTypeParameterProxyTest/InvalidProxyTest.ISerde.g.verified.cs
@@ -58,6 +58,7 @@ partial class InvalidProxyTest<T>
                         throw new InvalidOperationException("Unexpected index: " + _l_index_);
                 }
             }
+            typeDeserialize.End(_l_serdeInfo);
             if ((_r_assignedValid & 0b0) != 0b0)
             {
                 throw Serde.DeserializeException.UnassignedMember();

--- a/test/Serde.Generation.Test/test_output/SerdeTests.NestedNullable/ComplexRecord.ISerde.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/SerdeTests.NestedNullable/ComplexRecord.ISerde.g.verified.cs
@@ -61,6 +61,7 @@ partial record ComplexRecord
                         throw new InvalidOperationException("Unexpected index: " + _l_index_);
                 }
             }
+            typeDeserialize.End(_l_serdeInfo);
             if ((_r_assignedValid & 0b1) != 0b1)
             {
                 throw Serde.DeserializeException.UnassignedMember();

--- a/test/Serde.Generation.Test/test_output/SerdeTests.NestedNullable/SimpleRecord.ISerde.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/SerdeTests.NestedNullable/SimpleRecord.ISerde.g.verified.cs
@@ -54,6 +54,7 @@ partial record SimpleRecord
                         throw new InvalidOperationException("Unexpected index: " + _l_index_);
                 }
             }
+            typeDeserialize.End(_l_serdeInfo);
             if ((_r_assignedValid & 0b11) != 0b11)
             {
                 throw Serde.DeserializeException.UnassignedMember();

--- a/test/Serde.Generation.Test/test_output/SerdeTests.OrdinalOnEnumMemberReportsError/ColorProxy.ISerde.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/SerdeTests.OrdinalOnEnumMemberReportsError/ColorProxy.ISerde.g.verified.cs
@@ -23,22 +23,28 @@ partial class ColorProxy : Serde.ISerde<Color>
     Color IDeserialize<Color>.Deserialize(IDeserializer deserializer)
     {
         var serdeInfo = global::Serde.SerdeInfoProvider.GetInfo(this);
-        using var de = deserializer.ReadType(serdeInfo);
+        var de = deserializer.ReadType(serdeInfo);
         var (index, errorName) = de.TryReadIndexWithName(serdeInfo);
         if (index == ITypeDeserializer.IndexNotFound)
         {
             throw Serde.DeserializeException.UnknownMember(errorName!, serdeInfo);
         }
+        Color _l_result;
         if (index == ITypeDeserializer.EndOfType)
         {
             // Assume we want to read the underlying value
-            return (Color)de.ReadI32(serdeInfo, index);
+            _l_result = (Color)de.ReadI32(serdeInfo, index);
         }
-        return index switch {
-            0 => Color.Red,
-            1 => Color.Green,
-            2 => Color.Blue,
-            _ => throw new InvalidOperationException($"Unexpected index: {index}")
-        };
+        else
+        {
+            _l_result = index switch {
+                0 => Color.Red,
+                1 => Color.Green,
+                2 => Color.Blue,
+                _ => throw new InvalidOperationException($"Unexpected index: {index}")
+            };
+        }
+        de.End(serdeInfo);
+        return _l_result;
     }
 }

--- a/test/Serde.Generation.Test/test_output/SerdeTests.OrdinalOnNonPublicMemberReportsError/NonPublic.ISerde.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/SerdeTests.OrdinalOnNonPublicMemberReportsError/NonPublic.ISerde.g.verified.cs
@@ -47,6 +47,7 @@ partial record NonPublic
                         throw new InvalidOperationException("Unexpected index: " + _l_index_);
                 }
             }
+            typeDeserialize.End(_l_serdeInfo);
             if ((_r_assignedValid & 0b1) != 0b1)
             {
                 throw Serde.DeserializeException.UnassignedMember();

--- a/test/Serde.Generation.Test/test_output/SerdeTests.PartialMemberOrdinalReportsError/Partial.ISerde.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/SerdeTests.PartialMemberOrdinalReportsError/Partial.ISerde.g.verified.cs
@@ -54,6 +54,7 @@ partial record Partial
                         throw new InvalidOperationException("Unexpected index: " + _l_index_);
                 }
             }
+            typeDeserialize.End(_l_serdeInfo);
             if ((_r_assignedValid & 0b11) != 0b11)
             {
                 throw Serde.DeserializeException.UnassignedMember();

--- a/test/Serde.Generation.Test/test_output/SerdeTests.SparseMemberOrdinals/Sparse.ISerde.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/SerdeTests.SparseMemberOrdinals/Sparse.ISerde.g.verified.cs
@@ -61,6 +61,7 @@ partial record Sparse
                         throw new InvalidOperationException("Unexpected index: " + _l_index_);
                 }
             }
+            typeDeserialize.End(_l_serdeInfo);
             if ((_r_assignedValid & 0b111) != 0b111)
             {
                 throw Serde.DeserializeException.UnassignedMember();

--- a/test/Serde.Generation.Test/test_output/SerializeTests.NestedExplicitSerializeWrapper/OPTSWrap.ISerde.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/SerializeTests.NestedExplicitSerializeWrapper/OPTSWrap.ISerde.g.verified.cs
@@ -68,6 +68,7 @@ partial class OPTSWrap
                         throw new InvalidOperationException("Unexpected index: " + _l_index_);
                 }
             }
+            typeDeserialize.End(_l_serdeInfo);
             if ((_r_assignedValid & 0b1111) != 0b1111)
             {
                 throw Serde.DeserializeException.UnassignedMember();

--- a/test/Serde.Generation.Test/test_output/SerializeTests.NestedExplicitSerializeWrapper/S.ISerde.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/SerializeTests.NestedExplicitSerializeWrapper/S.ISerde.g.verified.cs
@@ -47,6 +47,7 @@ partial struct S
                         throw new InvalidOperationException("Unexpected index: " + _l_index_);
                 }
             }
+            typeDeserialize.End(_l_serdeInfo);
             if ((_r_assignedValid & 0b1) != 0b1)
             {
                 throw Serde.DeserializeException.UnassignedMember();

--- a/test/Serde.Test/CustomImplTests.cs
+++ b/test/Serde.Test/CustomImplTests.cs
@@ -56,6 +56,7 @@ public sealed partial class CustomImplTests
                 }
             }
 
+            deType.End(fieldMap);
             return new RgbWithFieldMap { Red = red, Green = green, Blue = blue };
         }
     }

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Json.Test.InvalidJsonTests.ClassWithDictionaryOfIntArray.IDeserialize.g.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Json.Test.InvalidJsonTests.ClassWithDictionaryOfIntArray.IDeserialize.g.cs
@@ -44,6 +44,7 @@ partial class InvalidJsonTests
                             throw new InvalidOperationException("Unexpected index: " + _l_index_);
                     }
                 }
+                typeDeserialize.End(_l_serdeInfo);
                 if ((_r_assignedValid & 0b1) != 0b1)
                 {
                     throw Serde.DeserializeException.UnassignedMember();

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Json.Test.InvalidJsonTests.ClassWithDictionaryOfPoco.IDeserialize.g.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Json.Test.InvalidJsonTests.ClassWithDictionaryOfPoco.IDeserialize.g.cs
@@ -44,6 +44,7 @@ partial class InvalidJsonTests
                             throw new InvalidOperationException("Unexpected index: " + _l_index_);
                     }
                 }
+                typeDeserialize.End(_l_serdeInfo);
                 if ((_r_assignedValid & 0b1) != 0b1)
                 {
                     throw Serde.DeserializeException.UnassignedMember();

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Json.Test.InvalidJsonTests.ClassWithDictionaryOfPocoList.IDeserialize.g.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Json.Test.InvalidJsonTests.ClassWithDictionaryOfPocoList.IDeserialize.g.cs
@@ -44,6 +44,7 @@ partial class InvalidJsonTests
                             throw new InvalidOperationException("Unexpected index: " + _l_index_);
                     }
                 }
+                typeDeserialize.End(_l_serdeInfo);
                 if ((_r_assignedValid & 0b1) != 0b1)
                 {
                     throw Serde.DeserializeException.UnassignedMember();

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Json.Test.InvalidJsonTests.ClassWithInt.IDeserialize.g.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Json.Test.InvalidJsonTests.ClassWithInt.IDeserialize.g.cs
@@ -44,6 +44,7 @@ partial class InvalidJsonTests
                             throw new InvalidOperationException("Unexpected index: " + _l_index_);
                     }
                 }
+                typeDeserialize.End(_l_serdeInfo);
                 if ((_r_assignedValid & 0b1) != 0b1)
                 {
                     throw Serde.DeserializeException.UnassignedMember();

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Json.Test.InvalidJsonTests.ClassWithIntArray.IDeserialize.g.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Json.Test.InvalidJsonTests.ClassWithIntArray.IDeserialize.g.cs
@@ -44,6 +44,7 @@ partial class InvalidJsonTests
                             throw new InvalidOperationException("Unexpected index: " + _l_index_);
                     }
                 }
+                typeDeserialize.End(_l_serdeInfo);
                 if ((_r_assignedValid & 0b1) != 0b1)
                 {
                     throw Serde.DeserializeException.UnassignedMember();

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Json.Test.InvalidJsonTests.ClassWithIntList.IDeserialize.g.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Json.Test.InvalidJsonTests.ClassWithIntList.IDeserialize.g.cs
@@ -44,6 +44,7 @@ partial class InvalidJsonTests
                             throw new InvalidOperationException("Unexpected index: " + _l_index_);
                     }
                 }
+                typeDeserialize.End(_l_serdeInfo);
                 if ((_r_assignedValid & 0b1) != 0b1)
                 {
                     throw Serde.DeserializeException.UnassignedMember();

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Json.Test.InvalidJsonTests.ClassWithPoco.IDeserialize.g.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Json.Test.InvalidJsonTests.ClassWithPoco.IDeserialize.g.cs
@@ -44,6 +44,7 @@ partial class InvalidJsonTests
                             throw new InvalidOperationException("Unexpected index: " + _l_index_);
                     }
                 }
+                typeDeserialize.End(_l_serdeInfo);
                 if ((_r_assignedValid & 0b1) != 0b1)
                 {
                     throw Serde.DeserializeException.UnassignedMember();

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Json.Test.InvalidJsonTests.ClassWithPocoArray.IDeserialize.g.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Json.Test.InvalidJsonTests.ClassWithPocoArray.IDeserialize.g.cs
@@ -44,6 +44,7 @@ partial class InvalidJsonTests
                             throw new InvalidOperationException("Unexpected index: " + _l_index_);
                     }
                 }
+                typeDeserialize.End(_l_serdeInfo);
                 if ((_r_assignedValid & 0b1) != 0b1)
                 {
                     throw Serde.DeserializeException.UnassignedMember();

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Json.Test.InvalidJsonTests.NoComma.IDeserialize.g.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Json.Test.InvalidJsonTests.NoComma.IDeserialize.g.cs
@@ -50,6 +50,7 @@ partial class InvalidJsonTests
                             throw new InvalidOperationException("Unexpected index: " + _l_index_);
                     }
                 }
+                typeDeserialize.End(_l_serdeInfo);
                 if ((_r_assignedValid & 0b11) != 0b11)
                 {
                     throw Serde.DeserializeException.UnassignedMember();

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Json.Test.InvalidJsonTests.PocoWithParameterizedCtor.IDeserialize.g.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Json.Test.InvalidJsonTests.PocoWithParameterizedCtor.IDeserialize.g.cs
@@ -44,6 +44,7 @@ partial class InvalidJsonTests
                             throw new InvalidOperationException("Unexpected index: " + _l_index_);
                     }
                 }
+                typeDeserialize.End(_l_serdeInfo);
                 if ((_r_assignedValid & 0b1) != 0b1)
                 {
                     throw Serde.DeserializeException.UnassignedMember();

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Json.Test.InvalidJsonTests.SkipClass.IDeserialize.g.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Json.Test.InvalidJsonTests.SkipClass.IDeserialize.g.cs
@@ -44,6 +44,7 @@ partial class InvalidJsonTests
                             throw new InvalidOperationException("Unexpected index: " + _l_index_);
                     }
                 }
+                typeDeserialize.End(_l_serdeInfo);
                 if ((_r_assignedValid & 0b1) != 0b1)
                 {
                     throw Serde.DeserializeException.UnassignedMember();

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Json.Test.Poco.IDeserialize.g.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Json.Test.Poco.IDeserialize.g.cs
@@ -42,6 +42,7 @@ partial class Poco
                         throw new InvalidOperationException("Unexpected index: " + _l_index_);
                 }
             }
+            typeDeserialize.End(_l_serdeInfo);
             if ((_r_assignedValid & 0b1) != 0b1)
             {
                 throw Serde.DeserializeException.UnassignedMember();

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Json.Test.PocoDictionary.IDeserialize.g.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Json.Test.PocoDictionary.IDeserialize.g.cs
@@ -42,6 +42,7 @@ partial class PocoDictionary
                         throw new InvalidOperationException("Unexpected index: " + _l_index_);
                 }
             }
+            typeDeserialize.End(_l_serdeInfo);
             if ((_r_assignedValid & 0b1) != 0b1)
             {
                 throw Serde.DeserializeException.UnassignedMember();

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Json.Test.Test.ISerde.g.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Json.Test.Test.ISerde.g.cs
@@ -70,6 +70,7 @@ partial class Test
                         throw new InvalidOperationException("Unexpected index: " + _l_index_);
                 }
             }
+            typeDeserialize.End(_l_serdeInfo);
             if ((_r_assignedValid & 0b1111) != 0b1111)
             {
                 throw Serde.DeserializeException.UnassignedMember();

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Json.Test.Vector2Proxy.ISerde.g.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Json.Test.Vector2Proxy.ISerde.g.cs
@@ -56,6 +56,7 @@ partial class Vector2Proxy
                         throw new InvalidOperationException("Unexpected index: " + _l_index_);
                 }
             }
+            typeDeserialize.End(_l_serdeInfo);
             if ((_r_assignedValid & 0b11) != 0b11)
             {
                 throw Serde.DeserializeException.UnassignedMember();

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Json.Test.Vector2Proxy2.ISerde.g.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Json.Test.Vector2Proxy2.ISerde.g.cs
@@ -56,6 +56,7 @@ partial class Vector2Proxy2
                         throw new InvalidOperationException("Unexpected index: " + _l_index_);
                 }
             }
+            typeDeserialize.End(_l_serdeInfo);
             if ((_r_assignedValid & 0b11) != 0b11)
             {
                 throw Serde.DeserializeException.UnassignedMember();

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Json.Test.Vector3Proxy.ISerde.g.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Json.Test.Vector3Proxy.ISerde.g.cs
@@ -63,6 +63,7 @@ partial class Vector3Proxy
                         throw new InvalidOperationException("Unexpected index: " + _l_index_);
                 }
             }
+            typeDeserialize.End(_l_serdeInfo);
             if ((_r_assignedValid & 0b111) != 0b111)
             {
                 throw Serde.DeserializeException.UnassignedMember();

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Json.Test.Vector4Proxy.ISerde.g.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Json.Test.Vector4Proxy.ISerde.g.cs
@@ -70,6 +70,7 @@ partial class Vector4Proxy
                         throw new InvalidOperationException("Unexpected index: " + _l_index_);
                 }
             }
+            typeDeserialize.End(_l_serdeInfo);
             if ((_r_assignedValid & 0b1111) != 0b1111)
             {
                 throw Serde.DeserializeException.UnassignedMember();

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.AllInOne.ColorEnumProxy.ISerde.g.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.AllInOne.ColorEnumProxy.ISerde.g.cs
@@ -27,23 +27,29 @@ partial record AllInOne
         Serde.Test.AllInOne.ColorEnum IDeserialize<Serde.Test.AllInOne.ColorEnum>.Deserialize(IDeserializer deserializer)
         {
             var serdeInfo = global::Serde.SerdeInfoProvider.GetInfo(this);
-            using var de = deserializer.ReadType(serdeInfo);
+            var de = deserializer.ReadType(serdeInfo);
             var (index, errorName) = de.TryReadIndexWithName(serdeInfo);
             if (index == ITypeDeserializer.IndexNotFound)
             {
                 throw Serde.DeserializeException.UnknownMember(errorName!, serdeInfo);
             }
+            Serde.Test.AllInOne.ColorEnum _l_result;
             if (index == ITypeDeserializer.EndOfType)
             {
                 // Assume we want to read the underlying value
-                return (Serde.Test.AllInOne.ColorEnum)de.ReadI32(serdeInfo, index);
+                _l_result = (Serde.Test.AllInOne.ColorEnum)de.ReadI32(serdeInfo, index);
             }
-            return index switch {
-                0 => Serde.Test.AllInOne.ColorEnum.Red,
-                1 => Serde.Test.AllInOne.ColorEnum.Blue,
-                2 => Serde.Test.AllInOne.ColorEnum.Green,
-                _ => throw new InvalidOperationException($"Unexpected index: {index}")
-            };
+            else
+            {
+                _l_result = index switch {
+                    0 => Serde.Test.AllInOne.ColorEnum.Red,
+                    1 => Serde.Test.AllInOne.ColorEnum.Blue,
+                    2 => Serde.Test.AllInOne.ColorEnum.Green,
+                    _ => throw new InvalidOperationException($"Unexpected index: {index}")
+                };
+            }
+            de.End(serdeInfo);
+            return _l_result;
         }
     }
 }

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.AllInOne.IDeserialize.g.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.AllInOne.IDeserialize.g.cs
@@ -186,6 +186,7 @@ partial record AllInOne
                         throw new InvalidOperationException("Unexpected index: " + _l_index_);
                 }
             }
+            typeDeserialize.End(_l_serdeInfo);
             if ((_r_assignedValid & 0b1111101111111111111111111) != 0b1111101111111111111111111)
             {
                 throw Serde.DeserializeException.UnassignedMember();

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.AsTests.Point.ISerde.g.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.AsTests.Point.ISerde.g.cs
@@ -58,6 +58,7 @@ partial class AsTests
                             throw new InvalidOperationException("Unexpected index: " + _l_index_);
                     }
                 }
+                typeDeserialize.End(_l_serdeInfo);
                 if ((_r_assignedValid & 0b11) != 0b11)
                 {
                     throw Serde.DeserializeException.UnassignedMember();

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.DuplicateKeyTests.SimpleType.IDeserialize.g.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.DuplicateKeyTests.SimpleType.IDeserialize.g.cs
@@ -50,6 +50,7 @@ partial class DuplicateKeyTests
                             throw new InvalidOperationException("Unexpected index: " + _l_index_);
                     }
                 }
+                typeDeserialize.End(_l_serdeInfo);
                 if ((_r_assignedValid & 0b11) != 0b11)
                 {
                     throw Serde.DeserializeException.UnassignedMember();

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.DuplicateKeyTests.SimpleTypeAllowDuplicates.IDeserialize.g.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.DuplicateKeyTests.SimpleTypeAllowDuplicates.IDeserialize.g.cs
@@ -50,6 +50,7 @@ partial class DuplicateKeyTests
                             throw new InvalidOperationException("Unexpected index: " + _l_index_);
                     }
                 }
+                typeDeserialize.End(_l_serdeInfo);
                 if ((_r_assignedValid & 0b11) != 0b11)
                 {
                     throw Serde.DeserializeException.UnassignedMember();

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.GenericWrapperTests.CustomArrayWrapExplicitOnType.ISerde.g.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.GenericWrapperTests.CustomArrayWrapExplicitOnType.ISerde.g.cs
@@ -51,6 +51,7 @@ partial class GenericWrapperTests
                             throw new InvalidOperationException("Unexpected index: " + _l_index_);
                     }
                 }
+                typeDeserialize.End(_l_serdeInfo);
                 if ((_r_assignedValid & 0b1) != 0b1)
                 {
                     throw Serde.DeserializeException.UnassignedMember();

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.GenericWrapperTests.CustomImArrayExplicitWrapOnMember.ISerde.g.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.GenericWrapperTests.CustomImArrayExplicitWrapOnMember.ISerde.g.cs
@@ -51,6 +51,7 @@ partial class GenericWrapperTests
                             throw new InvalidOperationException("Unexpected index: " + _l_index_);
                     }
                 }
+                typeDeserialize.End(_l_serdeInfo);
                 if ((_r_assignedValid & 0b1) != 0b1)
                 {
                     throw Serde.DeserializeException.UnassignedMember();

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonDeserializeTests.BasicDU.IDeserialize.g.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonDeserializeTests.BasicDU.IDeserialize.g.cs
@@ -17,7 +17,7 @@ partial class JsonDeserializeTests
             Serde.Test.JsonDeserializeTests.BasicDU IDeserialize<Serde.Test.JsonDeserializeTests.BasicDU>.Deserialize(IDeserializer deserializer)
             {
                 var _l_serdeInfo = global::Serde.SerdeInfoProvider.GetInfo(this);
-                using var de = deserializer.ReadType(_l_serdeInfo);
+                var de = deserializer.ReadType(_l_serdeInfo);
                 var (index, errorName) = de.TryReadIndexWithName(_l_serdeInfo);
                 if (index == ITypeDeserializer.IndexNotFound)
                 {
@@ -34,6 +34,7 @@ partial class JsonDeserializeTests
                 {
                     throw Serde.DeserializeException.ExpectedEndOfType(index);
                 }
+                de.End(_l_serdeInfo);
                 return _l_result;
             }
         }

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonDeserializeTests.BasicDU._m_AProxy.IDeserialize.g.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonDeserializeTests.BasicDU._m_AProxy.IDeserialize.g.cs
@@ -46,6 +46,7 @@ partial class JsonDeserializeTests
                                 throw new InvalidOperationException("Unexpected index: " + _l_index_);
                         }
                     }
+                    typeDeserialize.End(_l_serdeInfo);
                     if ((_r_assignedValid & 0b1) != 0b1)
                     {
                         throw Serde.DeserializeException.UnassignedMember();

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonDeserializeTests.BasicDU._m_BProxy.IDeserialize.g.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonDeserializeTests.BasicDU._m_BProxy.IDeserialize.g.cs
@@ -46,6 +46,7 @@ partial class JsonDeserializeTests
                                 throw new InvalidOperationException("Unexpected index: " + _l_index_);
                         }
                     }
+                    typeDeserialize.End(_l_serdeInfo);
                     if ((_r_assignedValid & 0b1) != 0b1)
                     {
                         throw Serde.DeserializeException.UnassignedMember();

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonDeserializeTests.DenyUnknown.IDeserialize.g.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonDeserializeTests.DenyUnknown.IDeserialize.g.cs
@@ -49,6 +49,7 @@ partial class JsonDeserializeTests
                             throw new InvalidOperationException("Unexpected index: " + _l_index_);
                     }
                 }
+                typeDeserialize.End(_l_serdeInfo);
                 if ((_r_assignedValid & 0b1) != 0b1)
                 {
                     throw Serde.DeserializeException.UnassignedMember();

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonDeserializeTests.ExtraMembers.IDeserialize.g.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonDeserializeTests.ExtraMembers.IDeserialize.g.cs
@@ -44,6 +44,7 @@ partial class JsonDeserializeTests
                             throw new InvalidOperationException("Unexpected index: " + _l_index_);
                     }
                 }
+                typeDeserialize.End(_l_serdeInfo);
                 if ((_r_assignedValid & 0b1) != 0b1)
                 {
                     throw Serde.DeserializeException.UnassignedMember();

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonDeserializeTests.IdStruct.IDeserialize.g.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonDeserializeTests.IdStruct.IDeserialize.g.cs
@@ -44,6 +44,7 @@ partial class JsonDeserializeTests
                             throw new InvalidOperationException("Unexpected index: " + _l_index_);
                     }
                 }
+                typeDeserialize.End(_l_serdeInfo);
                 if ((_r_assignedValid & 0b1) != 0b1)
                 {
                     throw Serde.DeserializeException.UnassignedMember();

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonDeserializeTests.IdStructList.IDeserialize.g.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonDeserializeTests.IdStructList.IDeserialize.g.cs
@@ -50,6 +50,7 @@ partial class JsonDeserializeTests
                             throw new InvalidOperationException("Unexpected index: " + _l_index_);
                     }
                 }
+                typeDeserialize.End(_l_serdeInfo);
                 if ((_r_assignedValid & 0b11) != 0b11)
                 {
                     throw Serde.DeserializeException.UnassignedMember();

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonDeserializeTests.Location.IDeserialize.g.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonDeserializeTests.Location.IDeserialize.g.cs
@@ -92,6 +92,7 @@ partial class JsonDeserializeTests
                             throw new InvalidOperationException("Unexpected index: " + _l_index_);
                     }
                 }
+                typeDeserialize.End(_l_serdeInfo);
                 if ((_r_assignedValid & 0b111111111) != 0b111111111)
                 {
                     throw Serde.DeserializeException.UnassignedMember();

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonDeserializeTests.NullableFields.IDeserialize.g.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonDeserializeTests.NullableFields.IDeserialize.g.cs
@@ -50,6 +50,7 @@ partial class JsonDeserializeTests
                             throw new InvalidOperationException("Unexpected index: " + _l_index_);
                     }
                 }
+                typeDeserialize.End(_l_serdeInfo);
                 if ((_r_assignedValid & 0b10) != 0b10)
                 {
                     throw Serde.DeserializeException.UnassignedMember();

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonDeserializeTests.SetToNull.IDeserialize.g.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonDeserializeTests.SetToNull.IDeserialize.g.cs
@@ -50,6 +50,7 @@ partial class JsonDeserializeTests
                             throw new InvalidOperationException("Unexpected index: " + _l_index_);
                     }
                 }
+                typeDeserialize.End(_l_serdeInfo);
                 if ((_r_assignedValid & 0b1) != 0b1)
                 {
                     throw Serde.DeserializeException.UnassignedMember();

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonDeserializeTests.SkipDeserialize.IDeserialize.g.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonDeserializeTests.SkipDeserialize.IDeserialize.g.cs
@@ -45,6 +45,7 @@ partial class JsonDeserializeTests
                             throw new InvalidOperationException("Unexpected index: " + _l_index_);
                     }
                 }
+                typeDeserialize.End(_l_serdeInfo);
                 if ((_r_assignedValid & 0b1) != 0b1)
                 {
                     throw Serde.DeserializeException.UnassignedMember();

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonDeserializeTests.ThrowMissing.IDeserialize.g.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonDeserializeTests.ThrowMissing.IDeserialize.g.cs
@@ -50,6 +50,7 @@ partial class JsonDeserializeTests
                             throw new InvalidOperationException("Unexpected index: " + _l_index_);
                     }
                 }
+                typeDeserialize.End(_l_serdeInfo);
                 if ((_r_assignedValid & 0b11) != 0b11)
                 {
                     throw Serde.DeserializeException.UnassignedMember();

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonDeserializeTests.ThrowMissingFalse.IDeserialize.g.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonDeserializeTests.ThrowMissingFalse.IDeserialize.g.cs
@@ -50,6 +50,7 @@ partial class JsonDeserializeTests
                             throw new InvalidOperationException("Unexpected index: " + _l_index_);
                     }
                 }
+                typeDeserialize.End(_l_serdeInfo);
                 if ((_r_assignedValid & 0b1) != 0b1)
                 {
                     throw Serde.DeserializeException.UnassignedMember();

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.MaxSizeType.ISerde.g.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.MaxSizeType.ISerde.g.cs
@@ -490,6 +490,7 @@ partial struct MaxSizeType
                         throw new InvalidOperationException("Unexpected index: " + _l_index_);
                 }
             }
+            typeDeserialize.End(_l_serdeInfo);
             if ((_r_assignedValid & 0b1111111111111111111111111111111111111111111111111111111111111111) != 0b1111111111111111111111111111111111111111111111111111111111111111)
             {
                 throw Serde.DeserializeException.UnassignedMember();

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.MemberOrdinalTests.FullyOrdered.ISerde.g.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.MemberOrdinalTests.FullyOrdered.ISerde.g.cs
@@ -72,6 +72,7 @@ partial class MemberOrdinalTests
                             throw new InvalidOperationException("Unexpected index: " + _l_index_);
                     }
                 }
+                typeDeserialize.End(_l_serdeInfo);
                 if ((_r_assignedValid & 0b1111) != 0b1111)
                 {
                     throw Serde.DeserializeException.UnassignedMember();

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.MemberOrdinalTests.NoOrdinals.ISerde.g.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.MemberOrdinalTests.NoOrdinals.ISerde.g.cs
@@ -58,6 +58,7 @@ partial class MemberOrdinalTests
                             throw new InvalidOperationException("Unexpected index: " + _l_index_);
                     }
                 }
+                typeDeserialize.End(_l_serdeInfo);
                 if ((_r_assignedValid & 0b11) != 0b11)
                 {
                     throw Serde.DeserializeException.UnassignedMember();

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.MemberOrdinalTests.OrderedWithSkip.ISerde.g.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.MemberOrdinalTests.OrderedWithSkip.ISerde.g.cs
@@ -58,6 +58,7 @@ partial class MemberOrdinalTests
                             throw new InvalidOperationException("Unexpected index: " + _l_index_);
                     }
                 }
+                typeDeserialize.End(_l_serdeInfo);
                 if ((_r_assignedValid & 0b11) != 0b11)
                 {
                     throw Serde.DeserializeException.UnassignedMember();

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.MemberOrdinalTests.Reordered.ISerde.g.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.MemberOrdinalTests.Reordered.ISerde.g.cs
@@ -65,6 +65,7 @@ partial class MemberOrdinalTests
                             throw new InvalidOperationException("Unexpected index: " + _l_index_);
                     }
                 }
+                typeDeserialize.End(_l_serdeInfo);
                 if ((_r_assignedValid & 0b111) != 0b111)
                 {
                     throw Serde.DeserializeException.UnassignedMember();

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.MemberOrdinalTests.SparseOrdinals.ISerde.g.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.MemberOrdinalTests.SparseOrdinals.ISerde.g.cs
@@ -65,6 +65,7 @@ partial class MemberOrdinalTests
                             throw new InvalidOperationException("Unexpected index: " + _l_index_);
                     }
                 }
+                typeDeserialize.End(_l_serdeInfo);
                 if ((_r_assignedValid & 0b111) != 0b111)
                 {
                     throw Serde.DeserializeException.UnassignedMember();

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.RoundtripTests.ForeignPointProxy.ISerde.g.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.RoundtripTests.ForeignPointProxy.ISerde.g.cs
@@ -59,6 +59,7 @@ partial class RoundtripTests
                             throw new InvalidOperationException("Unexpected index: " + _l_index_);
                     }
                 }
+                typeDeserialize.End(_l_serdeInfo);
                 if ((_r_assignedValid & 0b11) != 0b11)
                 {
                     throw Serde.DeserializeException.UnassignedMember();

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.RoundtripTests.Point.ISerde.g.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.RoundtripTests.Point.ISerde.g.cs
@@ -58,6 +58,7 @@ partial class RoundtripTests
                             throw new InvalidOperationException("Unexpected index: " + _l_index_);
                     }
                 }
+                typeDeserialize.End(_l_serdeInfo);
                 if ((_r_assignedValid & 0b11) != 0b11)
                 {
                     throw Serde.DeserializeException.UnassignedMember();

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.SerdeInfoTests.EmptyRecord.IDeserialize.g.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.SerdeInfoTests.EmptyRecord.IDeserialize.g.cs
@@ -38,6 +38,7 @@ partial class SerdeInfoTests
                             throw new InvalidOperationException("Unexpected index: " + _l_index_);
                     }
                 }
+                typeDeserialize.End(_l_serdeInfo);
                 if ((_r_assignedValid & 0b0) != 0b0)
                 {
                     throw Serde.DeserializeException.UnassignedMember();

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.SerdeInfoTests.RgbProxy.IDeserialize.g.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.SerdeInfoTests.RgbProxy.IDeserialize.g.cs
@@ -56,6 +56,7 @@ partial class SerdeInfoTests
                             throw new InvalidOperationException("Unexpected index: " + _l_index_);
                     }
                 }
+                typeDeserialize.End(_l_serdeInfo);
                 if ((_r_assignedValid & 0b111) != 0b111)
                 {
                     throw Serde.DeserializeException.UnassignedMember();

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.SerdeInfoTests.UnionBase.IDeserialize.g.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.SerdeInfoTests.UnionBase.IDeserialize.g.cs
@@ -17,7 +17,7 @@ partial class SerdeInfoTests
             Serde.Test.SerdeInfoTests.UnionBase IDeserialize<Serde.Test.SerdeInfoTests.UnionBase>.Deserialize(IDeserializer deserializer)
             {
                 var _l_serdeInfo = global::Serde.SerdeInfoProvider.GetInfo(this);
-                using var de = deserializer.ReadType(_l_serdeInfo);
+                var de = deserializer.ReadType(_l_serdeInfo);
                 var (index, errorName) = de.TryReadIndexWithName(_l_serdeInfo);
                 if (index == ITypeDeserializer.IndexNotFound)
                 {
@@ -34,6 +34,7 @@ partial class SerdeInfoTests
                 {
                     throw Serde.DeserializeException.ExpectedEndOfType(index);
                 }
+                de.End(_l_serdeInfo);
                 return _l_result;
             }
         }

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.SerdeInfoTests.UnionBase._m_AProxy.IDeserialize.g.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.SerdeInfoTests.UnionBase._m_AProxy.IDeserialize.g.cs
@@ -40,6 +40,7 @@ partial class SerdeInfoTests
                                 throw new InvalidOperationException("Unexpected index: " + _l_index_);
                         }
                     }
+                    typeDeserialize.End(_l_serdeInfo);
                     if ((_r_assignedValid & 0b0) != 0b0)
                     {
                         throw Serde.DeserializeException.UnassignedMember();

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.SerdeInfoTests.UnionBase._m_BProxy.IDeserialize.g.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.SerdeInfoTests.UnionBase._m_BProxy.IDeserialize.g.cs
@@ -40,6 +40,7 @@ partial class SerdeInfoTests
                                 throw new InvalidOperationException("Unexpected index: " + _l_index_);
                         }
                     }
+                    typeDeserialize.End(_l_serdeInfo);
                     if ((_r_assignedValid & 0b0) != 0b0)
                     {
                         throw Serde.DeserializeException.UnassignedMember();

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.TupleTests.TupleHolder.ISerde.g.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.TupleTests.TupleHolder.ISerde.g.cs
@@ -65,6 +65,7 @@ partial class TupleTests
                             throw new InvalidOperationException("Unexpected index: " + _l_index_);
                     }
                 }
+                typeDeserialize.End(_l_serdeInfo);
                 if ((_r_assignedValid & 0b111) != 0b111)
                 {
                     throw Serde.DeserializeException.UnassignedMember();


### PR DESCRIPTION
Using IDisposable is problematic because the main deserializer might want to implement ITypeDeserializer and IDeserializer. That creates a conflict because the type can't have two dispose methods. Having a dedicated End method is clearer and creates fewer conflicts.