### PR TITLE
Add optimization for class types

### DIFF
--- a/src/serde/IDeserializer.cs
+++ b/src/serde/IDeserializer.cs
@@ -134,4 +134,12 @@ public interface ITypeDeserializer
     /// cref="ITypeDeserializer" /> should not be used again.
     /// </summary>
     void End(ISerdeInfo info) { }
+
+    // Non-virtual members
+    public sealed T ReadValue<T, TProvider>(ISerdeInfo info, int index)
+        where T : class?
+        where TProvider : IDeserializeProvider<T>
+    {
+        return ReadValue(info, index, TProvider.Instance);
+    }
 }

--- a/src/serde/PublicApi.cssig
+++ b/src/serde/PublicApi.cssig
@@ -493,6 +493,7 @@ namespace Serde
         System.Int128 ReadI128(Serde.ISerdeInfo info, int index);
         System.TimeOnly ReadTimeOnly(Serde.ISerdeInfo info, int index);
         System.UInt128 ReadU128(Serde.ISerdeInfo info, int index);
+        T ReadValue<T, TProvider>(Serde.ISerdeInfo info, int index) where T : class? where TProvider : Serde.IDeserializeProvider<T>;
         T ReadValue<T>(Serde.ISerdeInfo info, int index, Serde.IDeserialize<T> deserialize) where T : class?;
         bool ReadBool(Serde.ISerdeInfo info, int index);
         byte ReadU8(Serde.ISerdeInfo info, int index);

--- a/test/Serde.Generation.Test/test_output/ProxyTests.ExplicitInvalidGenericWrapper/FinalDiagnostics.verified.txt
+++ b/test/Serde.Generation.Test/test_output/ProxyTests.ExplicitInvalidGenericWrapper/FinalDiagnostics.verified.txt
@@ -1,5 +1,16 @@
 ﻿[
   {
+    "Id": "CS0452",
+    "Title": "",
+    "Severity": "Error",
+    "WarningLevel": "0",
+    "Location": "SerdeGenerator/Serde.SerdeImplRoslynGenerator/Container.IDeserialize.g.cs: (31,52)-(31,79)",
+    "HelpLink": "https://msdn.microsoft.com/query/roslyn.query?appId=roslyn&k=k(CS0452)",
+    "MessageFormat": "The type '{2}' must be a reference type in order to use it as parameter '{1}' in the generic type or method '{0}'",
+    "Message": "The type 'Original?' must be a reference type in order to use it as parameter 'T' in the generic type or method 'ITypeDeserializer.ReadValue<T, TProvider>(ISerdeInfo, int)'",
+    "Category": "Compiler"
+  },
+  {
     "Id": "CS0311",
     "Title": "",
     "Severity": "Error",
@@ -7,7 +18,7 @@
     "Location": "SerdeGenerator/Serde.SerdeImplRoslynGenerator/Container.IDeserialize.g.cs: (31,52)-(31,79)",
     "HelpLink": "https://msdn.microsoft.com/query/roslyn.query?appId=roslyn&k=k(CS0311)",
     "MessageFormat": "The type '{3}' cannot be used as type parameter '{2}' in the generic type or method '{0}'. There is no implicit reference conversion from '{3}' to '{1}'.",
-    "Message": "The type 'Proxy' cannot be used as type parameter 'TProvider' in the generic type or method 'ITypeDeserializerExt.ReadValue<T, TProvider>(ITypeDeserializer, ISerdeInfo, int)'. There is no implicit reference conversion from 'Proxy' to 'Serde.IDeserializeProvider<Original?>'.",
+    "Message": "The type 'Proxy' cannot be used as type parameter 'TProvider' in the generic type or method 'ITypeDeserializer.ReadValue<T, TProvider>(ISerdeInfo, int)'. There is no implicit reference conversion from 'Proxy' to 'Serde.IDeserializeProvider<Original?>'.",
     "Category": "Compiler"
   },
   {

--- a/test/Serde.Generation.Test/test_output/SerdeTests.InvalidTypeParameterProxyTest/FinalDiagnostics.verified.txt
+++ b/test/Serde.Generation.Test/test_output/SerdeTests.InvalidTypeParameterProxyTest/FinalDiagnostics.verified.txt
@@ -1,5 +1,16 @@
 ﻿[
   {
+    "Id": "CS0452",
+    "Title": "",
+    "Severity": "Error",
+    "WarningLevel": "0",
+    "Location": "SerdeGenerator/Serde.SerdeImplRoslynGenerator/InvalidProxyTest.ISerde.g.cs: (39,52)-(39,69)",
+    "HelpLink": "https://msdn.microsoft.com/query/roslyn.query?appId=roslyn&k=k(CS0452)",
+    "MessageFormat": "The type '{2}' must be a reference type in order to use it as parameter '{1}' in the generic type or method '{0}'",
+    "Message": "The type 'T' must be a reference type in order to use it as parameter 'T' in the generic type or method 'ITypeDeserializer.ReadValue<T, TProvider>(ISerdeInfo, int)'",
+    "Category": "Compiler"
+  },
+  {
     "Id": "CS0314",
     "Title": "",
     "Severity": "Error",
@@ -7,7 +18,18 @@
     "Location": "SerdeGenerator/Serde.SerdeImplRoslynGenerator/InvalidProxyTest.ISerde.g.cs: (39,52)-(39,69)",
     "HelpLink": "https://msdn.microsoft.com/query/roslyn.query?appId=roslyn&k=k(CS0314)",
     "MessageFormat": "The type '{3}' cannot be used as type parameter '{2}' in the generic type or method '{0}'. There is no boxing conversion or type parameter conversion from '{3}' to '{1}'.",
-    "Message": "The type 'T' cannot be used as type parameter 'TProvider' in the generic type or method 'ITypeDeserializerExt.ReadValue<T, TProvider>(ITypeDeserializer, ISerdeInfo, int)'. There is no boxing conversion or type parameter conversion from 'T' to 'Serde.IDeserializeProvider<T?>'.",
+    "Message": "The type 'T' cannot be used as type parameter 'TProvider' in the generic type or method 'ITypeDeserializer.ReadValue<T, TProvider>(ISerdeInfo, int)'. There is no boxing conversion or type parameter conversion from 'T' to 'Serde.IDeserializeProvider<T?>'.",
+    "Category": "Compiler"
+  },
+  {
+    "Id": "CS0452",
+    "Title": "",
+    "Severity": "Error",
+    "WarningLevel": "0",
+    "Location": "SerdeGenerator/Serde.SerdeImplRoslynGenerator/InvalidProxyTest.ISerde.g.cs: (44,52)-(44,69)",
+    "HelpLink": "https://msdn.microsoft.com/query/roslyn.query?appId=roslyn&k=k(CS0452)",
+    "MessageFormat": "The type '{2}' must be a reference type in order to use it as parameter '{1}' in the generic type or method '{0}'",
+    "Message": "The type 'T' must be a reference type in order to use it as parameter 'T' in the generic type or method 'ITypeDeserializer.ReadValue<T, TProvider>(ISerdeInfo, int)'",
     "Category": "Compiler"
   },
   {
@@ -18,7 +40,18 @@
     "Location": "SerdeGenerator/Serde.SerdeImplRoslynGenerator/InvalidProxyTest.ISerde.g.cs: (44,52)-(44,69)",
     "HelpLink": "https://msdn.microsoft.com/query/roslyn.query?appId=roslyn&k=k(CS0314)",
     "MessageFormat": "The type '{3}' cannot be used as type parameter '{2}' in the generic type or method '{0}'. There is no boxing conversion or type parameter conversion from '{3}' to '{1}'.",
-    "Message": "The type 'T' cannot be used as type parameter 'TProvider' in the generic type or method 'ITypeDeserializerExt.ReadValue<T, TProvider>(ITypeDeserializer, ISerdeInfo, int)'. There is no boxing conversion or type parameter conversion from 'T' to 'Serde.IDeserializeProvider<T?>'.",
+    "Message": "The type 'T' cannot be used as type parameter 'TProvider' in the generic type or method 'ITypeDeserializer.ReadValue<T, TProvider>(ISerdeInfo, int)'. There is no boxing conversion or type parameter conversion from 'T' to 'Serde.IDeserializeProvider<T?>'.",
+    "Category": "Compiler"
+  },
+  {
+    "Id": "CS0452",
+    "Title": "",
+    "Severity": "Error",
+    "WarningLevel": "0",
+    "Location": "SerdeGenerator/Serde.SerdeImplRoslynGenerator/InvalidProxyTest.ISerde.g.cs: (49,52)-(49,69)",
+    "HelpLink": "https://msdn.microsoft.com/query/roslyn.query?appId=roslyn&k=k(CS0452)",
+    "MessageFormat": "The type '{2}' must be a reference type in order to use it as parameter '{1}' in the generic type or method '{0}'",
+    "Message": "The type 'T' must be a reference type in order to use it as parameter 'T' in the generic type or method 'ITypeDeserializer.ReadValue<T, TProvider>(ISerdeInfo, int)'",
     "Category": "Compiler"
   },
   {
@@ -29,7 +62,7 @@
     "Location": "SerdeGenerator/Serde.SerdeImplRoslynGenerator/InvalidProxyTest.ISerde.g.cs: (49,52)-(49,69)",
     "HelpLink": "https://msdn.microsoft.com/query/roslyn.query?appId=roslyn&k=k(CS0314)",
     "MessageFormat": "The type '{3}' cannot be used as type parameter '{2}' in the generic type or method '{0}'. There is no boxing conversion or type parameter conversion from '{3}' to '{1}'.",
-    "Message": "The type 'T' cannot be used as type parameter 'TProvider' in the generic type or method 'ITypeDeserializerExt.ReadValue<T, TProvider>(ITypeDeserializer, ISerdeInfo, int)'. There is no boxing conversion or type parameter conversion from 'T' to 'Serde.IDeserializeProvider<T?>'.",
+    "Message": "The type 'T' cannot be used as type parameter 'TProvider' in the generic type or method 'ITypeDeserializer.ReadValue<T, TProvider>(ISerdeInfo, int)'. There is no boxing conversion or type parameter conversion from 'T' to 'Serde.IDeserializeProvider<T?>'.",
     "Category": "Compiler"
   }
 ]


### PR DESCRIPTION
Currently everything goes through the unconstained ReadValue extension method. This is a de-opt for reference types because there's a specialty ReadValue interface method that fuses all the interface dispatch. Adding a class-constrained instance method takes priority and re-adds the optimization.