### PR TITLE
Introduce System.Nullable fast path

### DIFF
--- a/perf/bench/DataGenerator.cs
+++ b/perf/bench/DataGenerator.cs
@@ -18,7 +18,20 @@ namespace Benchmarks
             if (typeof(T) == typeof(Guids))
                 return (T)(object)Guids.Sample;
 
+            if (typeof(T) == typeof(LocationList))
+                return (T)(object)CreateLocationList();
+
             throw new InvalidOperationException();
+
+            static LocationList CreateLocationList()
+            {
+                var list = new System.Collections.Generic.List<Location>();
+                for (int i = 0; i < 16; i++)
+                {
+                    list.Add(CreateLocation());
+                }
+                return new LocationList { Locations = list };
+            }
 
             static LoginViewModel CreateLoginViewModel() =>
                 new LoginViewModel

--- a/perf/bench/JsonToString.cs
+++ b/perf/bench/JsonToString.cs
@@ -9,6 +9,7 @@ namespace Benchmarks
 {
     [GenericTypeArguments(typeof(LoginViewModel))]
     [GenericTypeArguments(typeof(Location))]
+    [GenericTypeArguments(typeof(LocationList))]
     [GenericTypeArguments(typeof(Serde.Test.AllInOne))]
     public class SerializeToString<T>
         where T : Serde.ISerializeProvider<T>

--- a/perf/bench/SampleTypes.cs
+++ b/perf/bench/SampleTypes.cs
@@ -6,7 +6,6 @@ using Serde;
 
 namespace Benchmarks;
 
-
 // A type whose members are themselves generated reference types. Serializing each
 // element of the list goes through the synthesized ISerialize<Location>.SerializeAsField,
 // which is the path affected by routing WriteValue through SerializeAsField.

--- a/perf/bench/SampleTypes.cs
+++ b/perf/bench/SampleTypes.cs
@@ -1,9 +1,20 @@
 #nullable disable
 
 using System;
+using System.Collections.Generic;
 using Serde;
 
 namespace Benchmarks;
+
+
+// A type whose members are themselves generated reference types. Serializing each
+// element of the list goes through the synthesized ISerialize<Location>.SerializeAsField,
+// which is the path affected by routing WriteValue through SerializeAsField.
+[GenerateSerde]
+public partial record LocationList
+{
+    public List<Location> Locations { get; set; }
+}
 
 // the view models come from a real world app called "AllReady"
 [GenerateSerialize, GenerateDeserialize]

--- a/src/serde/IDeserializer.cs
+++ b/src/serde/IDeserializer.cs
@@ -8,6 +8,8 @@ public interface IDeserializer : IDisposable
     T? ReadNullableRef<T>(IDeserialize<T> deserialize)
         where T : class;
 
+    bool TryReadNull();
+
     bool ReadBool();
     char ReadChar();
     byte ReadU8();

--- a/src/serde/Proxies.cs
+++ b/src/serde/Proxies.cs
@@ -635,7 +635,7 @@ public static class NullableProxy
 
         public T? Deserialize(IDeserializer deserializer)
         {
-            if (deserializer.ReadNullableRef(EmptyStringProxy.Instance) is null)
+            if (deserializer.TryReadNull())
             {
                 return null;
             }
@@ -645,19 +645,12 @@ public static class NullableProxy
             }
         }
 
-        private class EmptyStringProxy : IDeserialize<string>
+        T? IDeserialize<T?>.DeserializeAsField(ITypeDeserializer typeDeserializer, ISerdeInfo serdeInfo, int index)
         {
-            public static readonly EmptyStringProxy Instance = new EmptyStringProxy();
-            public ISerdeInfo SerdeInfo =>
-                NullableRefProxy.De<string, StringProxy>.Instance.SerdeInfo;
-
-            public string Deserialize(IDeserializer deserializer) => "";
-
-            string IDeserialize<string>.DeserializeAsField(
-                ITypeDeserializer typeDeserializer,
-                ISerdeInfo serdeInfo,
-                int index
-            ) => "";
+            var d = typeDeserializer.ReadFieldStart(serdeInfo, index);
+            T? result = d.TryReadNull() ? null : proxy.Deserialize(d);
+            typeDeserializer.ReadFieldEnd(serdeInfo, index, d);
+            return result;
         }
     }
 }

--- a/src/serde/Proxies.cs
+++ b/src/serde/Proxies.cs
@@ -645,7 +645,11 @@ public static class NullableProxy
             }
         }
 
-        T? IDeserialize<T?>.DeserializeAsField(ITypeDeserializer typeDeserializer, ISerdeInfo serdeInfo, int index)
+        T? IDeserialize<T?>.DeserializeAsField(
+            ITypeDeserializer typeDeserializer,
+            ISerdeInfo serdeInfo,
+            int index
+        )
         {
             var d = typeDeserializer.ReadFieldStart(serdeInfo, index);
             T? result = d.TryReadNull() ? null : proxy.Deserialize(d);

--- a/src/serde/PublicApi.cssig
+++ b/src/serde/PublicApi.cssig
@@ -375,6 +375,7 @@ namespace Serde
         System.UInt128 ReadU128();
         T? ReadNullableRef<T>(Serde.IDeserialize<T> deserialize) where T : class;
         bool ReadBool();
+        bool TryReadNull();
         byte ReadU8();
         char ReadChar();
         decimal ReadDecimal();

--- a/src/serde/json/JsonDeserializer.cs
+++ b/src/serde/json/JsonDeserializer.cs
@@ -52,14 +52,26 @@ internal sealed partial class JsonDeserializer<TReader> : BaseJsonDeserializer, 
     public T? ReadNullableRef<T>(IDeserialize<T> proxy)
         where T : class
     {
+        if (TryReadNull())
+        {
+            return null;
+        }
+        else
+        {
+            return proxy.Deserialize(this);
+        }
+    }
+
+    public bool TryReadNull()
+    {
         var peek = Reader.SkipWhitespace();
         switch (ThrowIfEos(peek))
         {
             case (byte)'n' when Reader.StartsWith("null"u8):
                 Reader.Advance(4);
-                return null;
+                return true;
             default:
-                return proxy.Deserialize(this);
+                return false;
         }
     }
 

--- a/test/Serde.Generation.Test/test_output/AllInOneTest.GeneratorTest/Serde.Test.AllInOne.IDeserialize.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/AllInOneTest.GeneratorTest/Serde.Test.AllInOne.IDeserialize.g.verified.cs
@@ -35,6 +35,7 @@ partial record AllInOne
             System.Guid _l_guidfield = default!;
             string _l_escapedstringfield = default!;
             string? _l_nullstringfield = null;
+            int? _l_nullintfield = null;
             uint[] _l_uintarr = null!;
             int[][] _l_nestedarr = null!;
             byte[] _l_bytearr = null!;
@@ -157,28 +158,33 @@ partial record AllInOne
                         break;
                     case 20:
                         Serde.DeserializeException.ThrowIfDuplicate(_r_assignedValid, 20, _l_serdeInfo);
-                        _l_uintarr = typeDeserialize.ReadValue<uint[], Serde.ArrayProxy.De<uint, global::Serde.U32Proxy>>(_l_serdeInfo, _l_index_);
+                        _l_nullintfield = typeDeserialize.ReadValue<int?, Serde.NullableProxy.De<int, global::Serde.I32Proxy>>(_l_serdeInfo, _l_index_);
                         _r_assignedValid |= ((uint)1) << 20;
                         break;
                     case 21:
                         Serde.DeserializeException.ThrowIfDuplicate(_r_assignedValid, 21, _l_serdeInfo);
-                        _l_nestedarr = typeDeserialize.ReadValue<int[][], Serde.ArrayProxy.De<int[], Serde.ArrayProxy.De<int, global::Serde.I32Proxy>>>(_l_serdeInfo, _l_index_);
+                        _l_uintarr = typeDeserialize.ReadValue<uint[], Serde.ArrayProxy.De<uint, global::Serde.U32Proxy>>(_l_serdeInfo, _l_index_);
                         _r_assignedValid |= ((uint)1) << 21;
                         break;
                     case 22:
                         Serde.DeserializeException.ThrowIfDuplicate(_r_assignedValid, 22, _l_serdeInfo);
-                        _l_bytearr = typeDeserialize.ReadValue<byte[], global::Serde.ByteArrayProxy>(_l_serdeInfo, _l_index_);
+                        _l_nestedarr = typeDeserialize.ReadValue<int[][], Serde.ArrayProxy.De<int[], Serde.ArrayProxy.De<int, global::Serde.I32Proxy>>>(_l_serdeInfo, _l_index_);
                         _r_assignedValid |= ((uint)1) << 22;
                         break;
                     case 23:
                         Serde.DeserializeException.ThrowIfDuplicate(_r_assignedValid, 23, _l_serdeInfo);
-                        _l_intimm = typeDeserialize.ReadValue<System.Collections.Immutable.ImmutableArray<int>, Serde.ImmutableArrayProxy.De<int, global::Serde.I32Proxy>>(_l_serdeInfo, _l_index_);
+                        _l_bytearr = typeDeserialize.ReadValue<byte[], global::Serde.ByteArrayProxy>(_l_serdeInfo, _l_index_);
                         _r_assignedValid |= ((uint)1) << 23;
                         break;
                     case 24:
                         Serde.DeserializeException.ThrowIfDuplicate(_r_assignedValid, 24, _l_serdeInfo);
-                        _l_color = typeDeserialize.ReadValue<Serde.Test.AllInOne.ColorEnum, Serde.Test.AllInOne.ColorEnumProxy>(_l_serdeInfo, _l_index_);
+                        _l_intimm = typeDeserialize.ReadValue<System.Collections.Immutable.ImmutableArray<int>, Serde.ImmutableArrayProxy.De<int, global::Serde.I32Proxy>>(_l_serdeInfo, _l_index_);
                         _r_assignedValid |= ((uint)1) << 24;
+                        break;
+                    case 25:
+                        Serde.DeserializeException.ThrowIfDuplicate(_r_assignedValid, 25, _l_serdeInfo);
+                        _l_color = typeDeserialize.ReadValue<Serde.Test.AllInOne.ColorEnum, Serde.Test.AllInOne.ColorEnumProxy>(_l_serdeInfo, _l_index_);
+                        _r_assignedValid |= ((uint)1) << 25;
                         break;
                     case Serde.ITypeDeserializer.IndexNotFound:
                         typeDeserialize.SkipValue(_l_serdeInfo, _l_index_);
@@ -188,7 +194,7 @@ partial record AllInOne
                 }
             }
             typeDeserialize.End(_l_serdeInfo);
-            if ((_r_assignedValid & 0b1111101111111111111111111) != 0b1111101111111111111111111)
+            if ((_r_assignedValid & 0b11111001111111111111111111) != 0b11111001111111111111111111)
             {
                 throw Serde.DeserializeException.UnassignedMember();
             }
@@ -213,6 +219,7 @@ partial record AllInOne
                 GuidField = _l_guidfield,
                 EscapedStringField = _l_escapedstringfield,
                 NullStringField = _l_nullstringfield,
+                NullIntField = _l_nullintfield,
                 UIntArr = _l_uintarr,
                 NestedArr = _l_nestedarr,
                 ByteArr = _l_bytearr,

--- a/test/Serde.Generation.Test/test_output/AllInOneTest.GeneratorTest/Serde.Test.AllInOne.ISerdeInfoProvider.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/AllInOneTest.GeneratorTest/Serde.Test.AllInOne.ISerdeInfoProvider.g.verified.cs
@@ -30,6 +30,7 @@ partial record AllInOne
             new("guidField", global::Serde.SerdeInfoProvider.GetSerializeInfo<System.Guid, global::Serde.GuidProxy>()),
             new("escapedStringField", global::Serde.SerdeInfoProvider.GetSerializeInfo<string, global::Serde.StringProxy>()),
             new("nullStringField", global::Serde.SerdeInfoProvider.GetSerializeInfo<string?, Serde.NullableRefProxy.Ser<string, global::Serde.StringProxy>>()),
+            new("nullIntField", global::Serde.SerdeInfoProvider.GetSerializeInfo<int?, Serde.NullableProxy.Ser<int, global::Serde.I32Proxy>>()),
             new("uIntArr", global::Serde.SerdeInfoProvider.GetSerializeInfo<uint[], Serde.ArrayProxy.Ser<uint, global::Serde.U32Proxy>>()),
             new("nestedArr", global::Serde.SerdeInfoProvider.GetSerializeInfo<int[][], Serde.ArrayProxy.Ser<int[], Serde.ArrayProxy.Ser<int, global::Serde.I32Proxy>>>()),
             new("byteArr", global::Serde.SerdeInfoProvider.GetSerializeInfo<byte[], global::Serde.ByteArrayProxy>()),

--- a/test/Serde.Generation.Test/test_output/AllInOneTest.GeneratorTest/Serde.Test.AllInOne.ISerialize.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/AllInOneTest.GeneratorTest/Serde.Test.AllInOne.ISerialize.g.verified.cs
@@ -37,11 +37,12 @@ partial record AllInOne
             _l_type.WriteGuid(_l_info, 17, value.GuidField);
             _l_type.WriteString(_l_info, 18, value.EscapedStringField);
             _l_type.WriteStringIfNotNull(_l_info, 19, value.NullStringField);
-            _l_type.WriteValue<uint[], Serde.ArrayProxy.Ser<uint, global::Serde.U32Proxy>>(_l_info, 20, value.UIntArr);
-            _l_type.WriteValue<int[][], Serde.ArrayProxy.Ser<int[], Serde.ArrayProxy.Ser<int, global::Serde.I32Proxy>>>(_l_info, 21, value.NestedArr);
-            _l_type.WriteValue<byte[], global::Serde.ByteArrayProxy>(_l_info, 22, value.ByteArr);
-            _l_type.WriteValue<System.Collections.Immutable.ImmutableArray<int>, Serde.ImmutableArrayProxy.Ser<int, global::Serde.I32Proxy>>(_l_info, 23, value.IntImm);
-            _l_type.WriteValue<Serde.Test.AllInOne.ColorEnum, Serde.Test.AllInOne.ColorEnumProxy>(_l_info, 24, value.Color);
+            _l_type.WriteValueIfNotNull<int, Serde.NullableProxy.Ser<int, global::Serde.I32Proxy>>(_l_info, 20, value.NullIntField);
+            _l_type.WriteValue<uint[], Serde.ArrayProxy.Ser<uint, global::Serde.U32Proxy>>(_l_info, 21, value.UIntArr);
+            _l_type.WriteValue<int[][], Serde.ArrayProxy.Ser<int[], Serde.ArrayProxy.Ser<int, global::Serde.I32Proxy>>>(_l_info, 22, value.NestedArr);
+            _l_type.WriteValue<byte[], global::Serde.ByteArrayProxy>(_l_info, 23, value.ByteArr);
+            _l_type.WriteValue<System.Collections.Immutable.ImmutableArray<int>, Serde.ImmutableArrayProxy.Ser<int, global::Serde.I32Proxy>>(_l_info, 24, value.IntImm);
+            _l_type.WriteValue<Serde.Test.AllInOne.ColorEnum, Serde.Test.AllInOne.ColorEnumProxy>(_l_info, 25, value.Color);
             _l_type.End(_l_info);
         }
 

--- a/test/Serde.Test/AllInOneSrc.cs
+++ b/test/Serde.Test/AllInOneSrc.cs
@@ -39,6 +39,7 @@ namespace Serde.Test
         public required string EscapedStringField;
 
         public string? NullStringField = null;
+        public int? NullIntField = null;
 
         public uint[] UIntArr = null!;
         public int[][] NestedArr = null!;
@@ -80,6 +81,7 @@ namespace Serde.Test
                 && EscapedStringField == other.EscapedStringField
                 && GuidField.Equals(other.GuidField)
                 && NullStringField == other.NullStringField
+                && NullIntField == other.NullIntField
                 && UIntArr.AsSpan().SequenceEqual(other.UIntArr.AsSpan())
                 && NestedArr.AsSpan().SequenceEqual(other.NestedArr.AsSpan(), new Comparer())
                 && ByteArr.AsSpan().SequenceEqual(other.ByteArr.AsSpan())

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.AllInOne.IDeserialize.g.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.AllInOne.IDeserialize.g.cs
@@ -34,6 +34,7 @@ partial record AllInOne
             System.Guid _l_guidfield = default!;
             string _l_escapedstringfield = default!;
             string? _l_nullstringfield = null;
+            int? _l_nullintfield = null;
             uint[] _l_uintarr = null!;
             int[][] _l_nestedarr = null!;
             byte[] _l_bytearr = null!;
@@ -156,28 +157,33 @@ partial record AllInOne
                         break;
                     case 20:
                         Serde.DeserializeException.ThrowIfDuplicate(_r_assignedValid, 20, _l_serdeInfo);
-                        _l_uintarr = typeDeserialize.ReadValue<uint[], Serde.ArrayProxy.De<uint, global::Serde.U32Proxy>>(_l_serdeInfo, _l_index_);
+                        _l_nullintfield = typeDeserialize.ReadValue<int?, Serde.NullableProxy.De<int, global::Serde.I32Proxy>>(_l_serdeInfo, _l_index_);
                         _r_assignedValid |= ((uint)1) << 20;
                         break;
                     case 21:
                         Serde.DeserializeException.ThrowIfDuplicate(_r_assignedValid, 21, _l_serdeInfo);
-                        _l_nestedarr = typeDeserialize.ReadValue<int[][], Serde.ArrayProxy.De<int[], Serde.ArrayProxy.De<int, global::Serde.I32Proxy>>>(_l_serdeInfo, _l_index_);
+                        _l_uintarr = typeDeserialize.ReadValue<uint[], Serde.ArrayProxy.De<uint, global::Serde.U32Proxy>>(_l_serdeInfo, _l_index_);
                         _r_assignedValid |= ((uint)1) << 21;
                         break;
                     case 22:
                         Serde.DeserializeException.ThrowIfDuplicate(_r_assignedValid, 22, _l_serdeInfo);
-                        _l_bytearr = typeDeserialize.ReadValue<byte[], global::Serde.ByteArrayProxy>(_l_serdeInfo, _l_index_);
+                        _l_nestedarr = typeDeserialize.ReadValue<int[][], Serde.ArrayProxy.De<int[], Serde.ArrayProxy.De<int, global::Serde.I32Proxy>>>(_l_serdeInfo, _l_index_);
                         _r_assignedValid |= ((uint)1) << 22;
                         break;
                     case 23:
                         Serde.DeserializeException.ThrowIfDuplicate(_r_assignedValid, 23, _l_serdeInfo);
-                        _l_intimm = typeDeserialize.ReadValue<System.Collections.Immutable.ImmutableArray<int>, Serde.ImmutableArrayProxy.De<int, global::Serde.I32Proxy>>(_l_serdeInfo, _l_index_);
+                        _l_bytearr = typeDeserialize.ReadValue<byte[], global::Serde.ByteArrayProxy>(_l_serdeInfo, _l_index_);
                         _r_assignedValid |= ((uint)1) << 23;
                         break;
                     case 24:
                         Serde.DeserializeException.ThrowIfDuplicate(_r_assignedValid, 24, _l_serdeInfo);
-                        _l_color = typeDeserialize.ReadValue<Serde.Test.AllInOne.ColorEnum, Serde.Test.AllInOne.ColorEnumProxy>(_l_serdeInfo, _l_index_);
+                        _l_intimm = typeDeserialize.ReadValue<System.Collections.Immutable.ImmutableArray<int>, Serde.ImmutableArrayProxy.De<int, global::Serde.I32Proxy>>(_l_serdeInfo, _l_index_);
                         _r_assignedValid |= ((uint)1) << 24;
+                        break;
+                    case 25:
+                        Serde.DeserializeException.ThrowIfDuplicate(_r_assignedValid, 25, _l_serdeInfo);
+                        _l_color = typeDeserialize.ReadValue<Serde.Test.AllInOne.ColorEnum, Serde.Test.AllInOne.ColorEnumProxy>(_l_serdeInfo, _l_index_);
+                        _r_assignedValid |= ((uint)1) << 25;
                         break;
                     case Serde.ITypeDeserializer.IndexNotFound:
                         typeDeserialize.SkipValue(_l_serdeInfo, _l_index_);
@@ -187,7 +193,7 @@ partial record AllInOne
                 }
             }
             typeDeserialize.End(_l_serdeInfo);
-            if ((_r_assignedValid & 0b1111101111111111111111111) != 0b1111101111111111111111111)
+            if ((_r_assignedValid & 0b11111001111111111111111111) != 0b11111001111111111111111111)
             {
                 throw Serde.DeserializeException.UnassignedMember();
             }
@@ -212,6 +218,7 @@ partial record AllInOne
                 GuidField = _l_guidfield,
                 EscapedStringField = _l_escapedstringfield,
                 NullStringField = _l_nullstringfield,
+                NullIntField = _l_nullintfield,
                 UIntArr = _l_uintarr,
                 NestedArr = _l_nestedarr,
                 ByteArr = _l_bytearr,

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.AllInOne.ISerdeInfoProvider.g.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.AllInOne.ISerdeInfoProvider.g.cs
@@ -29,6 +29,7 @@ partial record AllInOne
             new("guidField", global::Serde.SerdeInfoProvider.GetSerializeInfo<System.Guid, global::Serde.GuidProxy>()),
             new("escapedStringField", global::Serde.SerdeInfoProvider.GetSerializeInfo<string, global::Serde.StringProxy>()),
             new("nullStringField", global::Serde.SerdeInfoProvider.GetSerializeInfo<string?, Serde.NullableRefProxy.Ser<string, global::Serde.StringProxy>>()),
+            new("nullIntField", global::Serde.SerdeInfoProvider.GetSerializeInfo<int?, Serde.NullableProxy.Ser<int, global::Serde.I32Proxy>>()),
             new("uIntArr", global::Serde.SerdeInfoProvider.GetSerializeInfo<uint[], Serde.ArrayProxy.Ser<uint, global::Serde.U32Proxy>>()),
             new("nestedArr", global::Serde.SerdeInfoProvider.GetSerializeInfo<int[][], Serde.ArrayProxy.Ser<int[], Serde.ArrayProxy.Ser<int, global::Serde.I32Proxy>>>()),
             new("byteArr", global::Serde.SerdeInfoProvider.GetSerializeInfo<byte[], global::Serde.ByteArrayProxy>()),

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.AllInOne.ISerialize.g.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.AllInOne.ISerialize.g.cs
@@ -36,11 +36,12 @@ partial record AllInOne
             _l_type.WriteGuid(_l_info, 17, value.GuidField);
             _l_type.WriteString(_l_info, 18, value.EscapedStringField);
             _l_type.WriteStringIfNotNull(_l_info, 19, value.NullStringField);
-            _l_type.WriteValue<uint[], Serde.ArrayProxy.Ser<uint, global::Serde.U32Proxy>>(_l_info, 20, value.UIntArr);
-            _l_type.WriteValue<int[][], Serde.ArrayProxy.Ser<int[], Serde.ArrayProxy.Ser<int, global::Serde.I32Proxy>>>(_l_info, 21, value.NestedArr);
-            _l_type.WriteValue<byte[], global::Serde.ByteArrayProxy>(_l_info, 22, value.ByteArr);
-            _l_type.WriteValue<System.Collections.Immutable.ImmutableArray<int>, Serde.ImmutableArrayProxy.Ser<int, global::Serde.I32Proxy>>(_l_info, 23, value.IntImm);
-            _l_type.WriteValue<Serde.Test.AllInOne.ColorEnum, Serde.Test.AllInOne.ColorEnumProxy>(_l_info, 24, value.Color);
+            _l_type.WriteValueIfNotNull<int, Serde.NullableProxy.Ser<int, global::Serde.I32Proxy>>(_l_info, 20, value.NullIntField);
+            _l_type.WriteValue<uint[], Serde.ArrayProxy.Ser<uint, global::Serde.U32Proxy>>(_l_info, 21, value.UIntArr);
+            _l_type.WriteValue<int[][], Serde.ArrayProxy.Ser<int[], Serde.ArrayProxy.Ser<int, global::Serde.I32Proxy>>>(_l_info, 22, value.NestedArr);
+            _l_type.WriteValue<byte[], global::Serde.ByteArrayProxy>(_l_info, 23, value.ByteArr);
+            _l_type.WriteValue<System.Collections.Immutable.ImmutableArray<int>, Serde.ImmutableArrayProxy.Ser<int, global::Serde.I32Proxy>>(_l_info, 24, value.IntImm);
+            _l_type.WriteValue<Serde.Test.AllInOne.ColorEnum, Serde.Test.AllInOne.ColorEnumProxy>(_l_info, 25, value.Color);
             _l_type.End(_l_info);
         }
 


### PR DESCRIPTION
Right now deserializing System.Nullable has to go through multiple interface dispatch hops to finally get to the underlying type. This change allows for simplifying most of the dispatch logic -- the worst case only adds a ReadFieldStart/ReadFieldEnd pair.

The new pattern is that IDeserializer should provide a 'TryReadNull' fast path that proxies can use to quickly check for null, then bail out if needed.