### PR TITLE
Refactor enum serialization and deserialization

### DIFF
--- a/src/generator/DeserializeImplGen.cs
+++ b/src/generator/DeserializeImplGen.cs
@@ -13,7 +13,7 @@ using static Serde.SerdeImplRoslynGenerator;
 
 namespace Serde
 {
-    internal class DeserializeImplGen
+    internal partial class DeserializeImplGen
     {
         internal static SourceBuilder GenDeserialize(
             GeneratorExecutionContext context,
@@ -103,82 +103,6 @@ namespace Serde
         throw Serde.DeserializeException.ExpectedEndOfType(index);
     }
     de.End(_l_serdeInfo);
-    return _l_result;
-}
-"""
-            );
-            return src;
-        }
-
-        /// <summary>
-        /// Generates the method body for deserializing an enum.
-        /// Code looks like:
-        /// <code>
-        /// static T IDeserialize&lt;T&gt;Deserialize(IDeserializer deserializer)
-        /// {
-        ///    var serdeInfo = GetInfo(this);
-        ///    var de = deserializer.ReadType(serdeInfo);
-        ///    var (index, errorName) = de.TryReadIndex(serdeInfo);
-        ///    if (index == ITypeDeserializer.IndexNotFound)
-        ///    {
-        ///      throw new InvalidDeserializeValueException($"Unexpected value: {errorName}");
-        ///    }
-        ///    return index switch
-        ///    {
-        ///      {index} =&gt; {enum member},
-        ///      ...
-        ///      _ =&gt; throw new InvalidDeserializeValueException($"Unexpected index: {index}")
-        ///    };
-        /// }
-        /// </code>
-        /// </summary>
-        private static SourceBuilder GenerateEnumDeserializeMethod(
-            GeneratorExecutionContext context,
-            ITypeSymbol type,
-            TypeSyntax typeSyntax
-        )
-        {
-            Debug.Assert(type.TypeKind == TypeKind.Enum);
-            var primName = Proxies.TryGetPrimitiveName(
-                ((INamedTypeSymbol)type).EnumUnderlyingType!
-            );
-
-            var members = SymbolUtilities.GetDataMembers(type, SerdeUsage.Both, context);
-            var typeFqn = typeSyntax.ToString();
-            var assignedVarType = members.Count switch
-            {
-                <= 8 => "byte",
-                <= 16 => "ushort",
-                <= 32 => "uint",
-                <= 64 => "ulong",
-                _ => throw new InvalidOperationException("Too many members in type"),
-            };
-            var src = new SourceBuilder(
-                $$"""
-{{typeFqn}} IDeserialize<{{typeFqn}}>.Deserialize(IDeserializer deserializer)
-{
-    var serdeInfo = global::Serde.SerdeInfoProvider.GetInfo(this);
-    var de = deserializer.ReadType(serdeInfo);
-    var (index, errorName) = de.TryReadIndexWithName(serdeInfo);
-    if (index == ITypeDeserializer.IndexNotFound)
-    {
-        throw Serde.DeserializeException.UnknownMember(errorName!, serdeInfo);
-    }
-    {{typeFqn}} _l_result;
-    if (index == ITypeDeserializer.EndOfType)
-    {
-        // Assume we want to read the underlying value
-        _l_result = ({{typeFqn}})de.Read{{primName}}(serdeInfo, index);
-    }
-    else
-    {
-        _l_result = index switch {
-            {{string.Join("," + Utilities.NewLine, members
-                .Select((m, i) => $"{i} => {typeSyntax}.{m.Name}"))}},
-            _ => throw new InvalidOperationException($"Unexpected index: {index}")
-        };
-    }
-    de.End(serdeInfo);
     return _l_result;
 }
 """

--- a/src/generator/Diagnostics.cs
+++ b/src/generator/Diagnostics.cs
@@ -31,6 +31,7 @@ namespace Serde
         ERR_PartialMemberOrdinal = 19,
         ERR_OrdinalOnSkippedMember = 20,
         ERR_OrdinalOnEnumMember = 21,
+        ERR_AsUnderlyingOnNonEnum = 22,
     }
 
     internal static class Diagnostics
@@ -59,6 +60,7 @@ namespace Serde
                 ERR_PartialMemberOrdinal => nameof(ERR_PartialMemberOrdinal),
                 ERR_OrdinalOnSkippedMember => nameof(ERR_OrdinalOnSkippedMember),
                 ERR_OrdinalOnEnumMember => nameof(ERR_OrdinalOnEnumMember),
+                ERR_AsUnderlyingOnNonEnum => nameof(ERR_AsUnderlyingOnNonEnum),
             };
 
         public static Diagnostic CreateDiagnostic(

--- a/src/generator/GenEnumDeserialize.cs
+++ b/src/generator/GenEnumDeserialize.cs
@@ -1,0 +1,71 @@
+using System;
+using System.Diagnostics;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Serde;
+
+internal partial class DeserializeImplGen
+{
+    /// <summary>
+    /// Generates the method body for deserializing an enum.
+    /// Code looks like:
+    /// <code>
+    /// static T IDeserialize&lt;T&gt;Deserialize(IDeserializer deserializer)
+    /// {
+    ///    var serdeInfo = GetInfo(this);
+    ///    var index = deserializer.ReadEnum(serdeInfo);
+    ///    return index switch
+    ///    {
+    ///      {index} =&gt; {enum member},
+    ///      ...
+    ///      _ =&gt; throw new InvalidDeserializeValueException($"Unexpected index: {index}")
+    ///    };
+    /// }
+    /// </code>
+    /// </summary>
+    private static SourceBuilder GenerateEnumDeserializeMethod(
+        GeneratorExecutionContext context,
+        ITypeSymbol type,
+        TypeSyntax typeSyntax
+    )
+    {
+        Debug.Assert(type.TypeKind == TypeKind.Enum);
+        var enumType = (INamedTypeSymbol)type;
+        var typeFqn = typeSyntax.ToString();
+
+        // When `AsUnderlying = true`, read the underlying integral value directly (e.g.
+        // `(Color)deserializer.ReadI32()`) instead of reading a name.
+        if (Proxies.EnumSerializesAsUnderlying(enumType))
+        {
+            var primName = Proxies.TryGetPrimitiveName(enumType.EnumUnderlyingType!)!;
+            return new SourceBuilder(
+                $$"""
+{{typeFqn}} IDeserialize<{{typeFqn}}>.Deserialize(IDeserializer deserializer)
+{
+    return ({{typeFqn}})deserializer.Read{{primName}}();
+}
+"""
+            );
+        }
+
+        var members = SymbolUtilities.GetDataMembers(type, SerdeUsage.Both, context);
+        var src = new SourceBuilder(
+            $$"""
+{{typeFqn}} IDeserialize<{{typeFqn}}>.Deserialize(IDeserializer deserializer)
+{
+    var serdeInfo = global::Serde.SerdeInfoProvider.GetInfo(this);
+    var index = deserializer.ReadEnum(serdeInfo);
+    {{typeFqn}} _l_result = index switch {
+        {{string.Join("," + Utilities.NewLine, members
+        .Select((m, i) => $"{i} => {typeSyntax}.{m.Name}"))}},
+        _ => throw new InvalidOperationException($"Unexpected index: {index}")
+    };
+    return _l_result;
+}
+"""
+        );
+        return src;
+    }
+}

--- a/src/generator/GenEnumSerialize.cs
+++ b/src/generator/GenEnumSerialize.cs
@@ -1,0 +1,69 @@
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+
+namespace Serde;
+
+public partial class SerializeImplGen
+{
+    /// <summary>
+    /// Generates the serialization code for an enum type. The generated code looks like:
+    /// <code>
+    /// void ISerialize&lt;T&gt;.Serialize(T value, ISerializer serializer)
+    /// {
+    ///    var _l_info = GetInfo(this);
+    ///    var _l_index = value switch
+    ///    {
+    ///        Enum.Case1 => 0,
+    ///        Enum.Case2 => 1,
+    ///        var v => throw new InvalidOperationException($"Cannot serialize unnamed enum value '{v}' of enum '{TypeName}'");
+    ///    };
+    ///    serializer.WriteEnum(_l_info, _l_index);
+    /// }
+    /// </code>
+    /// </summary>
+    private static void GenEnumSerialize(
+        ITypeSymbol receiverType,
+        SourceBuilder statements,
+        List<DataMemberSymbol> fieldsAndProps
+    )
+    {
+        var enumType = (INamedTypeSymbol)receiverType;
+        var underlying = enumType.EnumUnderlyingType!;
+
+        // When `AsUnderlying = true`, serialize the enum directly as its underlying integral value
+        // (e.g. `serializer.WriteI32((int)value);`) instead of by name.
+        if (Proxies.EnumSerializesAsUnderlying(enumType))
+        {
+            var primName = Proxies.TryGetPrimitiveName(underlying)!;
+            statements.AppendLine(
+                $"serializer.Write{primName}(({underlying.ToDisplayString()})value);"
+            );
+            return;
+        }
+
+        // `var _l_info = GetInfo(this);`
+        statements.AppendLine($"var _l_info = global::Serde.SerdeInfoProvider.GetInfo(this);");
+
+        // ```
+        // var _l_index = value switch
+        // {
+        //   Enum.Case1 => 0,
+        //   Enum.Case2 => 1,
+        //   var v => throw new InvalidOperationException($"Cannot serialize unnamed enum value '{v}' of enum '{TypeName}'");
+        // };
+        statements.AppendLine(
+            $$"""
+                var _l_index = value switch
+                {
+                    {{string.Join("," + Utilities.NewLine, fieldsAndProps
+                    .Select((m, i) => $"{enumType.ToDisplayString()}.{m.Name} => {i}"))}},
+                    var v => throw new InvalidOperationException($"Cannot serialize unnamed enum value '{v}' of enum '{{enumType.Name}}'"),
+                };
+                """
+        );
+
+        // `var _l_type = serializer.WriteEnum(_l_info, );`
+        statements.AppendLine("serializer.WriteEnum(_l_info, _l_index);");
+    }
+}

--- a/src/generator/Proxies.cs
+++ b/src/generator/Proxies.cs
@@ -39,6 +39,38 @@ sealed partial class {{proxyName}};
         return newDecl;
     }
 
+    /// <summary>
+    /// Returns true if the enum is annotated to serialize/deserialize as its underlying integral
+    /// value (via <c>AsUnderlying = true</c> on a <c>GenerateSerde</c>, <c>GenerateSerialize</c>,
+    /// or <c>GenerateDeserialize</c> attribute) rather than by name.
+    /// </summary>
+    internal static bool EnumSerializesAsUnderlying(ITypeSymbol enumType)
+    {
+        foreach (var attr in enumType.GetAttributes())
+        {
+            if (attr.AttributeClass is not { } attrClass)
+            {
+                continue;
+            }
+            if (
+                !IsWellKnownAttribute(attrClass, WellKnownAttribute.GenerateSerde)
+                && !IsWellKnownAttribute(attrClass, WellKnownAttribute.GenerateSerialize)
+                && !IsWellKnownAttribute(attrClass, WellKnownAttribute.GenerateDeserialize)
+            )
+            {
+                continue;
+            }
+            foreach (var named in attr.NamedArguments)
+            {
+                if (named.Key == "AsUnderlying" && named.Value.Value is true)
+                {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
     internal static string? TryGetPrimitiveName(ITypeSymbol type)
     {
         // Nullable types are not considered primitive types

--- a/src/generator/Resources.resx
+++ b/src/generator/Resources.resx
@@ -161,7 +161,10 @@
     <value>The 'As' option cannot be applied to type '{0}': the 'As' type must be a named type.</value>
   </data>
   <data name="ERR_AsTypeOnEnum" xml:space="preserve">
-    <value>The 'As' option cannot be applied to type '{0}': enums cannot define user-defined conversions.</value>
+    <value>The 'As' option cannot be applied to enum '{0}'. Use 'AsUnderlying = true' to serialize an enum as its underlying value.</value>
+  </data>
+  <data name="ERR_AsUnderlyingOnNonEnum" xml:space="preserve">
+    <value>The 'AsUnderlying' option can only be applied to enums, but '{0}' is not an enum.</value>
   </data>
   <data name="ERR_AsTypeWithOption" xml:space="preserve">
     <value>The 'As' option cannot be combined with the '{0}' option.</value>

--- a/src/generator/SerdeImplRoslynGenerator.cs
+++ b/src/generator/SerdeImplRoslynGenerator.cs
@@ -215,7 +215,8 @@ public class SerdeImplRoslynGenerator : IIncrementalGenerator
         INamedTypeSymbol? foreignType = null;
 
         // If the `As` property is set, the type is serialized/deserialized by converting to and
-        // from the given type. This is incompatible with `ForType`, `With`, and enums.
+        // from the given type via user-defined conversions. This is incompatible with `ForType`,
+        // `With`, and enums (enums use `AsUnderlying` instead).
         INamedTypeSymbol? asType = null;
         if (
             attributeData.NamedArguments.FirstOrNull(a => a.Key == nameof(GenerateSerialize.As)) is
@@ -261,6 +262,28 @@ public class SerdeImplRoslynGenerator : IIncrementalGenerator
                 );
                 return;
             }
+        }
+
+        // If `AsUnderlying = true` is set (enums only), the enum is serialized as its underlying
+        // integral value rather than by name. This is handled by the enum serde-object generator
+        // (GenEnumSerialize/GenEnumDeserialize), which emits direct primitive Write/Read calls when
+        // it detects the option on the enum. Here we only validate that the target is an enum.
+        if (
+            attributeData.NamedArguments.FirstOrNull(a =>
+                a.Key == nameof(GenerateSerde.AsUnderlying)
+            )
+                is (_, { Value: true })
+            && !isEnum
+        )
+        {
+            generationContext.ReportDiagnostic(
+                CreateDiagnostic(
+                    DiagId.ERR_AsUnderlyingOnNonEnum,
+                    attributeData.ApplicationSyntaxReference!.GetSyntax().GetLocation(),
+                    typeSymbol
+                )
+            );
+            return;
         }
 
         if (proxiedType is not null)

--- a/src/generator/SerializeImplGen.cs
+++ b/src/generator/SerializeImplGen.cs
@@ -183,9 +183,9 @@ public partial class SerializeImplGen
                 var typeArg = m.IsNullable ? m.Type.ToDisplayString() : type;
                 return $"_l_type.WriteValue<{typeArg}, {proxy}>(_l_info, {i}, {valueExpr}.{m.Name});";
             }
+            // `type.End();`
+            statements.Append("_l_type.End(_l_info);");
         }
-        // `type.End();`
-        statements.Append("_l_type.End(_l_info);");
 
         // The interface type is the foreign type when present, otherwise the receiver.
         var interfaceType = (ITypeSymbol?)foreignType ?? receiverType;
@@ -202,43 +202,6 @@ public partial class SerializeImplGen
             """
         );
         return members;
-    }
-
-    private static void GenEnumSerialize(
-        ITypeSymbol receiverType,
-        SourceBuilder statements,
-        List<DataMemberSymbol> fieldsAndProps
-    )
-    {
-        // `var _l_info = GetInfo(this);`
-        statements.AppendLine($"var _l_info = global::Serde.SerdeInfoProvider.GetInfo(this);");
-        // `var _l_type = serializer.WriteType(_l_info);`
-        statements.AppendLine("var _l_type = serializer.WriteType(_l_info);");
-
-        // ```
-        // var index = value switch
-        // {
-        //   Enum.Case1 => 0,
-        //   Enum.Case2 => 1,
-        //   var v => throw new InvalidOperationException($"Cannot serialize unnamed enum value '{v}' of enum '{TypeName}'");
-        // };
-        // serializer.SerializeEnumValue("Enum", name, (Underlying)value, default(Underlying));
-        var enumType = (INamedTypeSymbol)receiverType;
-        var underlying = enumType.EnumUnderlyingType!;
-        statements.AppendLine(
-            $$"""
-                var index = value switch
-                {
-                    {{string.Join("," + Utilities.NewLine, fieldsAndProps
-                    .Select((m, i) => $"{enumType.ToDisplayString()}.{m.Name} => {i}"))}},
-                    var v => throw new InvalidOperationException($"Cannot serialize unnamed enum value '{v}' of enum '{{enumType.Name}}'"),
-                };
-                """
-        );
-        var methodName = Proxies.TryGetPrimitiveName(underlying).NotNull();
-        statements.AppendLine(
-            $"_l_type.Write{methodName}(_l_info, index, ({underlying.ToDisplayString()})value);"
-        );
     }
 
     /// <summary>

--- a/src/serde/Attributes.cs
+++ b/src/serde/Attributes.cs
@@ -35,6 +35,11 @@ sealed class GenerateSerialize : Attribute
     /// type must exist.
     /// </summary>
     public Type? As { get; init; }
+
+    /// <summary>
+    /// Enums only: serialize the enum as its underlying integral value instead of by name.
+    /// </summary>
+    public bool AsUnderlying { get; init; }
 }
 
 /// <summary>
@@ -66,6 +71,11 @@ sealed class GenerateDeserialize : Attribute
     /// type must exist.
     /// </summary>
     public Type? As { get; init; }
+
+    /// <summary>
+    /// Enums only: deserialize the enum from its underlying integral value instead of by name.
+    /// </summary>
+    public bool AsUnderlying { get; init; }
 }
 
 /// <summary>
@@ -102,6 +112,12 @@ sealed class GenerateSerde : Attribute
     /// both directions between the declaring type and this type must exist.
     /// </summary>
     public Type? As { get; init; }
+
+    /// <summary>
+    /// Enums only: serialize and deserialize the enum as its underlying integral value instead of
+    /// by name.
+    /// </summary>
+    public bool AsUnderlying { get; init; }
 }
 
 /// <summary>

--- a/src/serde/IDeserializer.cs
+++ b/src/serde/IDeserializer.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Buffers;
+using System.Text;
 
 namespace Serde;
 
@@ -46,6 +47,14 @@ public interface IDeserializer : IDisposable
         return TimeOnly.Parse(s);
     }
     void ReadBytes(IBufferWriter<byte> writer);
+
+    /// <summary>
+    /// Read an enum value and return the index of the value. This only works for "closed" enums,
+    /// where all possible enum values are named. For "open" enums, one of the other ReadValue
+    /// methods should be used to read the underlying enum value.
+    /// </summary>
+    int ReadEnum(ISerdeInfo info);
+
     ITypeDeserializer ReadType(ISerdeInfo typeInfo);
 }
 
@@ -128,6 +137,7 @@ public interface ITypeDeserializer
         return TimeOnly.Parse(s);
     }
     void ReadBytes(ISerdeInfo info, int index, IBufferWriter<byte> writer);
+    int ReadEnum(ISerdeInfo typeInfo, int index, ISerdeInfo fieldInfo);
 
     /// <summary>
     /// Finish deserializing the type. This method should be called when the type is fully

--- a/src/serde/IDeserializerExt.cs
+++ b/src/serde/IDeserializerExt.cs
@@ -13,9 +13,6 @@ public static class IDeserializerExt
 
     public static T ReadValue<T>(this IDeserializer deserializer)
         where T : IDeserializeProvider<T> => deserializer.ReadValue<T, T>();
-
-    public static Guid ReadGuid(this ITypeDeserializer @this, ISerdeInfo info, int index) =>
-        @this.ReadValue(info, index, GuidProxy.Instance);
 }
 
 public static class ITypeDeserializerExt
@@ -34,6 +31,9 @@ public static class ITypeDeserializerExt
     )
         where TProvider : IDeserializeProvider<T> =>
         TProvider.Instance.DeserializeAsField(@this, info, index);
+
+    public static Guid ReadGuid(this ITypeDeserializer @this, ISerdeInfo info, int index) =>
+        @this.ReadValue(info, index, GuidProxy.Instance);
 
     [Obsolete("Use ReadValue instead")]
     public static T ReadBoxedValue<T>(

--- a/src/serde/ISerializer.cs
+++ b/src/serde/ISerializer.cs
@@ -39,6 +39,7 @@ public interface ISerializer
         // Default implementation: serialize as ISO 8601 time string
         WriteString(t.ToString("HH:mm:ss"));
     }
+    void WriteEnum(ISerdeInfo info, int ordinal);
 
     /// <summary>
     /// Write a collection type -- either a list or a dictionary.
@@ -130,6 +131,23 @@ public interface ITypeSerializer
         WriteString(typeInfo, index, t.ToString("HH:mm:ss"));
     }
     void WriteBytes(ISerdeInfo typeInfo, int index, ReadOnlyMemory<byte> bytes);
+
+    /// <summary>
+    /// Write an enum value.
+    /// </summary>
+    /// <param name="typeInfo">
+    /// The type information for the parent type.
+    /// </param>
+    /// <param name="index">
+    /// The index of the current field in the parent type.
+    /// </param>
+    /// <param name="fieldInfo">
+    /// The type information for the enum field.
+    /// </param>
+    /// <param name="ordinal">
+    /// The ordinal value of the enum. This is the index of the enum variant in the enum type.
+    /// </param>
+    void WriteEnum(ISerdeInfo typeInfo, int index, ISerdeInfo fieldInfo, int ordinal);
 
     /// <summary>
     /// Write an arbitrary value with custom serialization. For reference types this method may be

--- a/src/serde/PublicApi.cssig
+++ b/src/serde/PublicApi.cssig
@@ -397,7 +397,6 @@ namespace Serde
     }
     public static class IDeserializerExt
     {
-        public static System.Guid ReadGuid(this Serde.ITypeDeserializer @this, Serde.ISerdeInfo info, int index);
         public static T ReadValue<T, TProvider>(this Serde.IDeserializer deserializer) where TProvider : Serde.IDeserializeProvider<T>;
         public static T ReadValue<T>(this Serde.IDeserializer deserializer) where T : Serde.IDeserializeProvider<T>;
     }
@@ -527,6 +526,7 @@ namespace Serde
     }
     public static class ITypeDeserializerExt
     {
+        public static System.Guid ReadGuid(this Serde.ITypeDeserializer @this, Serde.ISerdeInfo info, int index);
         [System.Obsolete("Use ReadValue instead")]
         public static T ReadBoxedValue<T, TProvider>(this Serde.ITypeDeserializer deserializeType, Serde.ISerdeInfo info, int index) where TProvider : Serde.IDeserializeProvider<T>;
         [System.Obsolete("Use ReadValue instead")]

--- a/src/serde/PublicApi.cssig
+++ b/src/serde/PublicApi.cssig
@@ -302,17 +302,20 @@ namespace Serde
     {
         public System.Type? As { get; init; }
         public System.Type? ForType { get; init; }
+        public bool AsUnderlying { get; init; }
     }
     public sealed class GenerateSerde()
     {
         public System.Type? As { get; init; }
         public System.Type? ForType { get; init; }
         public System.Type? With { get; init; }
+        public bool AsUnderlying { get; init; }
     }
     public sealed class GenerateSerialize()
     {
         public System.Type? As { get; init; }
         public System.Type? ForType { get; init; }
+        public bool AsUnderlying { get; init; }
     }
     public sealed class GuidProxy
     {
@@ -381,6 +384,7 @@ namespace Serde
         decimal ReadDecimal();
         double ReadF64();
         float ReadF32();
+        int ReadEnum(Serde.ISerdeInfo info);
         int ReadI32();
         long ReadI64();
         sbyte ReadI8();
@@ -456,6 +460,7 @@ namespace Serde
         void WriteDateTime(System.DateTime dt);
         void WriteDateTimeOffset(System.DateTimeOffset dt);
         void WriteDecimal(decimal d);
+        void WriteEnum(Serde.ISerdeInfo info, int ordinal);
         void WriteF16(System.Half h);
         void WriteF32(float f);
         void WriteF64(double d);
@@ -504,6 +509,7 @@ namespace Serde
         decimal ReadDecimal(Serde.ISerdeInfo info, int index);
         double ReadF64(Serde.ISerdeInfo info, int index);
         float ReadF32(Serde.ISerdeInfo info, int index);
+        int ReadEnum(Serde.ISerdeInfo typeInfo, int index, Serde.ISerdeInfo fieldInfo);
         int ReadI32(Serde.ISerdeInfo info, int index);
         int TryReadIndex(Serde.ISerdeInfo info);
         int? SizeOpt { get; }
@@ -547,6 +553,7 @@ namespace Serde
         void WriteDateTime(Serde.ISerdeInfo typeInfo, int index, System.DateTime dt);
         void WriteDateTimeOffset(Serde.ISerdeInfo typeInfo, int index, System.DateTimeOffset dt);
         void WriteDecimal(Serde.ISerdeInfo typeInfo, int index, decimal d);
+        void WriteEnum(Serde.ISerdeInfo typeInfo, int index, Serde.ISerdeInfo fieldInfo, int ordinal);
         void WriteF16(Serde.ISerdeInfo typeInfo, int index, System.Half h);
         void WriteF32(Serde.ISerdeInfo typeInfo, int index, float f);
         void WriteF64(Serde.ISerdeInfo typeInfo, int index, double d);
@@ -776,6 +783,7 @@ namespace Serde
         public static Serde.ISerdeInfo MakeCustom(string typeName, System.Collections.Generic.IList<System.Reflection.CustomAttributeData> typeAttributes, System.ReadOnlySpan<Serde.SerdeInfo.FieldInfo> fields);
         public static Serde.ISerdeInfo MakeDictionary(string typeName, Serde.ISerdeInfo keyInfo, Serde.ISerdeInfo valueInfo);
         public static Serde.ISerdeInfo MakeEnum(string typeName, System.Collections.Generic.IList<System.Reflection.CustomAttributeData> typeAttributes, Serde.ISerdeInfo underlyingInfo, System.ReadOnlySpan<(string SerializeName, System.Reflection.MemberInfo? MemberInfo)> fields);
+        public static Serde.ISerdeInfo MakeEnum(string typeName, System.Collections.Generic.IList<System.Reflection.CustomAttributeData> typeAttributes, Serde.ISerdeInfo underlyingInfo, System.ReadOnlySpan<(string SerializeName, System.Reflection.MemberInfo? MemberInfo)> fields, Serde.PrimitiveKind primitiveKind);
         public static Serde.ISerdeInfo MakeEnumerable(string typeName, Serde.ISerdeInfo elementInfo);
         public static Serde.ISerdeInfo MakeNullable(Serde.ISerdeInfo underlying);
         public static Serde.ISerdeInfo MakePrimitive(string name, Serde.PrimitiveKind kind);
@@ -1006,6 +1014,7 @@ namespace Serde.Json
         public void WriteDateTime(System.DateTime dt);
         public void WriteDateTimeOffset(System.DateTimeOffset dt);
         public void WriteDecimal(decimal d);
+        public void WriteEnum(Serde.ISerdeInfo info, int ordinal);
         public void WriteF16(System.Half h);
         public void WriteF32(float f);
         public void WriteF64(double d);

--- a/src/serde/SerdeInfo.cs
+++ b/src/serde/SerdeInfo.cs
@@ -153,6 +153,14 @@ public static class SerdeInfo
         IList<CustomAttributeData> typeAttributes,
         ISerdeInfo underlyingInfo,
         ReadOnlySpan<(string SerializeName, MemberInfo? MemberInfo)> fields
+    ) => MakeEnum(typeName, typeAttributes, underlyingInfo, fields, PrimitiveKind.String);
+
+    public static ISerdeInfo MakeEnum(
+        string typeName,
+        IList<CustomAttributeData> typeAttributes,
+        ISerdeInfo underlyingInfo,
+        ReadOnlySpan<(string SerializeName, MemberInfo? MemberInfo)> fields,
+        PrimitiveKind primitiveKind
     )
     {
         var fieldsWithInfo = new FieldInfo[fields.Length];
@@ -164,7 +172,13 @@ public static class SerdeInfo
             };
         }
 
-        return TypeWithFieldsInfo.Create(typeName, InfoKind.Enum, typeAttributes, fieldsWithInfo);
+        return TypeWithFieldsInfo.Create(
+            typeName,
+            InfoKind.Enum,
+            typeAttributes,
+            fieldsWithInfo,
+            primitiveKind
+        );
     }
 
     public static ISerdeInfo MakePrimitive(string name, PrimitiveKind kind) =>
@@ -386,7 +400,7 @@ file sealed record TypeWithFieldsInfo : ISerdeInfo
 
     public InfoKind Kind { get; }
 
-    public PrimitiveKind? PrimitiveKind => null;
+    public PrimitiveKind? PrimitiveKind { get; }
 
     public IList<CustomAttributeData> Attributes { get; }
 
@@ -396,7 +410,8 @@ file sealed record TypeWithFieldsInfo : ISerdeInfo
         IList<CustomAttributeData> typeAttributes,
         ImmutableArray<(ReadOnlyMemory<byte>, int)> nameToIndex,
         ImmutableArray<PrivateFieldInfo> indexToInfo,
-        bool hasExplicitOrdinals
+        bool hasExplicitOrdinals,
+        PrimitiveKind? primitiveKind = null
     )
     {
         Name = typeName;
@@ -405,6 +420,7 @@ file sealed record TypeWithFieldsInfo : ISerdeInfo
         _nameToIndex = nameToIndex;
         _indexToInfo = indexToInfo;
         _hasExplicitOrdinals = hasExplicitOrdinals;
+        PrimitiveKind = primitiveKind;
     }
 
     /// <summary>
@@ -415,7 +431,8 @@ file sealed record TypeWithFieldsInfo : ISerdeInfo
         string typeName,
         InfoKind typeKind,
         IList<CustomAttributeData> typeAttributes,
-        ReadOnlySpan<SerdeInfo.FieldInfo> fields
+        ReadOnlySpan<SerdeInfo.FieldInfo> fields,
+        PrimitiveKind? primitiveKind = null
     )
     {
         var nameToIndexBuilder = ImmutableArray.CreateBuilder<(
@@ -462,7 +479,8 @@ file sealed record TypeWithFieldsInfo : ISerdeInfo
             typeAttributes,
             nameToIndexBuilder.ToImmutable(),
             indexToInfoBuilder.ToImmutable(),
-            hasExplicitOrdinals
+            hasExplicitOrdinals,
+            primitiveKind
         );
     }
 

--- a/src/serde/json/JsonDeserializer.Collection.cs
+++ b/src/serde/json/JsonDeserializer.Collection.cs
@@ -272,6 +272,14 @@ partial class JsonDeserializer<TReader>
             _index++;
         }
 
+        /// <summary>
+        /// Default behavior of JSON is to read and write enums as strings.
+        /// </summary>
+        int ITypeDeserializer.ReadEnum(ISerdeInfo typeInfo, int index, ISerdeInfo fieldInfo)
+        {
+            return _deserializer.ReadEnum(fieldInfo);
+        }
+
         public void End(ISerdeInfo info)
         {
             // Nothing to do; the closing delimiter is consumed when the end of the type is reached.

--- a/src/serde/json/JsonDeserializer.Type.cs
+++ b/src/serde/json/JsonDeserializer.Type.cs
@@ -231,6 +231,12 @@ partial class JsonDeserializer<TReader>
             _deserializer.ReadBytes(writer);
         }
 
+        int ITypeDeserializer.ReadEnum(ISerdeInfo typeInfo, int index, ISerdeInfo fieldInfo)
+        {
+            ReadColon();
+            return _deserializer.ReadEnum(fieldInfo);
+        }
+
         void ITypeDeserializer.SkipValue(ISerdeInfo info, int index)
         {
             ReadColon();

--- a/src/serde/json/JsonDeserializer.cs
+++ b/src/serde/json/JsonDeserializer.cs
@@ -404,4 +404,35 @@ internal sealed partial class JsonDeserializer<TReader> : BaseJsonDeserializer, 
             throw new JsonException($"Invalid base64 string: {status}");
         }
     }
+
+    /// <summary>
+    /// Default behavior of JSON is to read and write enums as strings.
+    /// </summary>
+    public int ReadEnum(ISerdeInfo info)
+    {
+        if (info.Kind != InfoKind.Enum)
+        {
+            throw new ArgumentException($"Expected enum type, found {info.Kind}");
+        }
+        switch (ThrowIfEos(Reader.SkipWhitespace()))
+        {
+            case (byte)'"':
+                break;
+            default:
+                throw new JsonException("Expected enum name as string");
+        }
+
+        // Read a string
+        Reader.Advance();
+        _scratch.Clear();
+        var span = Reader.LexUtf8Span(_scratch);
+        var localIndex = info.TryGetIndex(span);
+        var errorName = localIndex == ITypeDeserializer.IndexNotFound ? span.ToString() : null;
+        if (errorName is not null)
+        {
+            throw Serde.DeserializeException.UnknownMember(errorName, info);
+        }
+        _first = false;
+        return localIndex;
+    }
 }

--- a/src/serde/json/JsonSerializer.Collection.cs
+++ b/src/serde/json/JsonSerializer.Collection.cs
@@ -134,6 +134,11 @@ partial class JsonSerializer
             serializer.WriteBytes(bytes);
         }
 
+        public void WriteEnum(ISerdeInfo typeInfo, int index, ISerdeInfo fieldInfo, int ordinal)
+        {
+            serializer.WriteEnum(fieldInfo, ordinal);
+        }
+
         public void WriteValue<T>(ISerdeInfo typeInfo, int index, T value, ISerialize<T> serialize)
             where T : class?
         {
@@ -200,6 +205,9 @@ partial class JsonSerializer
             throw new KeyNotStringException();
 
         public void WriteNull() => throw new KeyNotStringException();
+
+        void ISerializer.WriteEnum(ISerdeInfo info, int ordinal) =>
+            throw new KeyNotStringException();
     }
 
     private sealed class DictImpl(JsonSerializer serializer) : ITypeSerializer
@@ -289,6 +297,9 @@ partial class JsonSerializer
 
         public void WriteBytes(ISerdeInfo typeInfo, int index, ReadOnlyMemory<byte> bytes) =>
             GetSerializer(index).WriteBytes(bytes);
+
+        public void WriteEnum(ISerdeInfo typeInfo, int index, ISerdeInfo fieldInfo, int ordinal) =>
+            GetSerializer(index).WriteEnum(fieldInfo, ordinal);
 
         public void WriteValue<T>(ISerdeInfo typeInfo, int index, T value, ISerialize<T> serialize)
             where T : class? => serialize.Serialize(value, GetSerializer(index));

--- a/src/serde/json/JsonSerializer.Serialize.cs
+++ b/src/serde/json/JsonSerializer.Serialize.cs
@@ -10,13 +10,11 @@ partial class JsonSerializer
 {
     private readonly Utf8JsonWriter _writer;
     private readonly KeySerializer _keySerializer;
-    private readonly EnumSerializer _enumSerializer;
 
     internal JsonSerializer(Utf8JsonWriter writer)
     {
         _writer = writer;
         _keySerializer = new KeySerializer(this);
-        _enumSerializer = new EnumSerializer(this);
     }
 }
 
@@ -112,6 +110,12 @@ partial class JsonSerializer : ISerializer
     public void WriteBytes(ReadOnlyMemory<byte> bytes) =>
         _writer.WriteBase64StringValue(bytes.Span);
 
+    public void WriteEnum(ISerdeInfo info, int ordinal)
+    {
+        var name = info.GetFieldName(ordinal);
+        _writer.WriteStringValue(name);
+    }
+
     ITypeSerializer ISerializer.WriteCollection(ISerdeInfo info, int? size)
     {
         switch (info.Kind)
@@ -136,102 +140,14 @@ partial class JsonSerializer : ISerializer
     {
         switch (typeInfo.Kind)
         {
-            case InfoKind.Enum:
-                return _enumSerializer;
             case InfoKind.Union:
             case InfoKind.CustomType:
                 _writer.WriteStartObject();
                 return this;
+            case InfoKind.Enum:
             default:
                 throw new ArgumentException("Invalid type kind for WriteType: " + typeInfo.Kind);
         }
-    }
-
-    private sealed class EnumSerializer(JsonSerializer _parent) : ITypeSerializer
-    {
-        public ISerializer WriteFieldStart(ISerdeInfo typeInfo, int fieldIndex)
-        {
-            return _parent;
-        }
-
-        public void WriteFieldEnd(ISerdeInfo typeInfo, int fieldIndex, ISerializer serializer)
-        {
-            // noop
-        }
-
-        private void WriteEnumName(ISerdeInfo typeInfo, int index)
-        {
-            _parent._writer.WriteStringValue(typeInfo.GetFieldName(index));
-        }
-
-        public void End(ISerdeInfo info) { }
-
-        public void WriteBool(ISerdeInfo typeInfo, int index, bool b) => ThrowInvalidEnum();
-
-        public void WriteU8(ISerdeInfo typeInfo, int index, byte b) =>
-            WriteEnumName(typeInfo, index);
-
-        public void WriteChar(ISerdeInfo typeInfo, int index, char c) => ThrowInvalidEnum();
-
-        public void WriteDecimal(ISerdeInfo typeInfo, int index, decimal d) => ThrowInvalidEnum();
-
-        public void WriteF16(ISerdeInfo typeInfo, int index, Half h) => ThrowInvalidEnum();
-
-        public void WriteF64(ISerdeInfo typeInfo, int index, double d) => ThrowInvalidEnum();
-
-        public void WriteValue<T>(ISerdeInfo typeInfo, int index, T value, ISerialize<T> serialize)
-            where T : class? => ThrowInvalidEnum();
-
-        public void WriteF32(ISerdeInfo typeInfo, int index, float f) => ThrowInvalidEnum();
-
-        public void WriteI16(ISerdeInfo typeInfo, int index, short i16) =>
-            WriteEnumName(typeInfo, index);
-
-        public void WriteI32(ISerdeInfo typeInfo, int index, int i32) =>
-            WriteEnumName(typeInfo, index);
-
-        public void WriteI64(ISerdeInfo typeInfo, int index, long i64) =>
-            WriteEnumName(typeInfo, index);
-
-        public void WriteI128(ISerdeInfo typeInfo, int index, Int128 i128) =>
-            WriteEnumName(typeInfo, index);
-
-        public void WriteNull(ISerdeInfo typeInfo, int index) => ThrowInvalidEnum();
-
-        public void WriteI8(ISerdeInfo typeInfo, int index, sbyte b) =>
-            WriteEnumName(typeInfo, index);
-
-        public void WriteString(ISerdeInfo typeInfo, int index, string s) => ThrowInvalidEnum();
-
-        public void WriteU16(ISerdeInfo typeInfo, int index, ushort u16) =>
-            WriteEnumName(typeInfo, index);
-
-        public void WriteU32(ISerdeInfo typeInfo, int index, uint u32) =>
-            WriteEnumName(typeInfo, index);
-
-        public void WriteU64(ISerdeInfo typeInfo, int index, ulong u64) =>
-            WriteEnumName(typeInfo, index);
-
-        public void WriteU128(ISerdeInfo typeInfo, int index, UInt128 u128) =>
-            WriteEnumName(typeInfo, index);
-
-        public void WriteDateTime(ISerdeInfo typeInfo, int index, DateTime dt) =>
-            ThrowInvalidEnum();
-
-        public void WriteDateTimeOffset(ISerdeInfo typeInfo, int index, DateTimeOffset dt) =>
-            ThrowInvalidEnum();
-
-        public void WriteDateOnly(ISerdeInfo typeInfo, int index, DateOnly d) => ThrowInvalidEnum();
-
-        public void WriteTimeOnly(ISerdeInfo typeInfo, int index, TimeOnly t) => ThrowInvalidEnum();
-
-        public void WriteBytes(ISerdeInfo typeInfo, int index, ReadOnlyMemory<byte> bytes) =>
-            ThrowInvalidEnum();
-
-        private void ThrowInvalidEnum() =>
-            throw new InvalidOperationException(
-                "Invalid operation for enum serialization, expected integer value."
-            );
     }
 }
 
@@ -403,5 +319,16 @@ partial class JsonSerializer : ITypeSerializer
     {
         _writer.WritePropertyName(typeInfo.GetFieldName(index));
         _writer.WriteBase64StringValue(bytes.Span);
+    }
+
+    void ITypeSerializer.WriteEnum(
+        ISerdeInfo typeInfo,
+        int index,
+        ISerdeInfo fieldInfo,
+        int ordinal
+    )
+    {
+        _writer.WritePropertyName(typeInfo.GetFieldName(index));
+        WriteEnum(fieldInfo, ordinal);
     }
 }

--- a/test/Serde.Generation.Test/ProxyTests.cs
+++ b/test/Serde.Generation.Test/ProxyTests.cs
@@ -628,13 +628,37 @@ public readonly partial struct ArrayAsId
         }
 
         [Fact]
-        public Task AsCombinedWithEnum()
+        public Task AsUnderlyingOnEnum()
+        {
+            var src = """
+using Serde;
+
+[GenerateSerde(AsUnderlying = true)]
+public enum Color { Red, Green, Blue }
+""";
+            return VerifyMultiFile(src);
+        }
+
+        [Fact]
+        public Task AsOnEnumReportsError()
         {
             var src = """
 using Serde;
 
 [GenerateSerde(As = typeof(int))]
 public enum BadEnum { A, B }
+""";
+            return VerifyMultiFile(src);
+        }
+
+        [Fact]
+        public Task AsUnderlyingOnNonEnumReportsError()
+        {
+            var src = """
+using Serde;
+
+[GenerateSerde(AsUnderlying = true)]
+public partial struct NotAnEnum { public int Value; }
 """;
             return VerifyMultiFile(src);
         }

--- a/test/Serde.Generation.Test/test_output/AllInOneTest.GeneratorTest/Serde.Test.AllInOne.ColorEnumProxy.ISerde.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/AllInOneTest.GeneratorTest/Serde.Test.AllInOne.ColorEnumProxy.ISerde.g.verified.cs
@@ -14,42 +14,26 @@ partial record AllInOne
         void global::Serde.ISerialize<Serde.Test.AllInOne.ColorEnum>.Serialize(Serde.Test.AllInOne.ColorEnum value, global::Serde.ISerializer serializer)
         {
             var _l_info = global::Serde.SerdeInfoProvider.GetInfo(this);
-            var _l_type = serializer.WriteType(_l_info);
-            var index = value switch
+            var _l_index = value switch
             {
                 Serde.Test.AllInOne.ColorEnum.Red => 0,
                 Serde.Test.AllInOne.ColorEnum.Blue => 1,
                 Serde.Test.AllInOne.ColorEnum.Green => 2,
                 var v => throw new InvalidOperationException($"Cannot serialize unnamed enum value '{v}' of enum 'ColorEnum'"),
             };
-            _l_type.WriteI32(_l_info, index, (int)value);
-            _l_type.End(_l_info);
+            serializer.WriteEnum(_l_info, _l_index);
+
         }
         Serde.Test.AllInOne.ColorEnum IDeserialize<Serde.Test.AllInOne.ColorEnum>.Deserialize(IDeserializer deserializer)
         {
             var serdeInfo = global::Serde.SerdeInfoProvider.GetInfo(this);
-            var de = deserializer.ReadType(serdeInfo);
-            var (index, errorName) = de.TryReadIndexWithName(serdeInfo);
-            if (index == ITypeDeserializer.IndexNotFound)
-            {
-                throw Serde.DeserializeException.UnknownMember(errorName!, serdeInfo);
-            }
-            Serde.Test.AllInOne.ColorEnum _l_result;
-            if (index == ITypeDeserializer.EndOfType)
-            {
-                // Assume we want to read the underlying value
-                _l_result = (Serde.Test.AllInOne.ColorEnum)de.ReadI32(serdeInfo, index);
-            }
-            else
-            {
-                _l_result = index switch {
-                    0 => Serde.Test.AllInOne.ColorEnum.Red,
-                    1 => Serde.Test.AllInOne.ColorEnum.Blue,
-                    2 => Serde.Test.AllInOne.ColorEnum.Green,
-                    _ => throw new InvalidOperationException($"Unexpected index: {index}")
-                };
-            }
-            de.End(serdeInfo);
+            var index = deserializer.ReadEnum(serdeInfo);
+            Serde.Test.AllInOne.ColorEnum _l_result = index switch {
+                0 => Serde.Test.AllInOne.ColorEnum.Red,
+                1 => Serde.Test.AllInOne.ColorEnum.Blue,
+                2 => Serde.Test.AllInOne.ColorEnum.Green,
+                _ => throw new InvalidOperationException($"Unexpected index: {index}")
+            };
             return _l_result;
         }
     }

--- a/test/Serde.Generation.Test/test_output/DeserializeTests.EnumMember/ColorByteProxy.IDeserialize.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/DeserializeTests.EnumMember/ColorByteProxy.IDeserialize.g.verified.cs
@@ -9,28 +9,13 @@ partial class ColorByteProxy : Serde.IDeserialize<ColorByte>
     ColorByte IDeserialize<ColorByte>.Deserialize(IDeserializer deserializer)
     {
         var serdeInfo = global::Serde.SerdeInfoProvider.GetInfo(this);
-        var de = deserializer.ReadType(serdeInfo);
-        var (index, errorName) = de.TryReadIndexWithName(serdeInfo);
-        if (index == ITypeDeserializer.IndexNotFound)
-        {
-            throw Serde.DeserializeException.UnknownMember(errorName!, serdeInfo);
-        }
-        ColorByte _l_result;
-        if (index == ITypeDeserializer.EndOfType)
-        {
-            // Assume we want to read the underlying value
-            _l_result = (ColorByte)de.ReadU8(serdeInfo, index);
-        }
-        else
-        {
-            _l_result = index switch {
-                0 => ColorByte.Red,
-                1 => ColorByte.Green,
-                2 => ColorByte.Blue,
-                _ => throw new InvalidOperationException($"Unexpected index: {index}")
-            };
-        }
-        de.End(serdeInfo);
+        var index = deserializer.ReadEnum(serdeInfo);
+        ColorByte _l_result = index switch {
+            0 => ColorByte.Red,
+            1 => ColorByte.Green,
+            2 => ColorByte.Blue,
+            _ => throw new InvalidOperationException($"Unexpected index: {index}")
+        };
         return _l_result;
     }
 }

--- a/test/Serde.Generation.Test/test_output/DeserializeTests.EnumMember/ColorIntProxy.IDeserialize.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/DeserializeTests.EnumMember/ColorIntProxy.IDeserialize.g.verified.cs
@@ -9,28 +9,13 @@ partial class ColorIntProxy : Serde.IDeserialize<ColorInt>
     ColorInt IDeserialize<ColorInt>.Deserialize(IDeserializer deserializer)
     {
         var serdeInfo = global::Serde.SerdeInfoProvider.GetInfo(this);
-        var de = deserializer.ReadType(serdeInfo);
-        var (index, errorName) = de.TryReadIndexWithName(serdeInfo);
-        if (index == ITypeDeserializer.IndexNotFound)
-        {
-            throw Serde.DeserializeException.UnknownMember(errorName!, serdeInfo);
-        }
-        ColorInt _l_result;
-        if (index == ITypeDeserializer.EndOfType)
-        {
-            // Assume we want to read the underlying value
-            _l_result = (ColorInt)de.ReadI32(serdeInfo, index);
-        }
-        else
-        {
-            _l_result = index switch {
-                0 => ColorInt.Red,
-                1 => ColorInt.Green,
-                2 => ColorInt.Blue,
-                _ => throw new InvalidOperationException($"Unexpected index: {index}")
-            };
-        }
-        de.End(serdeInfo);
+        var index = deserializer.ReadEnum(serdeInfo);
+        ColorInt _l_result = index switch {
+            0 => ColorInt.Red,
+            1 => ColorInt.Green,
+            2 => ColorInt.Blue,
+            _ => throw new InvalidOperationException($"Unexpected index: {index}")
+        };
         return _l_result;
     }
 }

--- a/test/Serde.Generation.Test/test_output/DeserializeTests.EnumMember/ColorLongProxy.IDeserialize.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/DeserializeTests.EnumMember/ColorLongProxy.IDeserialize.g.verified.cs
@@ -9,28 +9,13 @@ partial class ColorLongProxy : Serde.IDeserialize<ColorLong>
     ColorLong IDeserialize<ColorLong>.Deserialize(IDeserializer deserializer)
     {
         var serdeInfo = global::Serde.SerdeInfoProvider.GetInfo(this);
-        var de = deserializer.ReadType(serdeInfo);
-        var (index, errorName) = de.TryReadIndexWithName(serdeInfo);
-        if (index == ITypeDeserializer.IndexNotFound)
-        {
-            throw Serde.DeserializeException.UnknownMember(errorName!, serdeInfo);
-        }
-        ColorLong _l_result;
-        if (index == ITypeDeserializer.EndOfType)
-        {
-            // Assume we want to read the underlying value
-            _l_result = (ColorLong)de.ReadI64(serdeInfo, index);
-        }
-        else
-        {
-            _l_result = index switch {
-                0 => ColorLong.Red,
-                1 => ColorLong.Green,
-                2 => ColorLong.Blue,
-                _ => throw new InvalidOperationException($"Unexpected index: {index}")
-            };
-        }
-        de.End(serdeInfo);
+        var index = deserializer.ReadEnum(serdeInfo);
+        ColorLong _l_result = index switch {
+            0 => ColorLong.Red,
+            1 => ColorLong.Green,
+            2 => ColorLong.Blue,
+            _ => throw new InvalidOperationException($"Unexpected index: {index}")
+        };
         return _l_result;
     }
 }

--- a/test/Serde.Generation.Test/test_output/DeserializeTests.EnumMember/ColorULongProxy.IDeserialize.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/DeserializeTests.EnumMember/ColorULongProxy.IDeserialize.g.verified.cs
@@ -9,28 +9,13 @@ partial class ColorULongProxy : Serde.IDeserialize<ColorULong>
     ColorULong IDeserialize<ColorULong>.Deserialize(IDeserializer deserializer)
     {
         var serdeInfo = global::Serde.SerdeInfoProvider.GetInfo(this);
-        var de = deserializer.ReadType(serdeInfo);
-        var (index, errorName) = de.TryReadIndexWithName(serdeInfo);
-        if (index == ITypeDeserializer.IndexNotFound)
-        {
-            throw Serde.DeserializeException.UnknownMember(errorName!, serdeInfo);
-        }
-        ColorULong _l_result;
-        if (index == ITypeDeserializer.EndOfType)
-        {
-            // Assume we want to read the underlying value
-            _l_result = (ColorULong)de.ReadU64(serdeInfo, index);
-        }
-        else
-        {
-            _l_result = index switch {
-                0 => ColorULong.Red,
-                1 => ColorULong.Green,
-                2 => ColorULong.Blue,
-                _ => throw new InvalidOperationException($"Unexpected index: {index}")
-            };
-        }
-        de.End(serdeInfo);
+        var index = deserializer.ReadEnum(serdeInfo);
+        ColorULong _l_result = index switch {
+            0 => ColorULong.Red,
+            1 => ColorULong.Green,
+            2 => ColorULong.Blue,
+            _ => throw new InvalidOperationException($"Unexpected index: {index}")
+        };
         return _l_result;
     }
 }

--- a/test/Serde.Generation.Test/test_output/FieldInitializerTests/FieldInitializerEnum#ColorProxy.IDeserialize.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/FieldInitializerTests/FieldInitializerEnum#ColorProxy.IDeserialize.g.verified.cs
@@ -9,28 +9,13 @@ partial class ColorProxy : Serde.IDeserialize<Color>
     Color IDeserialize<Color>.Deserialize(IDeserializer deserializer)
     {
         var serdeInfo = global::Serde.SerdeInfoProvider.GetInfo(this);
-        var de = deserializer.ReadType(serdeInfo);
-        var (index, errorName) = de.TryReadIndexWithName(serdeInfo);
-        if (index == ITypeDeserializer.IndexNotFound)
-        {
-            throw Serde.DeserializeException.UnknownMember(errorName!, serdeInfo);
-        }
-        Color _l_result;
-        if (index == ITypeDeserializer.EndOfType)
-        {
-            // Assume we want to read the underlying value
-            _l_result = (Color)de.ReadI32(serdeInfo, index);
-        }
-        else
-        {
-            _l_result = index switch {
-                0 => Color.Red,
-                1 => Color.Green,
-                2 => Color.Blue,
-                _ => throw new InvalidOperationException($"Unexpected index: {index}")
-            };
-        }
-        de.End(serdeInfo);
+        var index = deserializer.ReadEnum(serdeInfo);
+        Color _l_result = index switch {
+            0 => Color.Red,
+            1 => Color.Green,
+            2 => Color.Blue,
+            _ => throw new InvalidOperationException($"Unexpected index: {index}")
+        };
         return _l_result;
     }
 }

--- a/test/Serde.Generation.Test/test_output/FieldInitializerTests/FieldInitializerEnumCast#Other.ColorProxy.IDeserialize.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/FieldInitializerTests/FieldInitializerEnumCast#Other.ColorProxy.IDeserialize.g.verified.cs
@@ -12,27 +12,12 @@ partial class ColorProxy : Serde.IDeserialize<Other.Color>
     Other.Color IDeserialize<Other.Color>.Deserialize(IDeserializer deserializer)
     {
         var serdeInfo = global::Serde.SerdeInfoProvider.GetInfo(this);
-        var de = deserializer.ReadType(serdeInfo);
-        var (index, errorName) = de.TryReadIndexWithName(serdeInfo);
-        if (index == ITypeDeserializer.IndexNotFound)
-        {
-            throw Serde.DeserializeException.UnknownMember(errorName!, serdeInfo);
-        }
-        Other.Color _l_result;
-        if (index == ITypeDeserializer.EndOfType)
-        {
-            // Assume we want to read the underlying value
-            _l_result = (Other.Color)de.ReadI32(serdeInfo, index);
-        }
-        else
-        {
-            _l_result = index switch {
-                0 => Other.Color.Red,
-                1 => Other.Color.Green,
-                _ => throw new InvalidOperationException($"Unexpected index: {index}")
-            };
-        }
-        de.End(serdeInfo);
+        var index = deserializer.ReadEnum(serdeInfo);
+        Other.Color _l_result = index switch {
+            0 => Other.Color.Red,
+            1 => Other.Color.Green,
+            _ => throw new InvalidOperationException($"Unexpected index: {index}")
+        };
         return _l_result;
     }
 }

--- a/test/Serde.Generation.Test/test_output/MemberFormatTests.EnumFormat/ColorEnumProxy.ISerde.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/MemberFormatTests.EnumFormat/ColorEnumProxy.ISerde.g.verified.cs
@@ -9,42 +9,26 @@ partial class ColorEnumProxy : Serde.ISerde<ColorEnum>
     void global::Serde.ISerialize<ColorEnum>.Serialize(ColorEnum value, global::Serde.ISerializer serializer)
     {
         var _l_info = global::Serde.SerdeInfoProvider.GetInfo(this);
-        var _l_type = serializer.WriteType(_l_info);
-        var index = value switch
+        var _l_index = value switch
         {
             ColorEnum.Red => 0,
             ColorEnum.Green => 1,
             ColorEnum.Blue => 2,
             var v => throw new InvalidOperationException($"Cannot serialize unnamed enum value '{v}' of enum 'ColorEnum'"),
         };
-        _l_type.WriteI32(_l_info, index, (int)value);
-        _l_type.End(_l_info);
+        serializer.WriteEnum(_l_info, _l_index);
+
     }
     ColorEnum IDeserialize<ColorEnum>.Deserialize(IDeserializer deserializer)
     {
         var serdeInfo = global::Serde.SerdeInfoProvider.GetInfo(this);
-        var de = deserializer.ReadType(serdeInfo);
-        var (index, errorName) = de.TryReadIndexWithName(serdeInfo);
-        if (index == ITypeDeserializer.IndexNotFound)
-        {
-            throw Serde.DeserializeException.UnknownMember(errorName!, serdeInfo);
-        }
-        ColorEnum _l_result;
-        if (index == ITypeDeserializer.EndOfType)
-        {
-            // Assume we want to read the underlying value
-            _l_result = (ColorEnum)de.ReadI32(serdeInfo, index);
-        }
-        else
-        {
-            _l_result = index switch {
-                0 => ColorEnum.Red,
-                1 => ColorEnum.Green,
-                2 => ColorEnum.Blue,
-                _ => throw new InvalidOperationException($"Unexpected index: {index}")
-            };
-        }
-        de.End(serdeInfo);
+        var index = deserializer.ReadEnum(serdeInfo);
+        ColorEnum _l_result = index switch {
+            0 => ColorEnum.Red,
+            1 => ColorEnum.Green,
+            2 => ColorEnum.Blue,
+            _ => throw new InvalidOperationException($"Unexpected index: {index}")
+        };
         return _l_result;
     }
 }

--- a/test/Serde.Generation.Test/test_output/MemberFormatTests.EnumValues/ColorEnumProxy.ISerde.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/MemberFormatTests.EnumValues/ColorEnumProxy.ISerde.g.verified.cs
@@ -9,42 +9,26 @@ partial class ColorEnumProxy : Serde.ISerde<ColorEnum>
     void global::Serde.ISerialize<ColorEnum>.Serialize(ColorEnum value, global::Serde.ISerializer serializer)
     {
         var _l_info = global::Serde.SerdeInfoProvider.GetInfo(this);
-        var _l_type = serializer.WriteType(_l_info);
-        var index = value switch
+        var _l_index = value switch
         {
             ColorEnum.Red => 0,
             ColorEnum.Green => 1,
             ColorEnum.Blue => 2,
             var v => throw new InvalidOperationException($"Cannot serialize unnamed enum value '{v}' of enum 'ColorEnum'"),
         };
-        _l_type.WriteI32(_l_info, index, (int)value);
-        _l_type.End(_l_info);
+        serializer.WriteEnum(_l_info, _l_index);
+
     }
     ColorEnum IDeserialize<ColorEnum>.Deserialize(IDeserializer deserializer)
     {
         var serdeInfo = global::Serde.SerdeInfoProvider.GetInfo(this);
-        var de = deserializer.ReadType(serdeInfo);
-        var (index, errorName) = de.TryReadIndexWithName(serdeInfo);
-        if (index == ITypeDeserializer.IndexNotFound)
-        {
-            throw Serde.DeserializeException.UnknownMember(errorName!, serdeInfo);
-        }
-        ColorEnum _l_result;
-        if (index == ITypeDeserializer.EndOfType)
-        {
-            // Assume we want to read the underlying value
-            _l_result = (ColorEnum)de.ReadI32(serdeInfo, index);
-        }
-        else
-        {
-            _l_result = index switch {
-                0 => ColorEnum.Red,
-                1 => ColorEnum.Green,
-                2 => ColorEnum.Blue,
-                _ => throw new InvalidOperationException($"Unexpected index: {index}")
-            };
-        }
-        de.End(serdeInfo);
+        var index = deserializer.ReadEnum(serdeInfo);
+        ColorEnum _l_result = index switch {
+            0 => ColorEnum.Red,
+            1 => ColorEnum.Green,
+            2 => ColorEnum.Blue,
+            _ => throw new InvalidOperationException($"Unexpected index: {index}")
+        };
         return _l_result;
     }
 }

--- a/test/Serde.Generation.Test/test_output/ProxyTests.AsOnEnumReportsError/target.verified.txt
+++ b/test/Serde.Generation.Test/test_output/ProxyTests.AsOnEnumReportsError/target.verified.txt
@@ -1,0 +1,23 @@
+﻿{
+  Diagnostics: [
+    {
+      Location: /*
+
+[GenerateSerde(As = typeof(int))]
+ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+public enum BadEnum { A, B }
+*/
+ : (2,1)-(2,32),
+      Message: The 'As' option cannot be applied to enum 'BadEnum'. Use 'AsUnderlying = true' to serialize an enum as its underlying value.,
+      Severity: Error,
+      Descriptor: {
+        Id: ERR_AsTypeOnEnum,
+        Title: ,
+        MessageFormat: The 'As' option cannot be applied to enum 'BadEnum'. Use 'AsUnderlying = true' to serialize an enum as its underlying value.,
+        Category: Serde,
+        DefaultSeverity: Error,
+        IsEnabledByDefault: true
+      }
+    }
+  ]
+}

--- a/test/Serde.Generation.Test/test_output/ProxyTests.AsUnderlyingOnEnum/ColorProxy.ISerde.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/ProxyTests.AsUnderlyingOnEnum/ColorProxy.ISerde.g.verified.cs
@@ -1,0 +1,18 @@
+﻿//HintName: ColorProxy.ISerde.g.cs
+
+#nullable enable
+
+using System;
+using Serde;
+partial class ColorProxy : Serde.ISerde<Color>
+{
+    void global::Serde.ISerialize<Color>.Serialize(Color value, global::Serde.ISerializer serializer)
+    {
+        serializer.WriteI32((int)value);
+
+    }
+    Color IDeserialize<Color>.Deserialize(IDeserializer deserializer)
+    {
+        return (Color)deserializer.ReadI32();
+    }
+}

--- a/test/Serde.Generation.Test/test_output/ProxyTests.AsUnderlyingOnEnum/ColorProxy.ISerdeInfoProvider.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/ProxyTests.AsUnderlyingOnEnum/ColorProxy.ISerdeInfoProvider.g.verified.cs
@@ -1,0 +1,16 @@
+﻿//HintName: ColorProxy.ISerdeInfoProvider.g.cs
+
+#nullable enable
+partial class ColorProxy : global::Serde.ISerdeInfoProvider
+{
+    global::Serde.ISerdeInfo global::Serde.ISerdeInfoProvider.SerdeInfo { get; } = Serde.SerdeInfo.MakeEnum(
+        "Color",
+        typeof(Color).GetCustomAttributesData(),
+        global::Serde.SerdeInfoProvider.GetSerializeInfo<int, global::Serde.I32Proxy>(),
+        new (string, System.Reflection.MemberInfo?)[] {
+            ("red", typeof(Color).GetField("Red")),
+            ("green", typeof(Color).GetField("Green")),
+            ("blue", typeof(Color).GetField("Blue"))
+        }
+    );
+}

--- a/test/Serde.Generation.Test/test_output/ProxyTests.AsUnderlyingOnEnum/ColorProxy.ISerdeProvider.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/ProxyTests.AsUnderlyingOnEnum/ColorProxy.ISerdeProvider.g.verified.cs
@@ -1,0 +1,6 @@
+﻿//HintName: ColorProxy.ISerdeProvider.g.cs
+partial class ColorProxy : Serde.ISerdeProvider<ColorProxy, ColorProxy, Color>
+{
+    static ColorProxy global::Serde.ISerdeProvider<ColorProxy, ColorProxy, Color>.Instance { get; }
+        = new ColorProxy();
+}

--- a/test/Serde.Generation.Test/test_output/ProxyTests.AsUnderlyingOnEnum/ColorProxy.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/ProxyTests.AsUnderlyingOnEnum/ColorProxy.g.verified.cs
@@ -1,0 +1,2 @@
+﻿//HintName: ColorProxy.g.cs
+sealed partial class ColorProxy;

--- a/test/Serde.Generation.Test/test_output/ProxyTests.AsUnderlyingOnNonEnumReportsError/target.verified.txt
+++ b/test/Serde.Generation.Test/test_output/ProxyTests.AsUnderlyingOnNonEnumReportsError/target.verified.txt
@@ -1,0 +1,23 @@
+﻿{
+  Diagnostics: [
+    {
+      Location: /*
+
+[GenerateSerde(AsUnderlying = true)]
+ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+public partial struct NotAnEnum { public int Value; }
+*/
+ : (2,1)-(2,35),
+      Message: The 'AsUnderlying' option can only be applied to enums, but 'NotAnEnum' is not an enum.,
+      Severity: Error,
+      Descriptor: {
+        Id: ERR_AsUnderlyingOnNonEnum,
+        Title: ,
+        MessageFormat: The 'AsUnderlying' option can only be applied to enums, but 'NotAnEnum' is not an enum.,
+        Category: Serde,
+        DefaultSeverity: Error,
+        IsEnabledByDefault: true
+      }
+    }
+  ]
+}

--- a/test/Serde.Generation.Test/test_output/ProxyTests.ImmutableArrayEnumDeserialize/Test.ChannelProxy.IDeserialize.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/ProxyTests.ImmutableArrayEnumDeserialize/Test.ChannelProxy.IDeserialize.g.verified.cs
@@ -12,28 +12,13 @@ partial class ChannelProxy : Serde.IDeserialize<Test.Channel>
     Test.Channel IDeserialize<Test.Channel>.Deserialize(IDeserializer deserializer)
     {
         var serdeInfo = global::Serde.SerdeInfoProvider.GetInfo(this);
-        var de = deserializer.ReadType(serdeInfo);
-        var (index, errorName) = de.TryReadIndexWithName(serdeInfo);
-        if (index == ITypeDeserializer.IndexNotFound)
-        {
-            throw Serde.DeserializeException.UnknownMember(errorName!, serdeInfo);
-        }
-        Test.Channel _l_result;
-        if (index == ITypeDeserializer.EndOfType)
-        {
-            // Assume we want to read the underlying value
-            _l_result = (Test.Channel)de.ReadI32(serdeInfo, index);
-        }
-        else
-        {
-            _l_result = index switch {
-                0 => Test.Channel.A,
-                1 => Test.Channel.B,
-                2 => Test.Channel.C,
-                _ => throw new InvalidOperationException($"Unexpected index: {index}")
-            };
-        }
-        de.End(serdeInfo);
+        var index = deserializer.ReadEnum(serdeInfo);
+        Test.Channel _l_result = index switch {
+            0 => Test.Channel.A,
+            1 => Test.Channel.B,
+            2 => Test.Channel.C,
+            _ => throw new InvalidOperationException($"Unexpected index: {index}")
+        };
         return _l_result;
     }
 }

--- a/test/Serde.Generation.Test/test_output/SerdeTests.OrdinalOnEnumMemberReportsError/ColorProxy.ISerde.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/SerdeTests.OrdinalOnEnumMemberReportsError/ColorProxy.ISerde.g.verified.cs
@@ -9,42 +9,26 @@ partial class ColorProxy : Serde.ISerde<Color>
     void global::Serde.ISerialize<Color>.Serialize(Color value, global::Serde.ISerializer serializer)
     {
         var _l_info = global::Serde.SerdeInfoProvider.GetInfo(this);
-        var _l_type = serializer.WriteType(_l_info);
-        var index = value switch
+        var _l_index = value switch
         {
             Color.Red => 0,
             Color.Green => 1,
             Color.Blue => 2,
             var v => throw new InvalidOperationException($"Cannot serialize unnamed enum value '{v}' of enum 'Color'"),
         };
-        _l_type.WriteI32(_l_info, index, (int)value);
-        _l_type.End(_l_info);
+        serializer.WriteEnum(_l_info, _l_index);
+
     }
     Color IDeserialize<Color>.Deserialize(IDeserializer deserializer)
     {
         var serdeInfo = global::Serde.SerdeInfoProvider.GetInfo(this);
-        var de = deserializer.ReadType(serdeInfo);
-        var (index, errorName) = de.TryReadIndexWithName(serdeInfo);
-        if (index == ITypeDeserializer.IndexNotFound)
-        {
-            throw Serde.DeserializeException.UnknownMember(errorName!, serdeInfo);
-        }
-        Color _l_result;
-        if (index == ITypeDeserializer.EndOfType)
-        {
-            // Assume we want to read the underlying value
-            _l_result = (Color)de.ReadI32(serdeInfo, index);
-        }
-        else
-        {
-            _l_result = index switch {
-                0 => Color.Red,
-                1 => Color.Green,
-                2 => Color.Blue,
-                _ => throw new InvalidOperationException($"Unexpected index: {index}")
-            };
-        }
-        de.End(serdeInfo);
+        var index = deserializer.ReadEnum(serdeInfo);
+        Color _l_result = index switch {
+            0 => Color.Red,
+            1 => Color.Green,
+            2 => Color.Blue,
+            _ => throw new InvalidOperationException($"Unexpected index: {index}")
+        };
         return _l_result;
     }
 }

--- a/test/Serde.Generation.Test/test_output/SerializeTests.EnumMember/Some.Nested.Namespace.ColorByteProxy.ISerialize.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/SerializeTests.EnumMember/Some.Nested.Namespace.ColorByteProxy.ISerialize.g.verified.cs
@@ -12,16 +12,15 @@ partial class ColorByteProxy : Serde.ISerialize<Some.Nested.Namespace.ColorByte>
     void global::Serde.ISerialize<Some.Nested.Namespace.ColorByte>.Serialize(Some.Nested.Namespace.ColorByte value, global::Serde.ISerializer serializer)
     {
         var _l_info = global::Serde.SerdeInfoProvider.GetInfo(this);
-        var _l_type = serializer.WriteType(_l_info);
-        var index = value switch
+        var _l_index = value switch
         {
             Some.Nested.Namespace.ColorByte.Red => 0,
             Some.Nested.Namespace.ColorByte.Green => 1,
             Some.Nested.Namespace.ColorByte.Blue => 2,
             var v => throw new InvalidOperationException($"Cannot serialize unnamed enum value '{v}' of enum 'ColorByte'"),
         };
-        _l_type.WriteU8(_l_info, index, (byte)value);
-        _l_type.End(_l_info);
+        serializer.WriteEnum(_l_info, _l_index);
+
     }
 
 }

--- a/test/Serde.Generation.Test/test_output/SerializeTests.EnumMember/Some.Nested.Namespace.ColorIntProxy.ISerialize.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/SerializeTests.EnumMember/Some.Nested.Namespace.ColorIntProxy.ISerialize.g.verified.cs
@@ -12,16 +12,15 @@ partial class ColorIntProxy : Serde.ISerialize<Some.Nested.Namespace.ColorInt>
     void global::Serde.ISerialize<Some.Nested.Namespace.ColorInt>.Serialize(Some.Nested.Namespace.ColorInt value, global::Serde.ISerializer serializer)
     {
         var _l_info = global::Serde.SerdeInfoProvider.GetInfo(this);
-        var _l_type = serializer.WriteType(_l_info);
-        var index = value switch
+        var _l_index = value switch
         {
             Some.Nested.Namespace.ColorInt.Red => 0,
             Some.Nested.Namespace.ColorInt.Green => 1,
             Some.Nested.Namespace.ColorInt.Blue => 2,
             var v => throw new InvalidOperationException($"Cannot serialize unnamed enum value '{v}' of enum 'ColorInt'"),
         };
-        _l_type.WriteI32(_l_info, index, (int)value);
-        _l_type.End(_l_info);
+        serializer.WriteEnum(_l_info, _l_index);
+
     }
 
 }

--- a/test/Serde.Generation.Test/test_output/SerializeTests.EnumMember/Some.Nested.Namespace.ColorLongProxy.ISerialize.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/SerializeTests.EnumMember/Some.Nested.Namespace.ColorLongProxy.ISerialize.g.verified.cs
@@ -12,16 +12,15 @@ partial class ColorLongProxy : Serde.ISerialize<Some.Nested.Namespace.ColorLong>
     void global::Serde.ISerialize<Some.Nested.Namespace.ColorLong>.Serialize(Some.Nested.Namespace.ColorLong value, global::Serde.ISerializer serializer)
     {
         var _l_info = global::Serde.SerdeInfoProvider.GetInfo(this);
-        var _l_type = serializer.WriteType(_l_info);
-        var index = value switch
+        var _l_index = value switch
         {
             Some.Nested.Namespace.ColorLong.Red => 0,
             Some.Nested.Namespace.ColorLong.Green => 1,
             Some.Nested.Namespace.ColorLong.Blue => 2,
             var v => throw new InvalidOperationException($"Cannot serialize unnamed enum value '{v}' of enum 'ColorLong'"),
         };
-        _l_type.WriteI64(_l_info, index, (long)value);
-        _l_type.End(_l_info);
+        serializer.WriteEnum(_l_info, _l_index);
+
     }
 
 }

--- a/test/Serde.Generation.Test/test_output/SerializeTests.EnumMember/Some.Nested.Namespace.ColorULongProxy.ISerialize.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/SerializeTests.EnumMember/Some.Nested.Namespace.ColorULongProxy.ISerialize.g.verified.cs
@@ -12,16 +12,15 @@ partial class ColorULongProxy : Serde.ISerialize<Some.Nested.Namespace.ColorULon
     void global::Serde.ISerialize<Some.Nested.Namespace.ColorULong>.Serialize(Some.Nested.Namespace.ColorULong value, global::Serde.ISerializer serializer)
     {
         var _l_info = global::Serde.SerdeInfoProvider.GetInfo(this);
-        var _l_type = serializer.WriteType(_l_info);
-        var index = value switch
+        var _l_index = value switch
         {
             Some.Nested.Namespace.ColorULong.Red => 0,
             Some.Nested.Namespace.ColorULong.Green => 1,
             Some.Nested.Namespace.ColorULong.Blue => 2,
             var v => throw new InvalidOperationException($"Cannot serialize unnamed enum value '{v}' of enum 'ColorULong'"),
         };
-        _l_type.WriteU64(_l_info, index, (ulong)value);
-        _l_type.End(_l_info);
+        serializer.WriteEnum(_l_info, _l_index);
+
     }
 
 }

--- a/test/Serde.Generation.Test/test_output/SerializeTests.NestedEnumWrapper/RgbProxy.ISerialize.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/SerializeTests.NestedEnumWrapper/RgbProxy.ISerialize.g.verified.cs
@@ -9,16 +9,15 @@ partial class RgbProxy : Serde.ISerialize<Rgb>
     void global::Serde.ISerialize<Rgb>.Serialize(Rgb value, global::Serde.ISerializer serializer)
     {
         var _l_info = global::Serde.SerdeInfoProvider.GetInfo(this);
-        var _l_type = serializer.WriteType(_l_info);
-        var index = value switch
+        var _l_index = value switch
         {
             Rgb.Red => 0,
             Rgb.Green => 1,
             Rgb.Blue => 2,
             var v => throw new InvalidOperationException($"Cannot serialize unnamed enum value '{v}' of enum 'Rgb'"),
         };
-        _l_type.WriteI32(_l_info, index, (int)value);
-        _l_type.End(_l_info);
+        serializer.WriteEnum(_l_info, _l_index);
+
     }
 
 }

--- a/test/Serde.Test/AsTests.cs
+++ b/test/Serde.Test/AsTests.cs
@@ -100,4 +100,41 @@ public partial class AsTests
         var back = JsonSerializer.Deserialize<TupleWrapper>(json);
         Assert.Equal(w, back);
     }
+
+    [GenerateSerde(AsUnderlying = true)]
+    public enum Priority
+    {
+        Low = 1,
+        Medium = 5,
+        High = 10,
+    }
+
+    [Fact]
+    public void RoundTripEnumAsInt()
+    {
+        // Unlike the default by-name enum format, `AsUnderlying = true` serializes the enum as its
+        // underlying integral value (5), not its name ("medium") or ordinal index (1).
+        var json = JsonSerializer.Serialize<Priority, PriorityProxy>(Priority.Medium);
+        Assert.Equal("5", json);
+
+        var back = JsonSerializer.Deserialize<Priority, PriorityProxy>(json);
+        Assert.Equal(Priority.Medium, back);
+    }
+
+    [GenerateSerde(AsUnderlying = true)]
+    public enum Level : byte
+    {
+        A = 0,
+        B = 200,
+    }
+
+    [Fact]
+    public void RoundTripEnumAsByte()
+    {
+        var json = JsonSerializer.Serialize<Level, LevelProxy>(Level.B);
+        Assert.Equal("200", json);
+
+        var back = JsonSerializer.Deserialize<Level, LevelProxy>(json);
+        Assert.Equal(Level.B, back);
+    }
 }

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.AllInOne.ColorEnumProxy.ISerde.g.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.AllInOne.ColorEnumProxy.ISerde.g.cs
@@ -13,42 +13,26 @@ partial record AllInOne
         void global::Serde.ISerialize<Serde.Test.AllInOne.ColorEnum>.Serialize(Serde.Test.AllInOne.ColorEnum value, global::Serde.ISerializer serializer)
         {
             var _l_info = global::Serde.SerdeInfoProvider.GetInfo(this);
-            var _l_type = serializer.WriteType(_l_info);
-            var index = value switch
+            var _l_index = value switch
             {
                 Serde.Test.AllInOne.ColorEnum.Red => 0,
                 Serde.Test.AllInOne.ColorEnum.Blue => 1,
                 Serde.Test.AllInOne.ColorEnum.Green => 2,
                 var v => throw new InvalidOperationException($"Cannot serialize unnamed enum value '{v}' of enum 'ColorEnum'"),
             };
-            _l_type.WriteI32(_l_info, index, (int)value);
-            _l_type.End(_l_info);
+            serializer.WriteEnum(_l_info, _l_index);
+
         }
         Serde.Test.AllInOne.ColorEnum IDeserialize<Serde.Test.AllInOne.ColorEnum>.Deserialize(IDeserializer deserializer)
         {
             var serdeInfo = global::Serde.SerdeInfoProvider.GetInfo(this);
-            var de = deserializer.ReadType(serdeInfo);
-            var (index, errorName) = de.TryReadIndexWithName(serdeInfo);
-            if (index == ITypeDeserializer.IndexNotFound)
-            {
-                throw Serde.DeserializeException.UnknownMember(errorName!, serdeInfo);
-            }
-            Serde.Test.AllInOne.ColorEnum _l_result;
-            if (index == ITypeDeserializer.EndOfType)
-            {
-                // Assume we want to read the underlying value
-                _l_result = (Serde.Test.AllInOne.ColorEnum)de.ReadI32(serdeInfo, index);
-            }
-            else
-            {
-                _l_result = index switch {
-                    0 => Serde.Test.AllInOne.ColorEnum.Red,
-                    1 => Serde.Test.AllInOne.ColorEnum.Blue,
-                    2 => Serde.Test.AllInOne.ColorEnum.Green,
-                    _ => throw new InvalidOperationException($"Unexpected index: {index}")
-                };
-            }
-            de.End(serdeInfo);
+            var index = deserializer.ReadEnum(serdeInfo);
+            Serde.Test.AllInOne.ColorEnum _l_result = index switch {
+                0 => Serde.Test.AllInOne.ColorEnum.Red,
+                1 => Serde.Test.AllInOne.ColorEnum.Blue,
+                2 => Serde.Test.AllInOne.ColorEnum.Green,
+                _ => throw new InvalidOperationException($"Unexpected index: {index}")
+            };
             return _l_result;
         }
     }

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.AsTests.LevelProxy.ISerde.g.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.AsTests.LevelProxy.ISerde.g.cs
@@ -1,0 +1,23 @@
+
+#nullable enable
+
+using System;
+using Serde;
+
+namespace Serde.Test;
+
+partial class AsTests
+{
+    partial class LevelProxy : Serde.ISerde<Serde.Test.AsTests.Level>
+    {
+        void global::Serde.ISerialize<Serde.Test.AsTests.Level>.Serialize(Serde.Test.AsTests.Level value, global::Serde.ISerializer serializer)
+        {
+            serializer.WriteU8((byte)value);
+
+        }
+        Serde.Test.AsTests.Level IDeserialize<Serde.Test.AsTests.Level>.Deserialize(IDeserializer deserializer)
+        {
+            return (Serde.Test.AsTests.Level)deserializer.ReadU8();
+        }
+    }
+}

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.AsTests.LevelProxy.ISerdeInfoProvider.g.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.AsTests.LevelProxy.ISerdeInfoProvider.g.cs
@@ -1,0 +1,20 @@
+
+#nullable enable
+
+namespace Serde.Test;
+
+partial class AsTests
+{
+    partial class LevelProxy : global::Serde.ISerdeInfoProvider
+    {
+        global::Serde.ISerdeInfo global::Serde.ISerdeInfoProvider.SerdeInfo { get; } = Serde.SerdeInfo.MakeEnum(
+            "Level",
+            typeof(Serde.Test.AsTests.Level).GetCustomAttributesData(),
+            global::Serde.SerdeInfoProvider.GetSerializeInfo<byte, global::Serde.U8Proxy>(),
+            new (string, System.Reflection.MemberInfo?)[] {
+                ("a", typeof(Serde.Test.AsTests.Level).GetField("A")),
+                ("b", typeof(Serde.Test.AsTests.Level).GetField("B"))
+            }
+        );
+    }
+}

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.AsTests.LevelProxy.ISerdeProvider.g.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.AsTests.LevelProxy.ISerdeProvider.g.cs
@@ -1,0 +1,11 @@
+
+namespace Serde.Test;
+
+partial class AsTests
+{
+    partial class LevelProxy : Serde.ISerdeProvider<Serde.Test.AsTests.LevelProxy, Serde.Test.AsTests.LevelProxy, Serde.Test.AsTests.Level>
+    {
+        static Serde.Test.AsTests.LevelProxy global::Serde.ISerdeProvider<Serde.Test.AsTests.LevelProxy, Serde.Test.AsTests.LevelProxy, Serde.Test.AsTests.Level>.Instance { get; }
+            = new Serde.Test.AsTests.LevelProxy();
+    }
+}

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.AsTests.LevelProxy.g.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.AsTests.LevelProxy.g.cs
@@ -1,0 +1,7 @@
+
+namespace Serde.Test;
+
+partial class AsTests
+{
+    sealed partial class LevelProxy;
+}

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.AsTests.PriorityProxy.ISerde.g.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.AsTests.PriorityProxy.ISerde.g.cs
@@ -1,0 +1,23 @@
+
+#nullable enable
+
+using System;
+using Serde;
+
+namespace Serde.Test;
+
+partial class AsTests
+{
+    partial class PriorityProxy : Serde.ISerde<Serde.Test.AsTests.Priority>
+    {
+        void global::Serde.ISerialize<Serde.Test.AsTests.Priority>.Serialize(Serde.Test.AsTests.Priority value, global::Serde.ISerializer serializer)
+        {
+            serializer.WriteI32((int)value);
+
+        }
+        Serde.Test.AsTests.Priority IDeserialize<Serde.Test.AsTests.Priority>.Deserialize(IDeserializer deserializer)
+        {
+            return (Serde.Test.AsTests.Priority)deserializer.ReadI32();
+        }
+    }
+}

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.AsTests.PriorityProxy.ISerdeInfoProvider.g.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.AsTests.PriorityProxy.ISerdeInfoProvider.g.cs
@@ -1,0 +1,21 @@
+
+#nullable enable
+
+namespace Serde.Test;
+
+partial class AsTests
+{
+    partial class PriorityProxy : global::Serde.ISerdeInfoProvider
+    {
+        global::Serde.ISerdeInfo global::Serde.ISerdeInfoProvider.SerdeInfo { get; } = Serde.SerdeInfo.MakeEnum(
+            "Priority",
+            typeof(Serde.Test.AsTests.Priority).GetCustomAttributesData(),
+            global::Serde.SerdeInfoProvider.GetSerializeInfo<int, global::Serde.I32Proxy>(),
+            new (string, System.Reflection.MemberInfo?)[] {
+                ("low", typeof(Serde.Test.AsTests.Priority).GetField("Low")),
+                ("medium", typeof(Serde.Test.AsTests.Priority).GetField("Medium")),
+                ("high", typeof(Serde.Test.AsTests.Priority).GetField("High"))
+            }
+        );
+    }
+}

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.AsTests.PriorityProxy.ISerdeProvider.g.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.AsTests.PriorityProxy.ISerdeProvider.g.cs
@@ -1,0 +1,11 @@
+
+namespace Serde.Test;
+
+partial class AsTests
+{
+    partial class PriorityProxy : Serde.ISerdeProvider<Serde.Test.AsTests.PriorityProxy, Serde.Test.AsTests.PriorityProxy, Serde.Test.AsTests.Priority>
+    {
+        static Serde.Test.AsTests.PriorityProxy global::Serde.ISerdeProvider<Serde.Test.AsTests.PriorityProxy, Serde.Test.AsTests.PriorityProxy, Serde.Test.AsTests.Priority>.Instance { get; }
+            = new Serde.Test.AsTests.PriorityProxy();
+    }
+}

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.AsTests.PriorityProxy.g.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.AsTests.PriorityProxy.g.cs
@@ -1,0 +1,7 @@
+
+namespace Serde.Test;
+
+partial class AsTests
+{
+    sealed partial class PriorityProxy;
+}


### PR DESCRIPTION
Use string encoding by default for all enum serialization. Also adds the AsUnderlying flag to GenerateSerde to provide an option to choose the underlying value as the encoded format.

Also heavily streamlines the encoding paths, improving performance for serializing and deserializing