### PR TITLE
Mark members with preserved initializers as optional

### DIFF
--- a/src/generator/DataMemberSymbol.cs
+++ b/src/generator/DataMemberSymbol.cs
@@ -283,5 +283,31 @@ namespace Serde
             }
             return null;
         }
+
+        /// <summary>
+        /// Computes how this member should be initialized when deserializing into a local
+        /// variable: the <c>Initializer</c> expression to assign to the local, and whether the
+        /// member is <c>Required</c> to appear in the input.
+        ///
+        /// A member with a preserved initializer (see <see cref="GetConstInitializer"/>) already
+        /// has a valid default value, so it is optional unless <c>ThrowIfMissing</c> is explicitly
+        /// set to true. A non-nullable member without a preserved initializer stays required so
+        /// that a missing value is reported rather than silently left as <c>default!</c>.
+        ///
+        /// <paramref name="preserveInitializers"/> must be false when the deserializer is generated
+        /// outside the declaring type (e.g. a ForType proxy), where the initializer may reference
+        /// inaccessible members and so must not be relied upon.
+        /// </summary>
+        public (string Initializer, bool Required) GetDeserializeInitializer(
+            Compilation compilation,
+            bool preserveInitializers
+        )
+        {
+            var preserved = preserveInitializers ? GetConstInitializer(compilation) : null;
+            var required =
+                ThrowIfMissing == true
+                || (!IsNullable && ThrowIfMissing == null && preserved is null);
+            return (preserved ?? "default!", required);
+        }
     }
 }

--- a/src/generator/DeserializeImplGen.cs
+++ b/src/generator/DeserializeImplGen.cs
@@ -293,9 +293,10 @@ namespace Serde
                         readValueCall = $"ReadValue<{memberType}, {memberType}>";
                     }
                     var localName = GetLocalName(m);
-                    var initializer = preserveInitializers
-                        ? (m.GetConstInitializer(context.Compilation) ?? "default!")
-                        : "default!";
+                    var (initializer, isRequired) = m.GetDeserializeInitializer(
+                        context.Compilation,
+                        preserveInitializers
+                    );
                     localsBuilder.AppendLine($"{memberType} {localName} = {initializer};");
 
                     var typeOptions = SymbolUtilities.GetTypeOptions(type);
@@ -313,9 +314,7 @@ namespace Serde
                         """
                     );
 
-                    // Require that the member is assigned if m.ThrowIfMissing is set, or if it is not nullable
-                    // and ThrowIfMissing is unset
-                    if (m.ThrowIfMissing == true || (!m.IsNullable && m.ThrowIfMissing == null))
+                    if (isRequired)
                     {
                         assignedMaskValue |= 1L << fieldIndex;
                     }

--- a/src/serde/Proxies.cs
+++ b/src/serde/Proxies.cs
@@ -511,8 +511,11 @@ public sealed class StringProxy : ISerdePrimitive<StringProxy, string>
 
     private const string s_typeName = "string";
 
-    void ISerialize<string>.Serialize(string value, ISerializer serializer) =>
+    void ISerialize<string>.Serialize(string value, ISerializer serializer)
+    {
+        ArgumentNullException.ThrowIfNull(value);
         serializer.WriteString(value);
+    }
 
     public string Deserialize(IDeserializer deserializer) => deserializer.ReadString();
 

--- a/test/Serde.Generation.Test/test_output/AllInOneTest.GeneratorTest/Serde.Test.AllInOne.IDeserialize.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/AllInOneTest.GeneratorTest/Serde.Test.AllInOne.IDeserialize.g.verified.cs
@@ -194,7 +194,7 @@ partial record AllInOne
                 }
             }
             typeDeserialize.End(_l_serdeInfo);
-            if ((_r_assignedValid & 0b11111001111111111111111111) != 0b11111001111111111111111111)
+            if ((_r_assignedValid & 0b11000001111110111111111111) != 0b11000001111110111111111111)
             {
                 throw Serde.DeserializeException.UnassignedMember();
             }

--- a/test/Serde.Generation.Test/test_output/FieldInitializerTests/FieldInitializerEnum#C.IDeserialize.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/FieldInitializerTests/FieldInitializerEnum#C.IDeserialize.g.verified.cs
@@ -41,7 +41,7 @@ partial class C
                 }
             }
             typeDeserialize.End(_l_serdeInfo);
-            if ((_r_assignedValid & 0b1) != 0b1)
+            if ((_r_assignedValid & 0b0) != 0b0)
             {
                 throw Serde.DeserializeException.UnassignedMember();
             }

--- a/test/Serde.Generation.Test/test_output/FieldInitializerTests/FieldInitializerEnumCast#Mine.C.IDeserialize.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/FieldInitializerTests/FieldInitializerEnumCast#Mine.C.IDeserialize.g.verified.cs
@@ -50,7 +50,7 @@ partial class C
                 }
             }
             typeDeserialize.End(_l_serdeInfo);
-            if ((_r_assignedValid & 0b11) != 0b11)
+            if ((_r_assignedValid & 0b10) != 0b10)
             {
                 throw Serde.DeserializeException.UnassignedMember();
             }

--- a/test/Serde.Generation.Test/test_output/FieldInitializerTests/FieldInitializerNullForgiving#C.IDeserialize.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/FieldInitializerTests/FieldInitializerNullForgiving#C.IDeserialize.g.verified.cs
@@ -53,7 +53,7 @@ partial class C
                 }
             }
             typeDeserialize.End(_l_serdeInfo);
-            if ((_r_assignedValid & 0b11) != 0b11)
+            if ((_r_assignedValid & 0b0) != 0b0)
             {
                 throw Serde.DeserializeException.UnassignedMember();
             }

--- a/test/Serde.Generation.Test/test_output/FieldInitializerTests/FieldInitializerPrimaryCtorParam#C.IDeserialize.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/FieldInitializerTests/FieldInitializerPrimaryCtorParam#C.IDeserialize.g.verified.cs
@@ -53,7 +53,7 @@ partial record C
                 }
             }
             typeDeserialize.End(_l_serdeInfo);
-            if ((_r_assignedValid & 0b111) != 0b111)
+            if ((_r_assignedValid & 0b11) != 0b11)
             {
                 throw Serde.DeserializeException.UnassignedMember();
             }

--- a/test/Serde.Generation.Test/test_output/FieldInitializerTests/FieldInitializers#C.IDeserialize.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/FieldInitializerTests/FieldInitializers#C.IDeserialize.g.verified.cs
@@ -83,7 +83,7 @@ partial class C
                 }
             }
             typeDeserialize.End(_l_serdeInfo);
-            if ((_r_assignedValid & 0b11110111) != 0b11110111)
+            if ((_r_assignedValid & 0b0) != 0b0)
             {
                 throw Serde.DeserializeException.UnassignedMember();
             }

--- a/test/Serde.Generation.Test/test_output/SerdeTests.CommandResponseTest/ArgumentInfo.ISerde.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/SerdeTests.CommandResponseTest/ArgumentInfo.ISerde.g.verified.cs
@@ -55,7 +55,7 @@ partial class ArgumentInfo
                 }
             }
             typeDeserialize.End(_l_serdeInfo);
-            if ((_r_assignedValid & 0b11) != 0b11)
+            if ((_r_assignedValid & 0b0) != 0b0)
             {
                 throw Serde.DeserializeException.UnassignedMember();
             }

--- a/test/Serde.Generation.Test/test_output/SerdeTests.CommandResponseTest/CommandResponse.ISerde.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/SerdeTests.CommandResponseTest/CommandResponse.ISerde.g.verified.cs
@@ -76,7 +76,7 @@ partial class CommandResponse<TResult, TProxy>
                 }
             }
             typeDeserialize.End(_l_serdeInfo);
-            if ((_r_assignedValid & 0b11011) != 0b11011)
+            if ((_r_assignedValid & 0b11001) != 0b11001)
             {
                 throw Serde.DeserializeException.UnassignedMember();
             }

--- a/test/Serde.Test/JsonDeserializeTests.cs
+++ b/test/Serde.Test/JsonDeserializeTests.cs
@@ -329,6 +329,47 @@ namespace Serde.Test
             Assert.Equal(s.Dict.Count, de.Dict.Count);
         }
 
+        [GenerateDeserialize]
+        private partial class InitializedFields
+        {
+            // Non-nullable field with a preserved (constant) initializer: optional.
+            public int Num = 42;
+            public string Str = "hello";
+
+            // Non-nullable field without an initializer: still required.
+            public int Required;
+        }
+
+        [Fact]
+        public void InitializedFieldsAreOptional()
+        {
+            // Num and Str are omitted; they must fall back to their initializers rather
+            // than throwing an UnassignedMember exception.
+            var src = """
+{
+    "required": 7
+}
+""";
+            var de = JsonSerializer.Deserialize<InitializedFields>(src);
+            Assert.Equal(42, de.Num);
+            Assert.Equal("hello", de.Str);
+            Assert.Equal(7, de.Required);
+        }
+
+        [Fact]
+        public void FieldWithoutInitializerIsRequired()
+        {
+            // Required has no initializer, so omitting it still throws.
+            var src = """
+{
+    "num": 1
+}
+""";
+            Assert.Throws<DeserializeException>(() =>
+                JsonSerializer.Deserialize<InitializedFields>(src)
+            );
+        }
+
         [Fact]
         public void DeserializeWithSkip()
         {

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.AllInOne.IDeserialize.g.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.AllInOne.IDeserialize.g.cs
@@ -193,7 +193,7 @@ partial record AllInOne
                 }
             }
             typeDeserialize.End(_l_serdeInfo);
-            if ((_r_assignedValid & 0b11111001111111111111111111) != 0b11111001111111111111111111)
+            if ((_r_assignedValid & 0b11000001111110111111111111) != 0b11000001111110111111111111)
             {
                 throw Serde.DeserializeException.UnassignedMember();
             }

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonDeserializeTests.InitializedFields.IDeserialize.g.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonDeserializeTests.InitializedFields.IDeserialize.g.cs
@@ -1,0 +1,74 @@
+
+#nullable enable
+
+using System;
+using Serde;
+
+namespace Serde.Test;
+
+partial class JsonDeserializeTests
+{
+    partial class InitializedFields
+    {
+        sealed partial class _DeObj : Serde.IDeserialize<Serde.Test.JsonDeserializeTests.InitializedFields>
+        {
+            global::Serde.ISerdeInfo global::Serde.ISerdeInfoProvider.SerdeInfo => Serde.Test.JsonDeserializeTests.InitializedFields.s_serdeInfo;
+
+            Serde.Test.JsonDeserializeTests.InitializedFields Serde.IDeserialize<Serde.Test.JsonDeserializeTests.InitializedFields>.Deserialize(IDeserializer deserializer)
+            {
+                int _l_num = 42;
+                string _l_str = "hello";
+                int _l_required = default!;
+
+                byte _r_assignedValid = 0;
+
+                var _l_serdeInfo = global::Serde.SerdeInfoProvider.GetInfo(this);
+                var typeDeserialize = deserializer.ReadType(_l_serdeInfo);
+                while (true)
+                {
+                    var (_l_index_, _) = typeDeserialize.TryReadIndexWithName(_l_serdeInfo);
+                    if (_l_index_ == Serde.ITypeDeserializer.EndOfType)
+                    {
+                        break;
+                    }
+
+                    switch (_l_index_)
+                    {
+                        case 0:
+                            Serde.DeserializeException.ThrowIfDuplicate(_r_assignedValid, 0, _l_serdeInfo);
+                            _l_num = typeDeserialize.ReadI32(_l_serdeInfo, _l_index_);
+                            _r_assignedValid |= ((byte)1) << 0;
+                            break;
+                        case 1:
+                            Serde.DeserializeException.ThrowIfDuplicate(_r_assignedValid, 1, _l_serdeInfo);
+                            _l_str = typeDeserialize.ReadString(_l_serdeInfo, _l_index_);
+                            _r_assignedValid |= ((byte)1) << 1;
+                            break;
+                        case 2:
+                            Serde.DeserializeException.ThrowIfDuplicate(_r_assignedValid, 2, _l_serdeInfo);
+                            _l_required = typeDeserialize.ReadI32(_l_serdeInfo, _l_index_);
+                            _r_assignedValid |= ((byte)1) << 2;
+                            break;
+                        case Serde.ITypeDeserializer.IndexNotFound:
+                            typeDeserialize.SkipValue(_l_serdeInfo, _l_index_);
+                            break;
+                        default:
+                            throw new InvalidOperationException("Unexpected index: " + _l_index_);
+                    }
+                }
+                typeDeserialize.End(_l_serdeInfo);
+                if ((_r_assignedValid & 0b100) != 0b100)
+                {
+                    throw Serde.DeserializeException.UnassignedMember();
+                }
+                var newType = new Serde.Test.JsonDeserializeTests.InitializedFields() {
+                    Num = _l_num,
+                    Str = _l_str,
+                    Required = _l_required,
+                };
+
+                return newType;
+            }
+        }
+    }
+}

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonDeserializeTests.InitializedFields.IDeserializeProvider.g.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonDeserializeTests.InitializedFields.IDeserializeProvider.g.cs
@@ -1,0 +1,11 @@
+
+namespace Serde.Test;
+
+partial class JsonDeserializeTests
+{
+    partial class InitializedFields : Serde.IDeserializeProvider<Serde.Test.JsonDeserializeTests.InitializedFields>
+    {
+        static global::Serde.IDeserialize<Serde.Test.JsonDeserializeTests.InitializedFields> global::Serde.IDeserializeProvider<Serde.Test.JsonDeserializeTests.InitializedFields>.Instance { get; }
+            = new Serde.Test.JsonDeserializeTests.InitializedFields._DeObj();
+    }
+}

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonDeserializeTests.InitializedFields.ISerdeInfoProvider.g.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonDeserializeTests.InitializedFields.ISerdeInfoProvider.g.cs
@@ -1,0 +1,20 @@
+
+#nullable enable
+
+namespace Serde.Test;
+
+partial class JsonDeserializeTests
+{
+    partial class InitializedFields
+    {
+        private static global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
+            "InitializedFields",
+            typeof(Serde.Test.JsonDeserializeTests.InitializedFields).GetCustomAttributesData(),
+            new global::Serde.SerdeInfo.FieldInfo[] {
+                new("num", global::Serde.SerdeInfoProvider.GetDeserializeInfo<int, global::Serde.I32Proxy>()),
+                new("str", global::Serde.SerdeInfoProvider.GetDeserializeInfo<string, global::Serde.StringProxy>()),
+                new("required", global::Serde.SerdeInfoProvider.GetDeserializeInfo<int, global::Serde.I32Proxy>())
+            }
+        );
+    }
+}


### PR DESCRIPTION
Preserved initializers currently include constant values and most static field/property references.