### PR TITLE
Fix nullable arrays ser/de

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,6 +5,6 @@
     <Deterministic>true</Deterministic>
     <TestTfm>net10.0</TestTfm>
     <SerdeAssemblyVersion>0.10.1</SerdeAssemblyVersion>
-    <SerdePkgVersion>0.16.1</SerdePkgVersion>
+    <SerdePkgVersion>0.16.2</SerdePkgVersion>
   </PropertyGroup>
 </Project>

--- a/src/generator/Proxies.cs
+++ b/src/generator/Proxies.cs
@@ -212,10 +212,11 @@ sealed partial class {{proxyName}};
                 ContainingNamespace:
                 { Name: "System", ContainingNamespace: { IsGlobalNamespace: true } }
             } => new("global::System.Guid", "global::Serde.GuidProxy"),
-            IArrayTypeSymbol { ElementType: { SpecialType: SpecialType.System_Byte } } => new(
-                "global::System.Byte[]",
-                "global::Serde.ByteArrayProxy"
-            ),
+            IArrayTypeSymbol
+            {
+                ElementType: { SpecialType: SpecialType.System_Byte },
+                NullableAnnotation: not NullableAnnotation.Annotated
+            } => new("global::System.Byte[]", "global::Serde.ByteArrayProxy"),
             _ => null,
         };
     }

--- a/test/Serde.Test/JsonSerializerTests.cs
+++ b/test/Serde.Test/JsonSerializerTests.cs
@@ -237,6 +237,28 @@ namespace Serde.Test
             Assert.Equal("null", js);
         }
 
+        [GenerateSerde]
+        private partial record NullableByteArrayWrap
+        {
+            public byte[]? Bytes { get; init; }
+        }
+
+        [Fact]
+        public void NullableByteArray()
+        {
+            var wrap = new NullableByteArrayWrap { Bytes = new byte[] { 1, 2, 3 } };
+            var js = Serde.Json.JsonSerializer.Serialize(wrap);
+            Assert.Equal("""{"bytes":"AQID"}""", js);
+            var de = Serde.Json.JsonSerializer.Deserialize<NullableByteArrayWrap>(js);
+            Assert.Equal(wrap.Bytes, de.Bytes);
+
+            var nullWrap = new NullableByteArrayWrap { Bytes = null };
+            js = Serde.Json.JsonSerializer.Serialize(nullWrap);
+            Assert.Equal("{}", js);
+            de = Serde.Json.JsonSerializer.Deserialize<NullableByteArrayWrap>(js);
+            Assert.Null(de.Bytes);
+        }
+
         [GenerateSerialize]
         private partial class NullableFields
         {

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonSerializerTests.NullableByteArrayWrap.ISerde.g.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonSerializerTests.NullableByteArrayWrap.ISerde.g.cs
@@ -1,0 +1,67 @@
+
+#nullable enable
+
+using System;
+using Serde;
+
+namespace Serde.Test;
+
+partial class JsonSerializerTests
+{
+    partial record NullableByteArrayWrap
+    {
+        sealed partial class _SerdeObj : global::Serde.ISerde<Serde.Test.JsonSerializerTests.NullableByteArrayWrap>
+        {
+            global::Serde.ISerdeInfo global::Serde.ISerdeInfoProvider.SerdeInfo => Serde.Test.JsonSerializerTests.NullableByteArrayWrap.s_serdeInfo;
+
+            void global::Serde.ISerialize<Serde.Test.JsonSerializerTests.NullableByteArrayWrap>.Serialize(Serde.Test.JsonSerializerTests.NullableByteArrayWrap value, global::Serde.ISerializer serializer)
+            {
+                var _l_info = global::Serde.SerdeInfoProvider.GetInfo(this);
+                var _l_type = serializer.WriteType(_l_info);
+                _l_type.WriteValueIfNotNull<byte[], Serde.NullableRefProxy.Ser<byte[], global::Serde.ByteArrayProxy>>(_l_info, 0, value.Bytes);
+                _l_type.End(_l_info);
+            }
+            Serde.Test.JsonSerializerTests.NullableByteArrayWrap Serde.IDeserialize<Serde.Test.JsonSerializerTests.NullableByteArrayWrap>.Deserialize(IDeserializer deserializer)
+            {
+                byte[]? _l_bytes = default!;
+
+                byte _r_assignedValid = 0;
+
+                var _l_serdeInfo = global::Serde.SerdeInfoProvider.GetInfo(this);
+                var typeDeserialize = deserializer.ReadType(_l_serdeInfo);
+                while (true)
+                {
+                    var (_l_index_, _) = typeDeserialize.TryReadIndexWithName(_l_serdeInfo);
+                    if (_l_index_ == Serde.ITypeDeserializer.EndOfType)
+                    {
+                        break;
+                    }
+
+                    switch (_l_index_)
+                    {
+                        case 0:
+                            Serde.DeserializeException.ThrowIfDuplicate(_r_assignedValid, 0, _l_serdeInfo);
+                            _l_bytes = typeDeserialize.ReadValue<byte[]?, Serde.NullableRefProxy.De<byte[], global::Serde.ByteArrayProxy>>(_l_serdeInfo, _l_index_);
+                            _r_assignedValid |= ((byte)1) << 0;
+                            break;
+                        case Serde.ITypeDeserializer.IndexNotFound:
+                            typeDeserialize.SkipValue(_l_serdeInfo, _l_index_);
+                            break;
+                        default:
+                            throw new InvalidOperationException("Unexpected index: " + _l_index_);
+                    }
+                }
+                typeDeserialize.End(_l_serdeInfo);
+                if ((_r_assignedValid & 0b0) != 0b0)
+                {
+                    throw Serde.DeserializeException.UnassignedMember();
+                }
+                var newType = new Serde.Test.JsonSerializerTests.NullableByteArrayWrap() {
+                    Bytes = _l_bytes,
+                };
+
+                return newType;
+            }
+        }
+    }
+}

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonSerializerTests.NullableByteArrayWrap.ISerdeInfoProvider.g.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonSerializerTests.NullableByteArrayWrap.ISerdeInfoProvider.g.cs
@@ -1,0 +1,18 @@
+
+#nullable enable
+
+namespace Serde.Test;
+
+partial class JsonSerializerTests
+{
+    partial record NullableByteArrayWrap
+    {
+        private static global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
+            "NullableByteArrayWrap",
+            typeof(Serde.Test.JsonSerializerTests.NullableByteArrayWrap).GetCustomAttributesData(),
+            new global::Serde.SerdeInfo.FieldInfo[] {
+                new("bytes", global::Serde.SerdeInfoProvider.GetSerializeInfo<byte[]?, Serde.NullableRefProxy.Ser<byte[], global::Serde.ByteArrayProxy>>())
+            }
+        );
+    }
+}

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonSerializerTests.NullableByteArrayWrap.ISerdeProvider.g.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonSerializerTests.NullableByteArrayWrap.ISerdeProvider.g.cs
@@ -1,0 +1,11 @@
+
+namespace Serde.Test;
+
+partial class JsonSerializerTests
+{
+    partial record NullableByteArrayWrap : Serde.ISerdeProvider<Serde.Test.JsonSerializerTests.NullableByteArrayWrap, Serde.Test.JsonSerializerTests.NullableByteArrayWrap._SerdeObj, Serde.Test.JsonSerializerTests.NullableByteArrayWrap>
+    {
+        static Serde.Test.JsonSerializerTests.NullableByteArrayWrap._SerdeObj global::Serde.ISerdeProvider<Serde.Test.JsonSerializerTests.NullableByteArrayWrap, Serde.Test.JsonSerializerTests.NullableByteArrayWrap._SerdeObj, Serde.Test.JsonSerializerTests.NullableByteArrayWrap>.Instance { get; }
+            = new Serde.Test.JsonSerializerTests.NullableByteArrayWrap._SerdeObj();
+    }
+}


### PR DESCRIPTION
Nullable array serialization/deserialization wasn't correctly be wrapped
in a NullablRefProxy due to a bug in the generator. The generator should
now be fixed.