### PR TITLE
Add new WriteType method with a fieldCount

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,6 +5,6 @@
     <Deterministic>true</Deterministic>
     <TestTfm>net10.0</TestTfm>
     <SerdeAssemblyVersion>0.10.1</SerdeAssemblyVersion>
-    <SerdePkgVersion>0.16.2</SerdePkgVersion>
+    <SerdePkgVersion>0.17.0</SerdePkgVersion>
   </PropertyGroup>
 </Project>

--- a/src/generator/SerializeImplGen.cs
+++ b/src/generator/SerializeImplGen.cs
@@ -61,8 +61,15 @@ public partial class SerializeImplGen
             // `var _l_info = GetInfo(this);`
             statements.AppendLine($"var _l_info = global::Serde.SerdeInfoProvider.GetInfo(this);");
 
-            // `var type = serializer.WriteType(_l_info);`
-            statements.AppendLine("var _l_type = serializer.WriteType(_l_info);");
+            // The field-writing statements are collected separately so that the number of fields
+            // that will actually be written can be computed and passed to WriteType before any of
+            // them are emitted. Nullable fields that are skipped when null (i.e. serialized with an
+            // `IfNotNull` helper) are subtracted from the count at runtime.
+            var writeStatements = new SourceBuilder();
+
+            // Member-access expressions for fields that may be skipped when null. Each contributes a
+            // `-1` to the field count when its value is null.
+            var skippableExprs = new List<string>();
 
             for (int i = 0; i < fieldsAndProps.Count; i++)
             {
@@ -80,6 +87,7 @@ public partial class SerializeImplGen
                 ).ToDisplayString();
 
                 // 1. Check if this member has an explicit proxy. If so, we'll use it.
+                string writeStmt;
                 if (
                     Proxies.TryGetExplicitWrapper(
                         m,
@@ -91,9 +99,7 @@ public partial class SerializeImplGen
                     { } proxy
                 )
                 {
-                    statements.AppendLine(
-                        MakeWriteValueStmt(m, notNullTypeName, proxy, i, receiverExpr)
-                    );
+                    writeStmt = MakeWriteValueStmt(m, notNullTypeName, proxy, i, receiverExpr);
                 }
                 // 2. Check for a direct implementation of ISerialize
                 else if (
@@ -105,9 +111,7 @@ public partial class SerializeImplGen
                     )
                 )
                 {
-                    statements.AppendLine(
-                        MakeWriteValueStmt(m, notNullTypeName, notNullTypeName, i, receiverExpr)
-                    );
+                    writeStmt = MakeWriteValueStmt(m, notNullTypeName, notNullTypeName, i, receiverExpr);
                 }
                 // 3. Check if the member type is a primitive type. If so, it has a dedicated 'Write'
                 //    method. Check using the non-null form (even if it's nullable), since nullable
@@ -124,9 +128,7 @@ public partial class SerializeImplGen
                         // Use WriteValueIfNotNull if it's not been disabled and the field is nullable
                         primName += "IfNotNull";
                     }
-                    statements.AppendLine(
-                        $"_l_type.Write{primName}(_l_info, {i}, {receiverExpr}.{m.Name});"
-                    );
+                    writeStmt = $"_l_type.Write{primName}(_l_info, {i}, {receiverExpr}.{m.Name});";
                 }
                 // 4. A wrapper that implements ISerialize
                 else if (
@@ -140,9 +142,7 @@ public partial class SerializeImplGen
                     { } wrapper
                 )
                 {
-                    statements.AppendLine(
-                        MakeWriteValueStmt(m, notNullTypeName, wrapper.Proxy, i, receiverExpr)
-                    );
+                    writeStmt = MakeWriteValueStmt(m, notNullTypeName, wrapper.Proxy, i, receiverExpr);
                 }
                 else
                 {
@@ -158,31 +158,62 @@ public partial class SerializeImplGen
                     );
                     continue;
                 }
-            }
 
-            static string MakeWriteValueStmt(
-                DataMemberSymbol m,
-                string type,
-                string proxy,
-                int i,
-                string valueExpr
-            )
-            {
-                // Generate statements of the form `type.WriteValue<FieldType, Serialize>("FieldName", value.FieldValue)`
-                // Use WriteValueIfNotNull if it's not been disabled and the field is nullable. In that
-                // case the generic argument is the non-null inner type, because the IfNotNull overloads
-                // accept a `T?` value and a provider of the nullable type.
+                writeStatements.AppendLine(writeStmt);
+
+                // A nullable field that is not forced to serialize null is skipped when its value is
+                // null, so it must be removed from the field count in that case.
                 if (m.IsNullable && !m.SerializeNull)
                 {
-                    return $"_l_type.WriteValueIfNotNull<{type}, {proxy}>(_l_info, {i}, {valueExpr}.{m.Name});";
+                    skippableExprs.Add($"{receiverExpr}.{m.Name}");
                 }
-                // Plain WriteValue: the generic type argument must match the static type of the value
-                // expression and the provider. For a nullable member (e.g. `int?` serialized via
-                // NullableProxy when SerializeNull is set) that is the full nullable type, not the
-                // unwrapped inner type.
-                var typeArg = m.IsNullable ? m.Type.ToDisplayString() : type;
-                return $"_l_type.WriteValue<{typeArg}, {proxy}>(_l_info, {i}, {valueExpr}.{m.Name});";
+
+                static string MakeWriteValueStmt(
+                    DataMemberSymbol m,
+                    string type,
+                    string proxy,
+                    int i,
+                    string valueExpr
+                )
+                {
+                    // Generate statements of the form `type.WriteValue<FieldType, Serialize>("FieldName", value.FieldValue)`
+                    // Use WriteValueIfNotNull if it's not been disabled and the field is nullable. In that
+                    // case the generic argument is the non-null inner type, because the IfNotNull overloads
+                    // accept a `T?` value and a provider of the nullable type.
+                    if (m.IsNullable && !m.SerializeNull)
+                    {
+                        return $"_l_type.WriteValueIfNotNull<{type}, {proxy}>(_l_info, {i}, {valueExpr}.{m.Name});";
+                    }
+                    // Plain WriteValue: the generic type argument must match the static type of the value
+                    // expression and the provider. For a nullable member (e.g. `int?` serialized via
+                    // NullableProxy when SerializeNull is set) that is the full nullable type, not the
+                    // unwrapped inner type.
+                    var typeArg = m.IsNullable ? m.Type.ToDisplayString() : type;
+                    return $"_l_type.WriteValue<{typeArg}, {proxy}>(_l_info, {i}, {valueExpr}.{m.Name});";
+                }
             }
+
+            // Compute the number of fields that will actually be written and open the type. When no
+            // fields can be skipped the count is a constant; otherwise it starts at the total and is
+            // decremented for each nullable field whose value is null.
+            if (skippableExprs.Count == 0)
+            {
+                statements.AppendLine(
+                    $"var _l_type = serializer.WriteType(_l_info, {fieldsAndProps.Count});"
+                );
+            }
+            else
+            {
+                statements.AppendLine($"var _l_fieldCount = {fieldsAndProps.Count};");
+                foreach (var expr in skippableExprs)
+                {
+                    statements.AppendLine($"if ({expr} is null) _l_fieldCount--;");
+                }
+                statements.AppendLine("var _l_type = serializer.WriteType(_l_info, _l_fieldCount);");
+            }
+
+            statements.Append(writeStatements);
+
             // `type.End();`
             statements.Append("_l_type.End(_l_info);");
         }
@@ -231,7 +262,7 @@ public partial class SerializeImplGen
             void ISerialize<{{baseType.ToDisplayString()}}>.Serialize({{baseType.ToDisplayString()}} value, ISerializer serializer)
             {
                 var _l_serdeInfo = global::Serde.SerdeInfoProvider.GetInfo(this);
-                var _l_type = serializer.WriteType(_l_serdeInfo);
+                var _l_type = serializer.WriteType(_l_serdeInfo, 1);
                 switch (value)
                 {
                     {{casesBuilder}}

--- a/src/generator/SerializeImplGen.cs
+++ b/src/generator/SerializeImplGen.cs
@@ -111,7 +111,13 @@ public partial class SerializeImplGen
                     )
                 )
                 {
-                    writeStmt = MakeWriteValueStmt(m, notNullTypeName, notNullTypeName, i, receiverExpr);
+                    writeStmt = MakeWriteValueStmt(
+                        m,
+                        notNullTypeName,
+                        notNullTypeName,
+                        i,
+                        receiverExpr
+                    );
                 }
                 // 3. Check if the member type is a primitive type. If so, it has a dedicated 'Write'
                 //    method. Check using the non-null form (even if it's nullable), since nullable
@@ -142,7 +148,13 @@ public partial class SerializeImplGen
                     { } wrapper
                 )
                 {
-                    writeStmt = MakeWriteValueStmt(m, notNullTypeName, wrapper.Proxy, i, receiverExpr);
+                    writeStmt = MakeWriteValueStmt(
+                        m,
+                        notNullTypeName,
+                        wrapper.Proxy,
+                        i,
+                        receiverExpr
+                    );
                 }
                 else
                 {
@@ -209,7 +221,9 @@ public partial class SerializeImplGen
                 {
                     statements.AppendLine($"if ({expr} is null) _l_fieldCount--;");
                 }
-                statements.AppendLine("var _l_type = serializer.WriteType(_l_info, _l_fieldCount);");
+                statements.AppendLine(
+                    "var _l_type = serializer.WriteType(_l_info, _l_fieldCount);"
+                );
             }
 
             statements.Append(writeStatements);

--- a/src/serde/ISerializer.cs
+++ b/src/serde/ISerializer.cs
@@ -80,6 +80,33 @@ public interface ISerializer : IDisposable
     /// </returns>
     ITypeSerializer WriteType(ISerdeInfo info);
 
+    /// <summary>
+    /// Write a non-collection, non-primitive type. This could be a custom type, an enum, a union, a
+    /// nullable type, etc. The full set of options corresponds to the options represented by <see
+    /// cref="ISerdeInfo" />. The <paramref name="fieldCount"/> parameter is used to indicate the
+    /// number of nested fields to serialize. If some fields are skipped, the <paramref
+    /// name="fieldCount"/> parameter should be set to the number of fields that will be serialized.
+    /// If all fields are serialized, the <paramref name="fieldCount"/> parameter should be equal to
+    /// <see cref="ISerdeInfo.FieldCount"/>.
+    /// </summary>
+    /// <returns>
+    /// An <see cref="ITypeSerializer" /> that can be used to serialize the type. After this method
+    /// is called, the retuned <see cref="ITypeSerializer" /> should be used to serialize the type.
+    /// The <see cref="ITypeSerializer.End" /> method should be called when the type is fully
+    /// serialized. The parent <see cref="ISerializer"/> should not be used after this method is
+    /// called, until the <see cref="ITypeSerializer.End" /> method is called. Before the <see
+    /// cref="ITypeSerializer.End" /> method is called, all operations on the parent <see
+    /// cref="ISerializer" /> have undefined behavior.
+    /// </returns>
+    ITypeSerializer WriteType(ISerdeInfo info, int fieldCount)
+    {
+        // Default implementation: formats whose serialized representation does not need to know the
+        // number of fields up front (such as JSON, which delimits objects structurally) can ignore
+        // the field count and defer to the single-argument overload. Formats that must write the
+        // field count as part of the type header should override this method.
+        return WriteType(info);
+    }
+
     void IDisposable.Dispose() { }
 }
 

--- a/src/serde/PublicApi.cssig
+++ b/src/serde/PublicApi.cssig
@@ -452,6 +452,7 @@ namespace Serde
     {
         Serde.ITypeSerializer WriteCollection(Serde.ISerdeInfo info, int? count);
         Serde.ITypeSerializer WriteType(Serde.ISerdeInfo info);
+        Serde.ITypeSerializer WriteType(Serde.ISerdeInfo info, int fieldCount);
         void WriteBool(bool b);
         void WriteBytes(System.ReadOnlyMemory<byte> bytes);
         void WriteChar(char c);

--- a/src/serde/json/JsonSerializer.Serialize.cs
+++ b/src/serde/json/JsonSerializer.Serialize.cs
@@ -136,11 +136,10 @@ partial class JsonSerializer : ISerializer
         }
     }
 
-    ITypeSerializer ISerializer.WriteType(ISerdeInfo typeInfo)
-        => WriteType(typeInfo);
+    ITypeSerializer ISerializer.WriteType(ISerdeInfo typeInfo) => WriteType(typeInfo);
 
-    ITypeSerializer ISerializer.WriteType(ISerdeInfo typeInfo, int fieldCount)
-        => WriteType(typeInfo);
+    ITypeSerializer ISerializer.WriteType(ISerdeInfo typeInfo, int fieldCount) =>
+        WriteType(typeInfo);
 
     private ITypeSerializer WriteType(ISerdeInfo typeInfo)
     {

--- a/src/serde/json/JsonSerializer.Serialize.cs
+++ b/src/serde/json/JsonSerializer.Serialize.cs
@@ -137,6 +137,12 @@ partial class JsonSerializer : ISerializer
     }
 
     ITypeSerializer ISerializer.WriteType(ISerdeInfo typeInfo)
+        => WriteType(typeInfo);
+
+    ITypeSerializer ISerializer.WriteType(ISerdeInfo typeInfo, int fieldCount)
+        => WriteType(typeInfo);
+
+    private ITypeSerializer WriteType(ISerdeInfo typeInfo)
     {
         switch (typeInfo.Kind)
         {

--- a/test/Serde.Generation.Test/test_output/AllInOneTest.GeneratorTest/Serde.Test.AllInOne.ISerialize.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/AllInOneTest.GeneratorTest/Serde.Test.AllInOne.ISerialize.g.verified.cs
@@ -16,7 +16,10 @@ partial record AllInOne
         void global::Serde.ISerialize<Serde.Test.AllInOne>.Serialize(Serde.Test.AllInOne value, global::Serde.ISerializer serializer)
         {
             var _l_info = global::Serde.SerdeInfoProvider.GetInfo(this);
-            var _l_type = serializer.WriteType(_l_info);
+            var _l_fieldCount = 26;
+            if (value.NullStringField is null) _l_fieldCount--;
+            if (value.NullIntField is null) _l_fieldCount--;
+            var _l_type = serializer.WriteType(_l_info, _l_fieldCount);
             _l_type.WriteBool(_l_info, 0, value.BoolField);
             _l_type.WriteChar(_l_info, 1, value.CharField);
             _l_type.WriteU8(_l_info, 2, value.ByteField);

--- a/test/Serde.Generation.Test/test_output/DeserializeTests.BasicDUGenerateSerde/Some.Nested.Namespace.Base.ISerde.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/DeserializeTests.BasicDUGenerateSerde/Some.Nested.Namespace.Base.ISerde.g.verified.cs
@@ -16,7 +16,7 @@ partial record Base
         void ISerialize<Some.Nested.Namespace.Base>.Serialize(Some.Nested.Namespace.Base value, ISerializer serializer)
         {
             var _l_serdeInfo = global::Serde.SerdeInfoProvider.GetInfo(this);
-            var _l_type = serializer.WriteType(_l_serdeInfo);
+            var _l_type = serializer.WriteType(_l_serdeInfo, 1);
             switch (value)
             {
                 case Some.Nested.Namespace.Base.A c:

--- a/test/Serde.Generation.Test/test_output/DeserializeTests.BasicDUGenerateSerde/Some.Nested.Namespace.Base._m_AProxy.ISerde.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/DeserializeTests.BasicDUGenerateSerde/Some.Nested.Namespace.Base._m_AProxy.ISerde.g.verified.cs
@@ -18,7 +18,7 @@ partial record Base
             void global::Serde.ISerialize<Some.Nested.Namespace.Base.A>.Serialize(Some.Nested.Namespace.Base.A value, global::Serde.ISerializer serializer)
             {
                 var _l_info = global::Serde.SerdeInfoProvider.GetInfo(this);
-                var _l_type = serializer.WriteType(_l_info);
+                var _l_type = serializer.WriteType(_l_info, 1);
                 _l_type.WriteI32(_l_info, 0, value.X);
                 _l_type.End(_l_info);
             }

--- a/test/Serde.Generation.Test/test_output/DeserializeTests.BasicDUGenerateSerde/Some.Nested.Namespace.Base._m_BProxy.ISerde.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/DeserializeTests.BasicDUGenerateSerde/Some.Nested.Namespace.Base._m_BProxy.ISerde.g.verified.cs
@@ -18,7 +18,7 @@ partial record Base
             void global::Serde.ISerialize<Some.Nested.Namespace.Base.B>.Serialize(Some.Nested.Namespace.Base.B value, global::Serde.ISerializer serializer)
             {
                 var _l_info = global::Serde.SerdeInfoProvider.GetInfo(this);
-                var _l_type = serializer.WriteType(_l_info);
+                var _l_type = serializer.WriteType(_l_info, 1);
                 _l_type.WriteString(_l_info, 0, value.Y);
                 _l_type.End(_l_info);
             }

--- a/test/Serde.Generation.Test/test_output/DeserializeTests.BasicDUGenerateSerializeAndDeserialize/Some.Nested.Namespace.Base.ISerialize.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/DeserializeTests.BasicDUGenerateSerializeAndDeserialize/Some.Nested.Namespace.Base.ISerialize.g.verified.cs
@@ -16,7 +16,7 @@ partial record Base
         void ISerialize<Some.Nested.Namespace.Base>.Serialize(Some.Nested.Namespace.Base value, ISerializer serializer)
         {
             var _l_serdeInfo = global::Serde.SerdeInfoProvider.GetInfo(this);
-            var _l_type = serializer.WriteType(_l_serdeInfo);
+            var _l_type = serializer.WriteType(_l_serdeInfo, 1);
             switch (value)
             {
                 case Some.Nested.Namespace.Base.A c:

--- a/test/Serde.Generation.Test/test_output/DeserializeTests.BasicDUGenerateSerializeAndDeserialize/Some.Nested.Namespace.Base._m_AProxy.ISerialize.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/DeserializeTests.BasicDUGenerateSerializeAndDeserialize/Some.Nested.Namespace.Base._m_AProxy.ISerialize.g.verified.cs
@@ -18,7 +18,7 @@ partial record Base
             void global::Serde.ISerialize<Some.Nested.Namespace.Base.A>.Serialize(Some.Nested.Namespace.Base.A value, global::Serde.ISerializer serializer)
             {
                 var _l_info = global::Serde.SerdeInfoProvider.GetInfo(this);
-                var _l_type = serializer.WriteType(_l_info);
+                var _l_type = serializer.WriteType(_l_info, 1);
                 _l_type.WriteI32(_l_info, 0, value.X);
                 _l_type.End(_l_info);
             }

--- a/test/Serde.Generation.Test/test_output/DeserializeTests.BasicDUGenerateSerializeAndDeserialize/Some.Nested.Namespace.Base._m_BProxy.ISerialize.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/DeserializeTests.BasicDUGenerateSerializeAndDeserialize/Some.Nested.Namespace.Base._m_BProxy.ISerialize.g.verified.cs
@@ -18,7 +18,7 @@ partial record Base
             void global::Serde.ISerialize<Some.Nested.Namespace.Base.B>.Serialize(Some.Nested.Namespace.Base.B value, global::Serde.ISerializer serializer)
             {
                 var _l_info = global::Serde.SerdeInfoProvider.GetInfo(this);
-                var _l_type = serializer.WriteType(_l_info);
+                var _l_type = serializer.WriteType(_l_info, 1);
                 _l_type.WriteString(_l_info, 0, value.Y);
                 _l_type.End(_l_info);
             }

--- a/test/Serde.Generation.Test/test_output/DeserializeTests.CtorParamMismatch/MyForeignTypeProxy.ISerde.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/DeserializeTests.CtorParamMismatch/MyForeignTypeProxy.ISerde.g.verified.cs
@@ -13,7 +13,7 @@ partial struct MyForeignTypeProxy
         void global::Serde.ISerialize<MyForeignType>.Serialize(MyForeignType value, global::Serde.ISerializer serializer)
         {
             var _l_info = global::Serde.SerdeInfoProvider.GetInfo(this);
-            var _l_type = serializer.WriteType(_l_info);
+            var _l_type = serializer.WriteType(_l_info, 2);
             _l_type.WriteI32(_l_info, 0, value.MyInt);
             _l_type.WriteString(_l_info, 1, value.MyString);
             _l_type.End(_l_info);

--- a/test/Serde.Generation.Test/test_output/MemberFormatTests.CamelCase/S.ISerialize.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/MemberFormatTests.CamelCase/S.ISerialize.g.verified.cs
@@ -13,7 +13,7 @@ partial struct S
         void global::Serde.ISerialize<S>.Serialize(S value, global::Serde.ISerializer serializer)
         {
             var _l_info = global::Serde.SerdeInfoProvider.GetInfo(this);
-            var _l_type = serializer.WriteType(_l_info);
+            var _l_type = serializer.WriteType(_l_info, 2);
             _l_type.WriteI32(_l_info, 0, value.One);
             _l_type.WriteI32(_l_info, 1, value.TwoWord);
             _l_type.End(_l_info);

--- a/test/Serde.Generation.Test/test_output/MemberFormatTests.Default/S.ISerialize.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/MemberFormatTests.Default/S.ISerialize.g.verified.cs
@@ -13,7 +13,7 @@ partial struct S
         void global::Serde.ISerialize<S>.Serialize(S value, global::Serde.ISerializer serializer)
         {
             var _l_info = global::Serde.SerdeInfoProvider.GetInfo(this);
-            var _l_type = serializer.WriteType(_l_info);
+            var _l_type = serializer.WriteType(_l_info, 2);
             _l_type.WriteI32(_l_info, 0, value.One);
             _l_type.WriteI32(_l_info, 1, value.TwoWord);
             _l_type.End(_l_info);

--- a/test/Serde.Generation.Test/test_output/MemberFormatTests.EnumValues/S.ISerialize.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/MemberFormatTests.EnumValues/S.ISerialize.g.verified.cs
@@ -13,7 +13,7 @@ partial struct S
         void global::Serde.ISerialize<S>.Serialize(S value, global::Serde.ISerializer serializer)
         {
             var _l_info = global::Serde.SerdeInfoProvider.GetInfo(this);
-            var _l_type = serializer.WriteType(_l_info);
+            var _l_type = serializer.WriteType(_l_info, 1);
             _l_type.WriteValue<ColorEnum, ColorEnumProxy>(_l_info, 0, value.E);
             _l_type.End(_l_info);
         }

--- a/test/Serde.Generation.Test/test_output/MemberFormatTests.EnumValues/S2.ISerialize.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/MemberFormatTests.EnumValues/S2.ISerialize.g.verified.cs
@@ -13,7 +13,7 @@ partial struct S2
         void global::Serde.ISerialize<S2>.Serialize(S2 value, global::Serde.ISerializer serializer)
         {
             var _l_info = global::Serde.SerdeInfoProvider.GetInfo(this);
-            var _l_type = serializer.WriteType(_l_info);
+            var _l_type = serializer.WriteType(_l_info, 1);
             _l_type.WriteValue<ColorEnum, ColorEnumProxy>(_l_info, 0, value.E);
             _l_type.End(_l_info);
         }

--- a/test/Serde.Generation.Test/test_output/MemberFormatTests.KebabCase/S.ISerde.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/MemberFormatTests.KebabCase/S.ISerde.g.verified.cs
@@ -13,7 +13,7 @@ partial struct S
         void global::Serde.ISerialize<S>.Serialize(S value, global::Serde.ISerializer serializer)
         {
             var _l_info = global::Serde.SerdeInfoProvider.GetInfo(this);
-            var _l_type = serializer.WriteType(_l_info);
+            var _l_type = serializer.WriteType(_l_info, 2);
             _l_type.WriteI32(_l_info, 0, value.One);
             _l_type.WriteI32(_l_info, 1, value.TwoWord);
             _l_type.End(_l_info);

--- a/test/Serde.Generation.Test/test_output/MemberFormatTests.SnakeCase/S.ISerde.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/MemberFormatTests.SnakeCase/S.ISerde.g.verified.cs
@@ -13,7 +13,7 @@ partial struct S
         void global::Serde.ISerialize<S>.Serialize(S value, global::Serde.ISerializer serializer)
         {
             var _l_info = global::Serde.SerdeInfoProvider.GetInfo(this);
-            var _l_type = serializer.WriteType(_l_info);
+            var _l_type = serializer.WriteType(_l_info, 2);
             _l_type.WriteI32(_l_info, 0, value.One);
             _l_type.WriteI32(_l_info, 1, value.TwoWord);
             _l_type.End(_l_info);

--- a/test/Serde.Generation.Test/test_output/ProxyTests.AsGeneratedType/Point.ISerde.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/ProxyTests.AsGeneratedType/Point.ISerde.g.verified.cs
@@ -13,7 +13,7 @@ partial record Point
         void global::Serde.ISerialize<Point>.Serialize(Point value, global::Serde.ISerializer serializer)
         {
             var _l_info = global::Serde.SerdeInfoProvider.GetInfo(this);
-            var _l_type = serializer.WriteType(_l_info);
+            var _l_type = serializer.WriteType(_l_info, 2);
             _l_type.WriteI32(_l_info, 0, value.X);
             _l_type.WriteI32(_l_info, 1, value.Y);
             _l_type.End(_l_info);

--- a/test/Serde.Generation.Test/test_output/ProxyTests.AttributeWrapperTest/Address.ISerialize.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/ProxyTests.AttributeWrapperTest/Address.ISerialize.g.verified.cs
@@ -13,7 +13,7 @@ partial class Address
         void global::Serde.ISerialize<Address>.Serialize(Address value, global::Serde.ISerializer serializer)
         {
             var _l_info = global::Serde.SerdeInfoProvider.GetInfo(this);
-            var _l_type = serializer.WriteType(_l_info);
+            var _l_type = serializer.WriteType(_l_info, 5);
             _l_type.WriteString(_l_info, 0, value.Name);
             _l_type.WriteString(_l_info, 1, value.Line1);
             _l_type.WriteString(_l_info, 2, value.City);

--- a/test/Serde.Generation.Test/test_output/ProxyTests.GenerateSerdeWrap/OPTSWrap.ISerde.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/ProxyTests.GenerateSerdeWrap/OPTSWrap.ISerde.g.verified.cs
@@ -13,7 +13,7 @@ partial record struct OPTSWrap
         void global::Serde.ISerialize<System.Runtime.InteropServices.ComTypes.BIND_OPTS>.Serialize(System.Runtime.InteropServices.ComTypes.BIND_OPTS value, global::Serde.ISerializer serializer)
         {
             var _l_info = global::Serde.SerdeInfoProvider.GetInfo(this);
-            var _l_type = serializer.WriteType(_l_info);
+            var _l_type = serializer.WriteType(_l_info, 4);
             _l_type.WriteI32(_l_info, 0, value.cbStruct);
             _l_type.WriteI32(_l_info, 1, value.dwTickCountDeadline);
             _l_type.WriteI32(_l_info, 2, value.grfFlags);

--- a/test/Serde.Generation.Test/test_output/ProxyTests.InvalidNestedWrapper/Outer.SectionWrap.ISerialize.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/ProxyTests.InvalidNestedWrapper/Outer.SectionWrap.ISerialize.g.verified.cs
@@ -15,7 +15,7 @@ partial class Outer
             void global::Serde.ISerialize<System.Collections.Specialized.BitVector32.Section>.Serialize(System.Collections.Specialized.BitVector32.Section value, global::Serde.ISerializer serializer)
             {
                 var _l_info = global::Serde.SerdeInfoProvider.GetInfo(this);
-                var _l_type = serializer.WriteType(_l_info);
+                var _l_type = serializer.WriteType(_l_info, 2);
                 _l_type.WriteI16(_l_info, 0, value.Mask);
                 _l_type.WriteI16(_l_info, 1, value.Offset);
                 _l_type.End(_l_info);

--- a/test/Serde.Generation.Test/test_output/ProxyTests.InvalidNestedWrapper/S.ISerialize.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/ProxyTests.InvalidNestedWrapper/S.ISerialize.g.verified.cs
@@ -13,7 +13,7 @@ partial struct S
         void global::Serde.ISerialize<S>.Serialize(S value, global::Serde.ISerializer serializer)
         {
             var _l_info = global::Serde.SerdeInfoProvider.GetInfo(this);
-            var _l_type = serializer.WriteType(_l_info);
+            var _l_type = serializer.WriteType(_l_info, 1);
             _l_type.WriteValue<System.Collections.Generic.List<int>, Serde.ArrayProxy.Ser<System.Collections.Specialized.BitVector32.Section, Outer.SectionWrap>>(_l_info, 0, value.Sections);
             _l_type.End(_l_info);
         }

--- a/test/Serde.Generation.Test/test_output/ProxyTests.NestedDeserializeWrap/OPTSWrap.ISerde.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/ProxyTests.NestedDeserializeWrap/OPTSWrap.ISerde.g.verified.cs
@@ -13,7 +13,7 @@ partial class OPTSWrap
         void global::Serde.ISerialize<System.Runtime.InteropServices.ComTypes.BIND_OPTS>.Serialize(System.Runtime.InteropServices.ComTypes.BIND_OPTS value, global::Serde.ISerializer serializer)
         {
             var _l_info = global::Serde.SerdeInfoProvider.GetInfo(this);
-            var _l_type = serializer.WriteType(_l_info);
+            var _l_type = serializer.WriteType(_l_info, 4);
             _l_type.WriteI32(_l_info, 0, value.cbStruct);
             _l_type.WriteI32(_l_info, 1, value.dwTickCountDeadline);
             _l_type.WriteI32(_l_info, 2, value.grfFlags);

--- a/test/Serde.Generation.Test/test_output/ProxyTests.NestedExplicitWrapper/Outer.SectionWrap.ISerialize.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/ProxyTests.NestedExplicitWrapper/Outer.SectionWrap.ISerialize.g.verified.cs
@@ -15,7 +15,7 @@ partial class Outer
             void global::Serde.ISerialize<System.Collections.Specialized.BitVector32.Section>.Serialize(System.Collections.Specialized.BitVector32.Section value, global::Serde.ISerializer serializer)
             {
                 var _l_info = global::Serde.SerdeInfoProvider.GetInfo(this);
-                var _l_type = serializer.WriteType(_l_info);
+                var _l_type = serializer.WriteType(_l_info, 2);
                 _l_type.WriteI16(_l_info, 0, value.Mask);
                 _l_type.WriteI16(_l_info, 1, value.Offset);
                 _l_type.End(_l_info);

--- a/test/Serde.Generation.Test/test_output/ProxyTests.NestedExplicitWrapper/S.ISerialize.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/ProxyTests.NestedExplicitWrapper/S.ISerialize.g.verified.cs
@@ -13,7 +13,7 @@ partial struct S
         void global::Serde.ISerialize<S>.Serialize(S value, global::Serde.ISerializer serializer)
         {
             var _l_info = global::Serde.SerdeInfoProvider.GetInfo(this);
-            var _l_type = serializer.WriteType(_l_info);
+            var _l_type = serializer.WriteType(_l_info, 1);
             _l_type.WriteValue<System.Collections.Immutable.ImmutableArray<System.Collections.Specialized.BitVector32.Section>, Serde.ImmutableArrayProxy.Ser<System.Collections.Specialized.BitVector32.Section, Outer.SectionWrap>>(_l_info, 0, value.Sections);
             _l_type.End(_l_info);
         }

--- a/test/Serde.Generation.Test/test_output/ProxyTests.NonEmptyProxyAsMemberProxy/Container.ISerde.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/ProxyTests.NonEmptyProxyAsMemberProxy/Container.ISerde.g.verified.cs
@@ -13,7 +13,7 @@ partial class Container
         void global::Serde.ISerialize<Container>.Serialize(Container value, global::Serde.ISerializer serializer)
         {
             var _l_info = global::Serde.SerdeInfoProvider.GetInfo(this);
-            var _l_type = serializer.WriteType(_l_info);
+            var _l_type = serializer.WriteType(_l_info, 1);
             _l_type.WriteValue<ForeignPoint, ForeignPointProxy>(_l_info, 0, value.Point);
             _l_type.End(_l_info);
         }

--- a/test/Serde.Generation.Test/test_output/ProxyTests.NonEmptyProxyAsMemberProxy/ForeignPointProxy.ISerde.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/ProxyTests.NonEmptyProxyAsMemberProxy/ForeignPointProxy.ISerde.g.verified.cs
@@ -14,7 +14,7 @@ partial struct ForeignPointProxy
         {
             var _l_self = (ForeignPointProxy)value;
             var _l_info = global::Serde.SerdeInfoProvider.GetInfo(this);
-            var _l_type = serializer.WriteType(_l_info);
+            var _l_type = serializer.WriteType(_l_info, 2);
             _l_type.WriteI32(_l_info, 0, _l_self.X);
             _l_type.WriteI32(_l_info, 1, _l_self.Y);
             _l_type.End(_l_info);

--- a/test/Serde.Generation.Test/test_output/ProxyTests.NonEmptyProxyWithExplicitConversion/ForeignPointProxy.ISerde.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/ProxyTests.NonEmptyProxyWithExplicitConversion/ForeignPointProxy.ISerde.g.verified.cs
@@ -14,7 +14,7 @@ partial struct ForeignPointProxy
         {
             var _l_self = (ForeignPointProxy)value;
             var _l_info = global::Serde.SerdeInfoProvider.GetInfo(this);
-            var _l_type = serializer.WriteType(_l_info);
+            var _l_type = serializer.WriteType(_l_info, 2);
             _l_type.WriteI32(_l_info, 0, _l_self.X);
             _l_type.WriteI32(_l_info, 1, _l_self.Y);
             _l_type.End(_l_info);

--- a/test/Serde.Generation.Test/test_output/ProxyTests.PointWrap/PointWrap.ISerde.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/ProxyTests.PointWrap/PointWrap.ISerde.g.verified.cs
@@ -13,7 +13,7 @@ partial struct PointWrap
         void global::Serde.ISerialize<Point>.Serialize(Point value, global::Serde.ISerializer serializer)
         {
             var _l_info = global::Serde.SerdeInfoProvider.GetInfo(this);
-            var _l_type = serializer.WriteType(_l_info);
+            var _l_type = serializer.WriteType(_l_info, 2);
             _l_type.WriteI32(_l_info, 0, value.X);
             _l_type.WriteI32(_l_info, 1, value.Y);
             _l_type.End(_l_info);

--- a/test/Serde.Generation.Test/test_output/ProxyTests.RecursiveType/Test.Parent.ISerde.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/ProxyTests.RecursiveType/Test.Parent.ISerde.g.verified.cs
@@ -16,7 +16,7 @@ partial record Parent
         void global::Serde.ISerialize<Test.Parent>.Serialize(Test.Parent value, global::Serde.ISerializer serializer)
         {
             var _l_info = global::Serde.SerdeInfoProvider.GetInfo(this);
-            var _l_type = serializer.WriteType(_l_info);
+            var _l_type = serializer.WriteType(_l_info, 1);
             _l_type.WriteValue<Recursive, Test.RecursiveWrap>(_l_info, 0, value.R);
             _l_type.End(_l_info);
         }

--- a/test/Serde.Generation.Test/test_output/ProxyTests.RecursiveType/Test.RecursiveWrap.ISerde.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/ProxyTests.RecursiveType/Test.RecursiveWrap.ISerde.g.verified.cs
@@ -16,7 +16,9 @@ partial class RecursiveWrap
         void global::Serde.ISerialize<Recursive>.Serialize(Recursive value, global::Serde.ISerializer serializer)
         {
             var _l_info = global::Serde.SerdeInfoProvider.GetInfo(this);
-            var _l_type = serializer.WriteType(_l_info);
+            var _l_fieldCount = 1;
+            if (value.Next is null) _l_fieldCount--;
+            var _l_type = serializer.WriteType(_l_info, _l_fieldCount);
             _l_type.WriteValueIfNotNull<Recursive, Test.RecursiveWrap>(_l_info, 0, value.Next);
             _l_type.End(_l_info);
         }

--- a/test/Serde.Generation.Test/test_output/ProxyTests.SerdeMemberOptionsTakesPrecedenceOverUseProxy/C.ISerde.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/ProxyTests.SerdeMemberOptionsTakesPrecedenceOverUseProxy/C.ISerde.g.verified.cs
@@ -13,7 +13,7 @@ partial class C
         void global::Serde.ISerialize<C>.Serialize(C value, global::Serde.ISerializer serializer)
         {
             var _l_info = global::Serde.SerdeInfoProvider.GetInfo(this);
-            var _l_type = serializer.WriteType(_l_info);
+            var _l_type = serializer.WriteType(_l_info, 1);
             _l_type.WriteValue<System.Runtime.InteropServices.ComTypes.BIND_OPTS, Proxy2>(_l_info, 0, value.S);
             _l_type.End(_l_info);
         }

--- a/test/Serde.Generation.Test/test_output/ProxyTests.SerdeMemberOptionsTakesPrecedenceOverUseProxy/Proxy1.ISerde.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/ProxyTests.SerdeMemberOptionsTakesPrecedenceOverUseProxy/Proxy1.ISerde.g.verified.cs
@@ -13,7 +13,7 @@ partial class Proxy1
         void global::Serde.ISerialize<System.Runtime.InteropServices.ComTypes.BIND_OPTS>.Serialize(System.Runtime.InteropServices.ComTypes.BIND_OPTS value, global::Serde.ISerializer serializer)
         {
             var _l_info = global::Serde.SerdeInfoProvider.GetInfo(this);
-            var _l_type = serializer.WriteType(_l_info);
+            var _l_type = serializer.WriteType(_l_info, 4);
             _l_type.WriteI32(_l_info, 0, value.cbStruct);
             _l_type.WriteI32(_l_info, 1, value.dwTickCountDeadline);
             _l_type.WriteI32(_l_info, 2, value.grfFlags);

--- a/test/Serde.Generation.Test/test_output/ProxyTests.SerdeMemberOptionsTakesPrecedenceOverUseProxy/Proxy2.ISerde.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/ProxyTests.SerdeMemberOptionsTakesPrecedenceOverUseProxy/Proxy2.ISerde.g.verified.cs
@@ -13,7 +13,7 @@ partial class Proxy2
         void global::Serde.ISerialize<System.Runtime.InteropServices.ComTypes.BIND_OPTS>.Serialize(System.Runtime.InteropServices.ComTypes.BIND_OPTS value, global::Serde.ISerializer serializer)
         {
             var _l_info = global::Serde.SerdeInfoProvider.GetInfo(this);
-            var _l_type = serializer.WriteType(_l_info);
+            var _l_type = serializer.WriteType(_l_info, 4);
             _l_type.WriteI32(_l_info, 0, value.cbStruct);
             _l_type.WriteI32(_l_info, 1, value.dwTickCountDeadline);
             _l_type.WriteI32(_l_info, 2, value.grfFlags);

--- a/test/Serde.Generation.Test/test_output/SerdeTests.CommandResponseTest/ArgumentInfo.ISerde.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/SerdeTests.CommandResponseTest/ArgumentInfo.ISerde.g.verified.cs
@@ -13,7 +13,7 @@ partial class ArgumentInfo
         void global::Serde.ISerialize<ArgumentInfo>.Serialize(ArgumentInfo value, global::Serde.ISerializer serializer)
         {
             var _l_info = global::Serde.SerdeInfoProvider.GetInfo(this);
-            var _l_type = serializer.WriteType(_l_info);
+            var _l_type = serializer.WriteType(_l_info, 2);
             _l_type.WriteString(_l_info, 0, value.Name);
             _l_type.WriteString(_l_info, 1, value.Value);
             _l_type.End(_l_info);

--- a/test/Serde.Generation.Test/test_output/SerdeTests.CommandResponseTest/CommandResponse.ISerde.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/SerdeTests.CommandResponseTest/CommandResponse.ISerde.g.verified.cs
@@ -13,7 +13,9 @@ partial class CommandResponse<TResult, TProxy>
         void global::Serde.ISerialize<CommandResponse<TResult, TProxy>>.Serialize(CommandResponse<TResult, TProxy> value, global::Serde.ISerializer serializer)
         {
             var _l_info = global::Serde.SerdeInfoProvider.GetInfo(this);
-            var _l_type = serializer.WriteType(_l_info);
+            var _l_fieldCount = 5;
+            if (value.Arguments is null) _l_fieldCount--;
+            var _l_type = serializer.WriteType(_l_info, _l_fieldCount);
             _l_type.WriteI32(_l_info, 0, value.Status);
             _l_type.WriteString(_l_info, 1, value.Message);
             _l_type.WriteValueIfNotNull<System.Collections.Generic.List<ArgumentInfo>, Serde.NullableRefProxy.Ser<System.Collections.Generic.List<ArgumentInfo>, Serde.ListProxy.Ser<ArgumentInfo, ArgumentInfo>>>(_l_info, 2, value.Arguments);

--- a/test/Serde.Generation.Test/test_output/SerdeTests.DuplicateMemberOrdinalReportsError/Dupe.ISerde.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/SerdeTests.DuplicateMemberOrdinalReportsError/Dupe.ISerde.g.verified.cs
@@ -13,7 +13,7 @@ partial record Dupe
         void global::Serde.ISerialize<Dupe>.Serialize(Dupe value, global::Serde.ISerializer serializer)
         {
             var _l_info = global::Serde.SerdeInfoProvider.GetInfo(this);
-            var _l_type = serializer.WriteType(_l_info);
+            var _l_type = serializer.WriteType(_l_info, 2);
             _l_type.WriteI32(_l_info, 0, value.A);
             _l_type.WriteI32(_l_info, 1, value.B);
             _l_type.End(_l_info);

--- a/test/Serde.Generation.Test/test_output/SerdeTests.ExplicitMemberOrdinal/Reordered.ISerde.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/SerdeTests.ExplicitMemberOrdinal/Reordered.ISerde.g.verified.cs
@@ -13,7 +13,7 @@ partial record Reordered
         void global::Serde.ISerialize<Reordered>.Serialize(Reordered value, global::Serde.ISerializer serializer)
         {
             var _l_info = global::Serde.SerdeInfoProvider.GetInfo(this);
-            var _l_type = serializer.WriteType(_l_info);
+            var _l_type = serializer.WriteType(_l_info, 3);
             _l_type.WriteI32(_l_info, 0, value.B);
             _l_type.WriteI32(_l_info, 1, value.C);
             _l_type.WriteI32(_l_info, 2, value.A);

--- a/test/Serde.Generation.Test/test_output/SerdeTests.InvalidTypeParameterProxyTest/InvalidProxyTest.ISerde.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/SerdeTests.InvalidTypeParameterProxyTest/InvalidProxyTest.ISerde.g.verified.cs
@@ -13,7 +13,7 @@ partial class InvalidProxyTest<T>
         void global::Serde.ISerialize<InvalidProxyTest<T>>.Serialize(InvalidProxyTest<T> value, global::Serde.ISerializer serializer)
         {
             var _l_info = global::Serde.SerdeInfoProvider.GetInfo(this);
-            var _l_type = serializer.WriteType(_l_info, 0);
+            var _l_type = serializer.WriteType(_l_info, 3);
             _l_type.End(_l_info);
         }
         InvalidProxyTest<T> Serde.IDeserialize<InvalidProxyTest<T>>.Deserialize(IDeserializer deserializer)

--- a/test/Serde.Generation.Test/test_output/SerdeTests.InvalidTypeParameterProxyTest/InvalidProxyTest.ISerde.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/SerdeTests.InvalidTypeParameterProxyTest/InvalidProxyTest.ISerde.g.verified.cs
@@ -13,7 +13,7 @@ partial class InvalidProxyTest<T>
         void global::Serde.ISerialize<InvalidProxyTest<T>>.Serialize(InvalidProxyTest<T> value, global::Serde.ISerializer serializer)
         {
             var _l_info = global::Serde.SerdeInfoProvider.GetInfo(this);
-            var _l_type = serializer.WriteType(_l_info);
+            var _l_type = serializer.WriteType(_l_info, 0);
             _l_type.End(_l_info);
         }
         InvalidProxyTest<T> Serde.IDeserialize<InvalidProxyTest<T>>.Deserialize(IDeserializer deserializer)

--- a/test/Serde.Generation.Test/test_output/SerdeTests.NestedNullable/ComplexRecord.ISerde.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/SerdeTests.NestedNullable/ComplexRecord.ISerde.g.verified.cs
@@ -13,7 +13,10 @@ partial record ComplexRecord
         void global::Serde.ISerialize<ComplexRecord>.Serialize(ComplexRecord value, global::Serde.ISerializer serializer)
         {
             var _l_info = global::Serde.SerdeInfoProvider.GetInfo(this);
-            var _l_type = serializer.WriteType(_l_info);
+            var _l_fieldCount = 3;
+            if (value.Description is null) _l_fieldCount--;
+            if (value.NestedRecord is null) _l_fieldCount--;
+            var _l_type = serializer.WriteType(_l_info, _l_fieldCount);
             _l_type.WriteI32(_l_info, 0, value.Id);
             _l_type.WriteStringIfNotNull(_l_info, 1, value.Description);
             _l_type.WriteValueIfNotNull<SimpleRecord, Serde.NullableRefProxy.Ser<SimpleRecord, SimpleRecord>>(_l_info, 2, value.NestedRecord);

--- a/test/Serde.Generation.Test/test_output/SerdeTests.NestedNullable/SimpleRecord.ISerde.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/SerdeTests.NestedNullable/SimpleRecord.ISerde.g.verified.cs
@@ -13,7 +13,7 @@ partial record SimpleRecord
         void global::Serde.ISerialize<SimpleRecord>.Serialize(SimpleRecord value, global::Serde.ISerializer serializer)
         {
             var _l_info = global::Serde.SerdeInfoProvider.GetInfo(this);
-            var _l_type = serializer.WriteType(_l_info);
+            var _l_type = serializer.WriteType(_l_info, 2);
             _l_type.WriteI32(_l_info, 0, value.Id);
             _l_type.WriteString(_l_info, 1, value.Name);
             _l_type.End(_l_info);

--- a/test/Serde.Generation.Test/test_output/SerdeTests.OrdinalOnNonPublicMemberReportsError/NonPublic.ISerde.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/SerdeTests.OrdinalOnNonPublicMemberReportsError/NonPublic.ISerde.g.verified.cs
@@ -13,7 +13,7 @@ partial record NonPublic
         void global::Serde.ISerialize<NonPublic>.Serialize(NonPublic value, global::Serde.ISerializer serializer)
         {
             var _l_info = global::Serde.SerdeInfoProvider.GetInfo(this);
-            var _l_type = serializer.WriteType(_l_info);
+            var _l_type = serializer.WriteType(_l_info, 1);
             _l_type.WriteI32(_l_info, 0, value.B);
             _l_type.End(_l_info);
         }

--- a/test/Serde.Generation.Test/test_output/SerdeTests.PartialMemberOrdinalReportsError/Partial.ISerde.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/SerdeTests.PartialMemberOrdinalReportsError/Partial.ISerde.g.verified.cs
@@ -13,7 +13,7 @@ partial record Partial
         void global::Serde.ISerialize<Partial>.Serialize(Partial value, global::Serde.ISerializer serializer)
         {
             var _l_info = global::Serde.SerdeInfoProvider.GetInfo(this);
-            var _l_type = serializer.WriteType(_l_info);
+            var _l_type = serializer.WriteType(_l_info, 2);
             _l_type.WriteI32(_l_info, 0, value.A);
             _l_type.WriteI32(_l_info, 1, value.B);
             _l_type.End(_l_info);

--- a/test/Serde.Generation.Test/test_output/SerdeTests.SparseMemberOrdinals/Sparse.ISerde.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/SerdeTests.SparseMemberOrdinals/Sparse.ISerde.g.verified.cs
@@ -13,7 +13,7 @@ partial record Sparse
         void global::Serde.ISerialize<Sparse>.Serialize(Sparse value, global::Serde.ISerializer serializer)
         {
             var _l_info = global::Serde.SerdeInfoProvider.GetInfo(this);
-            var _l_type = serializer.WriteType(_l_info);
+            var _l_type = serializer.WriteType(_l_info, 3);
             _l_type.WriteI32(_l_info, 0, value.B);
             _l_type.WriteI32(_l_info, 1, value.C);
             _l_type.WriteI32(_l_info, 2, value.A);

--- a/test/Serde.Generation.Test/test_output/SerializeTests.ArrayOfGenerateSerialize/TestCase15.Class0.ISerialize.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/SerializeTests.ArrayOfGenerateSerialize/TestCase15.Class0.ISerialize.g.verified.cs
@@ -15,7 +15,7 @@ partial class TestCase15
             void global::Serde.ISerialize<TestCase15.Class0>.Serialize(TestCase15.Class0 value, global::Serde.ISerializer serializer)
             {
                 var _l_info = global::Serde.SerdeInfoProvider.GetInfo(this);
-                var _l_type = serializer.WriteType(_l_info);
+                var _l_type = serializer.WriteType(_l_info, 2);
                 _l_type.WriteValue<TestCase15.Class1[], Serde.ArrayProxy.Ser<TestCase15.Class1, TestCase15.Class1>>(_l_info, 0, value.Field0);
                 _l_type.WriteValue<bool[], Serde.ArrayProxy.Ser<bool, global::Serde.BoolProxy>>(_l_info, 1, value.Field1);
                 _l_type.End(_l_info);

--- a/test/Serde.Generation.Test/test_output/SerializeTests.ArrayOfGenerateSerialize/TestCase15.Class1.ISerialize.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/SerializeTests.ArrayOfGenerateSerialize/TestCase15.Class1.ISerialize.g.verified.cs
@@ -15,7 +15,7 @@ partial class TestCase15
             void global::Serde.ISerialize<TestCase15.Class1>.Serialize(TestCase15.Class1 value, global::Serde.ISerializer serializer)
             {
                 var _l_info = global::Serde.SerdeInfoProvider.GetInfo(this);
-                var _l_type = serializer.WriteType(_l_info);
+                var _l_type = serializer.WriteType(_l_info, 2);
                 _l_type.WriteI32(_l_info, 0, value.Field0);
                 _l_type.WriteU8(_l_info, 1, value.Field1);
                 _l_type.End(_l_info);

--- a/test/Serde.Generation.Test/test_output/SerializeTests.BasicDU/Some.Nested.Namespace.Base.ISerialize.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/SerializeTests.BasicDU/Some.Nested.Namespace.Base.ISerialize.g.verified.cs
@@ -16,7 +16,7 @@ partial record Base
         void ISerialize<Some.Nested.Namespace.Base>.Serialize(Some.Nested.Namespace.Base value, ISerializer serializer)
         {
             var _l_serdeInfo = global::Serde.SerdeInfoProvider.GetInfo(this);
-            var _l_type = serializer.WriteType(_l_serdeInfo);
+            var _l_type = serializer.WriteType(_l_serdeInfo, 1);
             switch (value)
             {
                 case Some.Nested.Namespace.Base.A c:

--- a/test/Serde.Generation.Test/test_output/SerializeTests.BasicDU/Some.Nested.Namespace.Base._m_AProxy.ISerialize.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/SerializeTests.BasicDU/Some.Nested.Namespace.Base._m_AProxy.ISerialize.g.verified.cs
@@ -18,7 +18,7 @@ partial record Base
             void global::Serde.ISerialize<Some.Nested.Namespace.Base.A>.Serialize(Some.Nested.Namespace.Base.A value, global::Serde.ISerializer serializer)
             {
                 var _l_info = global::Serde.SerdeInfoProvider.GetInfo(this);
-                var _l_type = serializer.WriteType(_l_info);
+                var _l_type = serializer.WriteType(_l_info, 1);
                 _l_type.WriteI32(_l_info, 0, value.X);
                 _l_type.End(_l_info);
             }

--- a/test/Serde.Generation.Test/test_output/SerializeTests.BasicDU/Some.Nested.Namespace.Base._m_BProxy.ISerialize.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/SerializeTests.BasicDU/Some.Nested.Namespace.Base._m_BProxy.ISerialize.g.verified.cs
@@ -18,7 +18,7 @@ partial record Base
             void global::Serde.ISerialize<Some.Nested.Namespace.Base.B>.Serialize(Some.Nested.Namespace.Base.B value, global::Serde.ISerializer serializer)
             {
                 var _l_info = global::Serde.SerdeInfoProvider.GetInfo(this);
-                var _l_type = serializer.WriteType(_l_info);
+                var _l_type = serializer.WriteType(_l_info, 1);
                 _l_type.WriteString(_l_info, 0, value.Y);
                 _l_type.End(_l_info);
             }

--- a/test/Serde.Generation.Test/test_output/SerializeTests.DictionaryGenerate2/C.ISerialize.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/SerializeTests.DictionaryGenerate2/C.ISerialize.g.verified.cs
@@ -13,7 +13,7 @@ partial record C
         void global::Serde.ISerialize<C>.Serialize(C value, global::Serde.ISerializer serializer)
         {
             var _l_info = global::Serde.SerdeInfoProvider.GetInfo(this);
-            var _l_type = serializer.WriteType(_l_info);
+            var _l_type = serializer.WriteType(_l_info, 1);
             _l_type.WriteI32(_l_info, 0, value.X);
             _l_type.End(_l_info);
         }

--- a/test/Serde.Generation.Test/test_output/SerializeTests.DictionaryGenerate2/C2.ISerialize.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/SerializeTests.DictionaryGenerate2/C2.ISerialize.g.verified.cs
@@ -13,7 +13,7 @@ partial class C2
         void global::Serde.ISerialize<C2>.Serialize(C2 value, global::Serde.ISerializer serializer)
         {
             var _l_info = global::Serde.SerdeInfoProvider.GetInfo(this);
-            var _l_type = serializer.WriteType(_l_info);
+            var _l_type = serializer.WriteType(_l_info, 1);
             _l_type.WriteValue<System.Collections.Generic.Dictionary<string, C>, Serde.DictProxy.Ser<string, C, global::Serde.StringProxy, C>>(_l_info, 0, value.Map);
             _l_type.End(_l_info);
         }

--- a/test/Serde.Generation.Test/test_output/SerializeTests.EnumMember/Some.Nested.Namespace.C.ISerialize.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/SerializeTests.EnumMember/Some.Nested.Namespace.C.ISerialize.g.verified.cs
@@ -16,7 +16,7 @@ partial class C
         void global::Serde.ISerialize<Some.Nested.Namespace.C>.Serialize(Some.Nested.Namespace.C value, global::Serde.ISerializer serializer)
         {
             var _l_info = global::Serde.SerdeInfoProvider.GetInfo(this);
-            var _l_type = serializer.WriteType(_l_info);
+            var _l_type = serializer.WriteType(_l_info, 4);
             _l_type.WriteValue<Some.Nested.Namespace.ColorInt, Some.Nested.Namespace.ColorIntProxy>(_l_info, 0, value.ColorInt);
             _l_type.WriteValue<Some.Nested.Namespace.ColorByte, Some.Nested.Namespace.ColorByteProxy>(_l_info, 1, value.ColorByte);
             _l_type.WriteValue<Some.Nested.Namespace.ColorLong, Some.Nested.Namespace.ColorLongProxy>(_l_info, 2, value.ColorLong);

--- a/test/Serde.Generation.Test/test_output/SerializeTests.NestedEnumWrapper/C.ISerialize.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/SerializeTests.NestedEnumWrapper/C.ISerialize.g.verified.cs
@@ -13,7 +13,9 @@ partial class C
         void global::Serde.ISerialize<C>.Serialize(C value, global::Serde.ISerializer serializer)
         {
             var _l_info = global::Serde.SerdeInfoProvider.GetInfo(this);
-            var _l_type = serializer.WriteType(_l_info);
+            var _l_fieldCount = 1;
+            if (value.ColorOpt is null) _l_fieldCount--;
+            var _l_type = serializer.WriteType(_l_info, _l_fieldCount);
             _l_type.WriteValueIfNotNull<Rgb, Serde.NullableProxy.Ser<Rgb, RgbProxy>>(_l_info, 0, value.ColorOpt);
             _l_type.End(_l_info);
         }

--- a/test/Serde.Generation.Test/test_output/SerializeTests.NestedExplicitSerializeWrapper/OPTSWrap.ISerde.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/SerializeTests.NestedExplicitSerializeWrapper/OPTSWrap.ISerde.g.verified.cs
@@ -13,7 +13,7 @@ partial class OPTSWrap
         void global::Serde.ISerialize<System.Runtime.InteropServices.ComTypes.BIND_OPTS>.Serialize(System.Runtime.InteropServices.ComTypes.BIND_OPTS value, global::Serde.ISerializer serializer)
         {
             var _l_info = global::Serde.SerdeInfoProvider.GetInfo(this);
-            var _l_type = serializer.WriteType(_l_info);
+            var _l_type = serializer.WriteType(_l_info, 4);
             _l_type.WriteI32(_l_info, 0, value.cbStruct);
             _l_type.WriteI32(_l_info, 1, value.dwTickCountDeadline);
             _l_type.WriteI32(_l_info, 2, value.grfFlags);

--- a/test/Serde.Generation.Test/test_output/SerializeTests.NestedExplicitSerializeWrapper/S.ISerde.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/SerializeTests.NestedExplicitSerializeWrapper/S.ISerde.g.verified.cs
@@ -13,7 +13,7 @@ partial struct S
         void global::Serde.ISerialize<S>.Serialize(S value, global::Serde.ISerializer serializer)
         {
             var _l_info = global::Serde.SerdeInfoProvider.GetInfo(this);
-            var _l_type = serializer.WriteType(_l_info);
+            var _l_type = serializer.WriteType(_l_info, 1);
             _l_type.WriteValue<System.Collections.Immutable.ImmutableArray<System.Runtime.InteropServices.ComTypes.BIND_OPTS>, Serde.ImmutableArrayProxy.Ser<System.Runtime.InteropServices.ComTypes.BIND_OPTS, OPTSWrap>>(_l_info, 0, value.Opts);
             _l_type.End(_l_info);
         }

--- a/test/Serde.Generation.Test/test_output/SerializeTests.SerializeOnlyWrapper/SectionWrap.ISerialize.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/SerializeTests.SerializeOnlyWrapper/SectionWrap.ISerialize.g.verified.cs
@@ -13,7 +13,7 @@ partial record struct SectionWrap
         void global::Serde.ISerialize<System.Collections.Specialized.BitVector32.Section>.Serialize(System.Collections.Specialized.BitVector32.Section value, global::Serde.ISerializer serializer)
         {
             var _l_info = global::Serde.SerdeInfoProvider.GetInfo(this);
-            var _l_type = serializer.WriteType(_l_info);
+            var _l_type = serializer.WriteType(_l_info, 2);
             _l_type.WriteI16(_l_info, 0, value.Mask);
             _l_type.WriteI16(_l_info, 1, value.Offset);
             _l_type.End(_l_info);

--- a/test/Serde.Generation.Test/test_output/SerializeTests/DictionaryGenerate#C.ISerialize.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/SerializeTests/DictionaryGenerate#C.ISerialize.g.verified.cs
@@ -13,7 +13,7 @@ partial class C
         void global::Serde.ISerialize<C>.Serialize(C value, global::Serde.ISerializer serializer)
         {
             var _l_info = global::Serde.SerdeInfoProvider.GetInfo(this);
-            var _l_type = serializer.WriteType(_l_info);
+            var _l_type = serializer.WriteType(_l_info, 1);
             _l_type.WriteValue<System.Collections.Generic.Dictionary<string, int>, Serde.DictProxy.Ser<string, int, global::Serde.StringProxy, global::Serde.I32Proxy>>(_l_info, 0, value.Map);
             _l_type.End(_l_info);
         }

--- a/test/Serde.Generation.Test/test_output/SerializeTests/ExplicitGenericWrapper#C.ISerialize.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/SerializeTests/ExplicitGenericWrapper#C.ISerialize.g.verified.cs
@@ -13,7 +13,7 @@ partial class C
         void global::Serde.ISerialize<C>.Serialize(C value, global::Serde.ISerializer serializer)
         {
             var _l_info = global::Serde.SerdeInfoProvider.GetInfo(this);
-            var _l_type = serializer.WriteType(_l_info);
+            var _l_type = serializer.WriteType(_l_info, 1);
             _l_type.WriteValue<S<int>, SWrap.Ser<int, global::Serde.I32Proxy>>(_l_info, 0, value.S);
             _l_type.End(_l_info);
         }

--- a/test/Serde.Generation.Test/test_output/SerializeTests/ExplicitWrapper#C.ISerialize.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/SerializeTests/ExplicitWrapper#C.ISerialize.g.verified.cs
@@ -13,7 +13,7 @@ partial class C
         void global::Serde.ISerialize<C>.Serialize(C value, global::Serde.ISerializer serializer)
         {
             var _l_info = global::Serde.SerdeInfoProvider.GetInfo(this);
-            var _l_type = serializer.WriteType(_l_info);
+            var _l_type = serializer.WriteType(_l_info, 1);
             _l_type.WriteValue<S, SWrap>(_l_info, 0, value.S);
             _l_type.End(_l_info);
         }

--- a/test/Serde.Generation.Test/test_output/SerializeTests/HiddenMembers#A.ISerialize.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/SerializeTests/HiddenMembers#A.ISerialize.g.verified.cs
@@ -13,7 +13,7 @@ partial class A
         void global::Serde.ISerialize<A>.Serialize(A value, global::Serde.ISerializer serializer)
         {
             var _l_info = global::Serde.SerdeInfoProvider.GetInfo(this);
-            var _l_type = serializer.WriteType(_l_info);
+            var _l_type = serializer.WriteType(_l_info, 1);
             _l_type.WriteI32(_l_info, 0, value.X);
             _l_type.End(_l_info);
         }

--- a/test/Serde.Generation.Test/test_output/SerializeTests/HiddenMembers#B.ISerialize.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/SerializeTests/HiddenMembers#B.ISerialize.g.verified.cs
@@ -13,7 +13,7 @@ partial class B
         void global::Serde.ISerialize<B>.Serialize(B value, global::Serde.ISerializer serializer)
         {
             var _l_info = global::Serde.SerdeInfoProvider.GetInfo(this);
-            var _l_type = serializer.WriteType(_l_info);
+            var _l_type = serializer.WriteType(_l_info, 2);
             _l_type.WriteI32(_l_info, 0, value.X);
             _l_type.WriteI32(_l_info, 1, value.Y);
             _l_type.End(_l_info);

--- a/test/Serde.Generation.Test/test_output/SerializeTests/Inheritance#A.ISerialize.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/SerializeTests/Inheritance#A.ISerialize.g.verified.cs
@@ -13,7 +13,7 @@ partial class A
         void global::Serde.ISerialize<A>.Serialize(A value, global::Serde.ISerializer serializer)
         {
             var _l_info = global::Serde.SerdeInfoProvider.GetInfo(this);
-            var _l_type = serializer.WriteType(_l_info);
+            var _l_type = serializer.WriteType(_l_info, 1);
             _l_type.WriteI32(_l_info, 0, value.X);
             _l_type.End(_l_info);
         }

--- a/test/Serde.Generation.Test/test_output/SerializeTests/Inheritance#B.ISerialize.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/SerializeTests/Inheritance#B.ISerialize.g.verified.cs
@@ -13,7 +13,7 @@ partial class B
         void global::Serde.ISerialize<B>.Serialize(B value, global::Serde.ISerializer serializer)
         {
             var _l_info = global::Serde.SerdeInfoProvider.GetInfo(this);
-            var _l_type = serializer.WriteType(_l_info);
+            var _l_type = serializer.WriteType(_l_info, 2);
             _l_type.WriteI32(_l_info, 0, value.Y);
             _l_type.WriteI32(_l_info, 1, value.X);
             _l_type.End(_l_info);

--- a/test/Serde.Generation.Test/test_output/SerializeTests/Inheritance#C.ISerialize.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/SerializeTests/Inheritance#C.ISerialize.g.verified.cs
@@ -13,7 +13,7 @@ partial class C
         void global::Serde.ISerialize<C>.Serialize(C value, global::Serde.ISerializer serializer)
         {
             var _l_info = global::Serde.SerdeInfoProvider.GetInfo(this);
-            var _l_type = serializer.WriteType(_l_info);
+            var _l_type = serializer.WriteType(_l_info, 3);
             _l_type.WriteI32(_l_info, 0, value.Z);
             _l_type.WriteI32(_l_info, 1, value.Y);
             _l_type.WriteI32(_l_info, 2, value.X);

--- a/test/Serde.Generation.Test/test_output/SerializeTests/MemberOverrides#A.ISerialize.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/SerializeTests/MemberOverrides#A.ISerialize.g.verified.cs
@@ -13,7 +13,7 @@ partial record A
         void global::Serde.ISerialize<A>.Serialize(A value, global::Serde.ISerializer serializer)
         {
             var _l_info = global::Serde.SerdeInfoProvider.GetInfo(this);
-            var _l_type = serializer.WriteType(_l_info);
+            var _l_type = serializer.WriteType(_l_info, 1);
             _l_type.WriteI32(_l_info, 0, value.X);
             _l_type.End(_l_info);
         }

--- a/test/Serde.Generation.Test/test_output/SerializeTests/MemberOverrides#B.ISerialize.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/SerializeTests/MemberOverrides#B.ISerialize.g.verified.cs
@@ -13,7 +13,7 @@ partial record B
         void global::Serde.ISerialize<B>.Serialize(B value, global::Serde.ISerializer serializer)
         {
             var _l_info = global::Serde.SerdeInfoProvider.GetInfo(this);
-            var _l_type = serializer.WriteType(_l_info);
+            var _l_type = serializer.WriteType(_l_info, 2);
             _l_type.WriteI32(_l_info, 0, value.Y);
             _l_type.WriteI32(_l_info, 1, value.X);
             _l_type.End(_l_info);

--- a/test/Serde.Generation.Test/test_output/SerializeTests/MemberSkip#Rgb.ISerialize.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/SerializeTests/MemberSkip#Rgb.ISerialize.g.verified.cs
@@ -13,7 +13,7 @@ partial struct Rgb
         void global::Serde.ISerialize<Rgb>.Serialize(Rgb value, global::Serde.ISerializer serializer)
         {
             var _l_info = global::Serde.SerdeInfoProvider.GetInfo(this);
-            var _l_type = serializer.WriteType(_l_info);
+            var _l_type = serializer.WriteType(_l_info, 2);
             _l_type.WriteU8(_l_info, 0, value.Red);
             _l_type.WriteU8(_l_info, 1, value.Blue);
             _l_type.End(_l_info);

--- a/test/Serde.Generation.Test/test_output/SerializeTests/MemberSkipDeserialize#Rgb.ISerialize.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/SerializeTests/MemberSkipDeserialize#Rgb.ISerialize.g.verified.cs
@@ -13,7 +13,7 @@ partial struct Rgb
         void global::Serde.ISerialize<Rgb>.Serialize(Rgb value, global::Serde.ISerializer serializer)
         {
             var _l_info = global::Serde.SerdeInfoProvider.GetInfo(this);
-            var _l_type = serializer.WriteType(_l_info);
+            var _l_type = serializer.WriteType(_l_info, 3);
             _l_type.WriteU8(_l_info, 0, value.Red);
             _l_type.WriteU8(_l_info, 1, value.Green);
             _l_type.WriteU8(_l_info, 2, value.Blue);

--- a/test/Serde.Generation.Test/test_output/SerializeTests/MemberSkipSerialize#Rgb.ISerialize.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/SerializeTests/MemberSkipSerialize#Rgb.ISerialize.g.verified.cs
@@ -13,7 +13,7 @@ partial struct Rgb
         void global::Serde.ISerialize<Rgb>.Serialize(Rgb value, global::Serde.ISerializer serializer)
         {
             var _l_info = global::Serde.SerdeInfoProvider.GetInfo(this);
-            var _l_type = serializer.WriteType(_l_info);
+            var _l_type = serializer.WriteType(_l_info, 2);
             _l_type.WriteU8(_l_info, 0, value.Red);
             _l_type.WriteU8(_l_info, 1, value.Blue);
             _l_type.End(_l_info);

--- a/test/Serde.Generation.Test/test_output/SerializeTests/NestedArray#C.ISerialize.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/SerializeTests/NestedArray#C.ISerialize.g.verified.cs
@@ -13,7 +13,7 @@ partial class C
         void global::Serde.ISerialize<C>.Serialize(C value, global::Serde.ISerializer serializer)
         {
             var _l_info = global::Serde.SerdeInfoProvider.GetInfo(this);
-            var _l_type = serializer.WriteType(_l_info);
+            var _l_type = serializer.WriteType(_l_info, 1);
             _l_type.WriteValue<int[][], Serde.ArrayProxy.Ser<int[], Serde.ArrayProxy.Ser<int, global::Serde.I32Proxy>>>(_l_info, 0, value.NestedArr);
             _l_type.End(_l_info);
         }

--- a/test/Serde.Generation.Test/test_output/SerializeTests/NestedArray2#C.ISerialize.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/SerializeTests/NestedArray2#C.ISerialize.g.verified.cs
@@ -13,7 +13,7 @@ partial class C
         void global::Serde.ISerialize<C>.Serialize(C value, global::Serde.ISerializer serializer)
         {
             var _l_info = global::Serde.SerdeInfoProvider.GetInfo(this);
-            var _l_type = serializer.WriteType(_l_info);
+            var _l_type = serializer.WriteType(_l_info, 1);
             _l_type.WriteValue<int[][], Serde.ArrayProxy.Ser<int[], Serde.ArrayProxy.Ser<int, global::Serde.I32Proxy>>>(_l_info, 0, value.NestedArr);
             _l_type.End(_l_info);
         }

--- a/test/Serde.Generation.Test/test_output/SerializeTests/NestedPartialClasses#A.B.C.D.ISerialize.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/SerializeTests/NestedPartialClasses#A.B.C.D.ISerialize.g.verified.cs
@@ -19,7 +19,7 @@ partial class A
                     void global::Serde.ISerialize<A.B.C.D>.Serialize(A.B.C.D value, global::Serde.ISerializer serializer)
                     {
                         var _l_info = global::Serde.SerdeInfoProvider.GetInfo(this);
-                        var _l_type = serializer.WriteType(_l_info);
+                        var _l_type = serializer.WriteType(_l_info, 1);
                         _l_type.WriteI32(_l_info, 0, value.Field);
                         _l_type.End(_l_info);
                     }

--- a/test/Serde.Generation.Test/test_output/SerializeTests/NoGenerateGeneric#C.ISerialize.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/SerializeTests/NoGenerateGeneric#C.ISerialize.g.verified.cs
@@ -13,7 +13,7 @@ partial class C<T>
         void global::Serde.ISerialize<C<T>>.Serialize(C<T> value, global::Serde.ISerializer serializer)
         {
             var _l_info = global::Serde.SerdeInfoProvider.GetInfo(this);
-            var _l_type = serializer.WriteType(_l_info, 0);
+            var _l_type = serializer.WriteType(_l_info, 1);
             _l_type.End(_l_info);
         }
 

--- a/test/Serde.Generation.Test/test_output/SerializeTests/NoGenerateGeneric#C.ISerialize.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/SerializeTests/NoGenerateGeneric#C.ISerialize.g.verified.cs
@@ -13,7 +13,7 @@ partial class C<T>
         void global::Serde.ISerialize<C<T>>.Serialize(C<T> value, global::Serde.ISerializer serializer)
         {
             var _l_info = global::Serde.SerdeInfoProvider.GetInfo(this);
-            var _l_type = serializer.WriteType(_l_info);
+            var _l_type = serializer.WriteType(_l_info, 0);
             _l_type.End(_l_info);
         }
 

--- a/test/Serde.Generation.Test/test_output/SerializeTests/NullableFields#S.ISerialize.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/SerializeTests/NullableFields#S.ISerialize.g.verified.cs
@@ -13,7 +13,10 @@ partial struct S<T1, T2, TSerialize>
         void global::Serde.ISerialize<S<T1, T2, TSerialize>>.Serialize(S<T1, T2, TSerialize> value, global::Serde.ISerializer serializer)
         {
             var _l_info = global::Serde.SerdeInfoProvider.GetInfo(this);
-            var _l_type = serializer.WriteType(_l_info);
+            var _l_fieldCount = 2;
+            if (value.FI is null) _l_fieldCount--;
+            if (value.F3 is null) _l_fieldCount--;
+            var _l_type = serializer.WriteType(_l_info, _l_fieldCount);
             _l_type.WriteValueIfNotNull<int, Serde.NullableProxy.Ser<int, global::Serde.I32Proxy>>(_l_info, 0, value.FI);
             _l_type.WriteValueIfNotNull<TSerialize, Serde.NullableProxy.Ser<TSerialize, TSerialize>>(_l_info, 3, value.F3);
             _l_type.End(_l_info);

--- a/test/Serde.Generation.Test/test_output/SerializeTests/NullableFields#S.ISerialize.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/SerializeTests/NullableFields#S.ISerialize.g.verified.cs
@@ -13,7 +13,7 @@ partial struct S<T1, T2, TSerialize>
         void global::Serde.ISerialize<S<T1, T2, TSerialize>>.Serialize(S<T1, T2, TSerialize> value, global::Serde.ISerializer serializer)
         {
             var _l_info = global::Serde.SerdeInfoProvider.GetInfo(this);
-            var _l_fieldCount = 2;
+            var _l_fieldCount = 4;
             if (value.FI is null) _l_fieldCount--;
             if (value.F3 is null) _l_fieldCount--;
             var _l_type = serializer.WriteType(_l_info, _l_fieldCount);

--- a/test/Serde.Generation.Test/test_output/SerializeTests/NullableRefFields#FinalDiagnostics.verified.txt
+++ b/test/Serde.Generation.Test/test_output/SerializeTests/NullableRefFields#FinalDiagnostics.verified.txt
@@ -11,25 +11,25 @@
     "Category": "Compiler"
   },
   {
-    "Id": "CS0452",
-    "Title": "",
-    "Severity": "Error",
-    "WarningLevel": "0",
-    "Location": "SerdeGenerator/Serde.SerdeImplRoslynGenerator/S.ISerialize.g.cs: (17,20)-(17,47)",
-    "HelpLink": "https://msdn.microsoft.com/query/roslyn.query?appId=roslyn&k=k(CS0452)",
-    "MessageFormat": "The type '{2}' must be a reference type in order to use it as parameter '{1}' in the generic type or method '{0}'",
-    "Message": "The type 'T2' must be a reference type in order to use it as parameter 'T' in the generic type or method 'ITypeSerializerExt.WriteValueIfNotNull<T, TProvider>(ITypeSerializer, ISerdeInfo, int, T?)'",
-    "Category": "Compiler"
-  },
-  {
     "Id": "CS8631",
     "Title": "The type cannot be used as type parameter in the generic type or method. Nullability of type argument doesn't match constraint type.",
     "Severity": "Warning",
     "WarningLevel": "1",
-    "Location": "SerdeGenerator/Serde.SerdeImplRoslynGenerator/S.ISerialize.g.cs: (19,12)-(19,47)",
+    "Location": "SerdeGenerator/Serde.SerdeImplRoslynGenerator/S.ISerialize.g.cs: (24,12)-(24,47)",
     "HelpLink": "https://msdn.microsoft.com/query/roslyn.query?appId=roslyn&k=k(CS8631)",
     "MessageFormat": "The type '{3}' cannot be used as type parameter '{2}' in the generic type or method '{0}'. Nullability of type argument '{3}' doesn't match constraint type '{1}'.",
     "Message": "The type 'T4' cannot be used as type parameter 'TProvider' in the generic type or method 'ITypeSerializerExt.WriteValueIfNotNull<T, TProvider>(ITypeSerializer, ISerdeInfo, int, T?)'. Nullability of type argument 'T4' doesn't match constraint type 'Serde.ISerializeProvider<T4?>'.",
+    "Category": "Compiler"
+  },
+  {
+    "Id": "CS0452",
+    "Title": "",
+    "Severity": "Error",
+    "WarningLevel": "0",
+    "Location": "SerdeGenerator/Serde.SerdeImplRoslynGenerator/S.ISerialize.g.cs: (22,20)-(22,47)",
+    "HelpLink": "https://msdn.microsoft.com/query/roslyn.query?appId=roslyn&k=k(CS0452)",
+    "MessageFormat": "The type '{2}' must be a reference type in order to use it as parameter '{1}' in the generic type or method '{0}'",
+    "Message": "The type 'T2' must be a reference type in order to use it as parameter 'T' in the generic type or method 'ITypeSerializerExt.WriteValueIfNotNull<T, TProvider>(ITypeSerializer, ISerdeInfo, int, T?)'",
     "Category": "Compiler"
   }
 ]

--- a/test/Serde.Generation.Test/test_output/SerializeTests/NullableRefFields#S.ISerialize.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/SerializeTests/NullableRefFields#S.ISerialize.g.verified.cs
@@ -13,7 +13,12 @@ partial struct S<T1, T2, T3, T4, T5>
         void global::Serde.ISerialize<S<T1, T2, T3, T4, T5>>.Serialize(S<T1, T2, T3, T4, T5> value, global::Serde.ISerializer serializer)
         {
             var _l_info = global::Serde.SerdeInfoProvider.GetInfo(this);
-            var _l_type = serializer.WriteType(_l_info);
+            var _l_fieldCount = 5;
+            if (value.FS is null) _l_fieldCount--;
+            if (value.F2 is null) _l_fieldCount--;
+            if (value.F3 is null) _l_fieldCount--;
+            if (value.F4 is null) _l_fieldCount--;
+            var _l_type = serializer.WriteType(_l_info, _l_fieldCount);
             _l_type.WriteStringIfNotNull(_l_info, 0, value.FS);
             _l_type.WriteValue<T1, T1>(_l_info, 1, value.F1);
             _l_type.WriteValueIfNotNull<T2, T2>(_l_info, 2, value.F2);

--- a/test/Serde.Generation.Test/test_output/SerializeTests/Rgb#Rgb.ISerialize.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/SerializeTests/Rgb#Rgb.ISerialize.g.verified.cs
@@ -13,7 +13,7 @@ partial struct Rgb
         void global::Serde.ISerialize<Rgb>.Serialize(Rgb value, global::Serde.ISerializer serializer)
         {
             var _l_info = global::Serde.SerdeInfoProvider.GetInfo(this);
-            var _l_type = serializer.WriteType(_l_info);
+            var _l_type = serializer.WriteType(_l_info, 3);
             _l_type.WriteU8(_l_info, 0, value.Red);
             _l_type.WriteU8(_l_info, 1, value.Green);
             _l_type.WriteU8(_l_info, 2, value.Blue);

--- a/test/Serde.Generation.Test/test_output/SerializeTests/TypeDoesntImplementISerialize#S1.ISerialize.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/SerializeTests/TypeDoesntImplementISerialize#S1.ISerialize.g.verified.cs
@@ -13,7 +13,7 @@ partial struct S1
         void global::Serde.ISerialize<S1>.Serialize(S1 value, global::Serde.ISerializer serializer)
         {
             var _l_info = global::Serde.SerdeInfoProvider.GetInfo(this);
-            var _l_type = serializer.WriteType(_l_info, 0);
+            var _l_type = serializer.WriteType(_l_info, 1);
             _l_type.End(_l_info);
         }
 

--- a/test/Serde.Generation.Test/test_output/SerializeTests/TypeDoesntImplementISerialize#S1.ISerialize.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/SerializeTests/TypeDoesntImplementISerialize#S1.ISerialize.g.verified.cs
@@ -13,7 +13,7 @@ partial struct S1
         void global::Serde.ISerialize<S1>.Serialize(S1 value, global::Serde.ISerializer serializer)
         {
             var _l_info = global::Serde.SerdeInfoProvider.GetInfo(this);
-            var _l_type = serializer.WriteType(_l_info);
+            var _l_type = serializer.WriteType(_l_info, 0);
             _l_type.End(_l_info);
         }
 

--- a/test/Serde.Generation.Test/test_output/SerializeTests/TypeWithArray#C.ISerialize.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/SerializeTests/TypeWithArray#C.ISerialize.g.verified.cs
@@ -13,7 +13,7 @@ partial class C
         void global::Serde.ISerialize<C>.Serialize(C value, global::Serde.ISerializer serializer)
         {
             var _l_info = global::Serde.SerdeInfoProvider.GetInfo(this);
-            var _l_type = serializer.WriteType(_l_info);
+            var _l_type = serializer.WriteType(_l_info, 1);
             _l_type.WriteValue<int[], Serde.ArrayProxy.Ser<int, global::Serde.I32Proxy>>(_l_info, 0, value.IntArr);
             _l_type.End(_l_info);
         }

--- a/test/Serde.Generation.Test/test_output/SerializeTests/WrongGenericWrapperForm#C.ISerialize.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/SerializeTests/WrongGenericWrapperForm#C.ISerialize.g.verified.cs
@@ -13,7 +13,7 @@ partial class C
         void global::Serde.ISerialize<C>.Serialize(C value, global::Serde.ISerializer serializer)
         {
             var _l_info = global::Serde.SerdeInfoProvider.GetInfo(this);
-            var _l_type = serializer.WriteType(_l_info);
+            var _l_type = serializer.WriteType(_l_info, 0);
             _l_type.End(_l_info);
         }
 

--- a/test/Serde.Generation.Test/test_output/SerializeTests/WrongGenericWrapperForm#C.ISerialize.g.verified.cs
+++ b/test/Serde.Generation.Test/test_output/SerializeTests/WrongGenericWrapperForm#C.ISerialize.g.verified.cs
@@ -13,7 +13,7 @@ partial class C
         void global::Serde.ISerialize<C>.Serialize(C value, global::Serde.ISerializer serializer)
         {
             var _l_info = global::Serde.SerdeInfoProvider.GetInfo(this);
-            var _l_type = serializer.WriteType(_l_info, 0);
+            var _l_type = serializer.WriteType(_l_info, 1);
             _l_type.End(_l_info);
         }
 

--- a/test/Serde.Test/JsonSerializerTests.cs
+++ b/test/Serde.Test/JsonSerializerTests.cs
@@ -605,5 +605,164 @@ namespace Serde.Test
                 Encoding.UTF8.GetString(mem.Span)
             );
         }
+
+        [GenerateSerialize]
+        private partial record ContactGen(int Id, string? Name, string? Email);
+
+        [Theory]
+        // Id is required; Name and Email are skipped when null, so the field count passed to
+        // WriteType by the generated code must reflect only the fields actually written.
+        [InlineData("Alice", "alice@example.com", 3)]
+        [InlineData(null, "bob@example.com", 2)]
+        [InlineData("Carol", null, 2)]
+        [InlineData(null, null, 1)]
+        public void GeneratedWriteTypeReceivesPostSkipFieldCount(
+            string? name,
+            string? email,
+            int expectedFieldCount
+        )
+        {
+            var recorder = new FieldCountRecordingSerializer();
+            Serde.SerializeProvider.GetSerialize<ContactGen>()
+                .Serialize(new ContactGen(1, name, email), recorder);
+            Assert.Equal(expectedFieldCount, recorder.FieldCount);
+        }
+
+        /// <summary>
+        /// A minimal <see cref="ISerializer"/>/<see cref="ITypeSerializer"/> that records the field
+        /// count passed to <see cref="ISerializer.WriteType(ISerdeInfo, int)"/>. All other members
+        /// are no-ops. Used to assert that generated code computes the correct post-skip count.
+        /// </summary>
+        private sealed class FieldCountRecordingSerializer : ISerializer, ITypeSerializer
+        {
+            public int? FieldCount { get; private set; }
+
+            ITypeSerializer ISerializer.WriteType(ISerdeInfo info, int fieldCount)
+            {
+                FieldCount = fieldCount;
+                return this;
+            }
+
+            ITypeSerializer ISerializer.WriteType(ISerdeInfo info) => this;
+
+            ITypeSerializer ISerializer.WriteCollection(ISerdeInfo info, int? count) => this;
+
+            // --- ISerializer no-op members ---
+            void ISerializer.WriteBool(bool b) { }
+
+            void ISerializer.WriteChar(char c) { }
+
+            void ISerializer.WriteU8(byte b) { }
+
+            void ISerializer.WriteU16(ushort u16) { }
+
+            void ISerializer.WriteU32(uint u32) { }
+
+            void ISerializer.WriteU64(ulong u64) { }
+
+            void ISerializer.WriteU128(System.UInt128 u128) { }
+
+            void ISerializer.WriteI8(sbyte b) { }
+
+            void ISerializer.WriteI16(short i16) { }
+
+            void ISerializer.WriteI32(int i32) { }
+
+            void ISerializer.WriteI64(long i64) { }
+
+            void ISerializer.WriteI128(System.Int128 i128) { }
+
+            void ISerializer.WriteF32(float f) { }
+
+            void ISerializer.WriteF64(double d) { }
+
+            void ISerializer.WriteDecimal(decimal d) { }
+
+            void ISerializer.WriteString(string s) { }
+
+            void ISerializer.WriteNull() { }
+
+            void ISerializer.WriteDateTime(System.DateTime dt) { }
+
+            void ISerializer.WriteDateTimeOffset(System.DateTimeOffset dt) { }
+
+            void ISerializer.WriteBytes(System.ReadOnlyMemory<byte> bytes) { }
+
+            void ISerializer.WriteEnum(ISerdeInfo info, int ordinal) { }
+
+            // --- ITypeSerializer members ---
+            ISerializer ITypeSerializer.WriteFieldStart(ISerdeInfo typeInfo, int index) => this;
+
+            void ITypeSerializer.WriteFieldEnd(
+                ISerdeInfo typeInfo,
+                int index,
+                ISerializer serializer
+            ) { }
+
+            void ITypeSerializer.WriteBool(ISerdeInfo typeInfo, int index, bool b) { }
+
+            void ITypeSerializer.WriteChar(ISerdeInfo typeInfo, int index, char c) { }
+
+            void ITypeSerializer.WriteU8(ISerdeInfo typeInfo, int index, byte b) { }
+
+            void ITypeSerializer.WriteU16(ISerdeInfo typeInfo, int index, ushort u16) { }
+
+            void ITypeSerializer.WriteU32(ISerdeInfo typeInfo, int index, uint u32) { }
+
+            void ITypeSerializer.WriteU64(ISerdeInfo typeInfo, int index, ulong u64) { }
+
+            void ITypeSerializer.WriteU128(ISerdeInfo typeInfo, int index, System.UInt128 u128) { }
+
+            void ITypeSerializer.WriteI8(ISerdeInfo typeInfo, int index, sbyte b) { }
+
+            void ITypeSerializer.WriteI16(ISerdeInfo typeInfo, int index, short i16) { }
+
+            void ITypeSerializer.WriteI32(ISerdeInfo typeInfo, int index, int i32) { }
+
+            void ITypeSerializer.WriteI64(ISerdeInfo typeInfo, int index, long i64) { }
+
+            void ITypeSerializer.WriteI128(ISerdeInfo typeInfo, int index, System.Int128 i128) { }
+
+            void ITypeSerializer.WriteF32(ISerdeInfo typeInfo, int index, float f) { }
+
+            void ITypeSerializer.WriteF64(ISerdeInfo typeInfo, int index, double d) { }
+
+            void ITypeSerializer.WriteDecimal(ISerdeInfo typeInfo, int index, decimal d) { }
+
+            void ITypeSerializer.WriteString(ISerdeInfo typeInfo, int index, string s) { }
+
+            void ITypeSerializer.WriteNull(ISerdeInfo typeInfo, int index) { }
+
+            void ITypeSerializer.WriteDateTime(ISerdeInfo typeInfo, int index, System.DateTime dt)
+            { }
+
+            void ITypeSerializer.WriteDateTimeOffset(
+                ISerdeInfo typeInfo,
+                int index,
+                System.DateTimeOffset dt
+            ) { }
+
+            void ITypeSerializer.WriteBytes(
+                ISerdeInfo typeInfo,
+                int index,
+                System.ReadOnlyMemory<byte> bytes
+            ) { }
+
+            void ITypeSerializer.WriteEnum(
+                ISerdeInfo typeInfo,
+                int index,
+                ISerdeInfo fieldInfo,
+                int ordinal
+            ) { }
+
+            void ITypeSerializer.WriteValue<T>(
+                ISerdeInfo typeInfo,
+                int index,
+                T value,
+                ISerialize<T> serialize
+            ) { }
+
+            void ITypeSerializer.End(ISerdeInfo info) { }
+        }
     }
 }

--- a/test/Serde.Test/JsonSerializerTests.cs
+++ b/test/Serde.Test/JsonSerializerTests.cs
@@ -623,7 +623,8 @@ namespace Serde.Test
         )
         {
             var recorder = new FieldCountRecordingSerializer();
-            Serde.SerializeProvider.GetSerialize<ContactGen>()
+            Serde
+                .SerializeProvider.GetSerialize<ContactGen>()
                 .Serialize(new ContactGen(1, name, email), recorder);
             Assert.Equal(expectedFieldCount, recorder.FieldCount);
         }
@@ -733,8 +734,11 @@ namespace Serde.Test
 
             void ITypeSerializer.WriteNull(ISerdeInfo typeInfo, int index) { }
 
-            void ITypeSerializer.WriteDateTime(ISerdeInfo typeInfo, int index, System.DateTime dt)
-            { }
+            void ITypeSerializer.WriteDateTime(
+                ISerdeInfo typeInfo,
+                int index,
+                System.DateTime dt
+            ) { }
 
             void ITypeSerializer.WriteDateTimeOffset(
                 ISerdeInfo typeInfo,

--- a/test/Serde.Test/JsonSerializerTests.cs
+++ b/test/Serde.Test/JsonSerializerTests.cs
@@ -457,6 +457,104 @@ namespace Serde.Test
             );
         }
 
+        // A hand-written serializer that exercises the new WriteType(ISerdeInfo, int fieldCount)
+        // overload together with the "IfNotNull" helpers that skip null fields. The field count
+        // passed to WriteType reflects the number of fields that are actually written (i.e. the
+        // total after nulls are skipped), which is what count-prefixed formats require.
+        private sealed record ContactManual(int Id, string? Name, string? Email)
+            : ISerializeProvider<ContactManual>
+        {
+            static ISerialize<ContactManual> ISerializeProvider<ContactManual>.Instance =>
+                _Serialize.Instance;
+
+            private static readonly ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
+                "ContactManual",
+                System.Array.Empty<CustomAttributeData>(),
+                [
+                    new Serde.SerdeInfo.FieldInfo("id", I32Proxy.SerdeInfo),
+                    new Serde.SerdeInfo.FieldInfo("name", StringProxy.SerdeInfo),
+                    new Serde.SerdeInfo.FieldInfo("email", StringProxy.SerdeInfo),
+                ]
+            );
+
+            private sealed class _Serialize : ISerialize<ContactManual>
+            {
+                public static readonly _Serialize Instance = new();
+
+                public ISerdeInfo SerdeInfo => ContactManual.s_serdeInfo;
+
+                public void Serialize(ContactManual value, ISerializer serializer)
+                {
+                    var info = this.SerdeInfo;
+                    // Count only the fields that will actually be written so that formats which
+                    // need the field count up front receive the post-skip total.
+                    var fieldCount =
+                        1 + (value.Name is null ? 0 : 1) + (value.Email is null ? 0 : 1);
+                    var type = serializer.WriteType(info, fieldCount);
+                    type.WriteI32(info, 0, value.Id);
+                    type.WriteStringIfNotNull(info, 1, value.Name);
+                    type.WriteStringIfNotNull(info, 2, value.Email);
+                    type.End(info);
+                }
+            }
+        }
+
+        [Fact]
+        public void WriteTypeWithFieldCountSkipsNullFields()
+        {
+            Assert.Equal(
+                """{"id":1,"name":"Alice","email":"alice@example.com"}""",
+                Serde.Json.JsonSerializer.Serialize(
+                    new ContactManual(1, "Alice", "alice@example.com")
+                )
+            );
+
+            // A null field is skipped by WriteStringIfNotNull; the remaining fields still serialize.
+            Assert.Equal(
+                """{"id":2,"email":"bob@example.com"}""",
+                Serde.Json.JsonSerializer.Serialize(new ContactManual(2, null, "bob@example.com"))
+            );
+
+            Assert.Equal(
+                """{"id":3,"name":"Carol"}""",
+                Serde.Json.JsonSerializer.Serialize(new ContactManual(3, "Carol", null))
+            );
+
+            // When every optional field is null, only the required field remains.
+            Assert.Equal(
+                """{"id":4}""",
+                Serde.Json.JsonSerializer.Serialize(new ContactManual(4, null, null))
+            );
+        }
+
+        // Passes a deliberately inaccurate field count to WriteType to confirm that the JSON
+        // serializer's default implementation ignores the count (JSON objects are structurally
+        // delimited and do not need it) and produces the same output regardless.
+        private sealed class WrongCountSerialize : ISerialize<ContactManual>
+        {
+            public ISerdeInfo SerdeInfo => SerdeInfoProvider.GetSerializeInfo<ContactManual>();
+
+            public void Serialize(ContactManual value, ISerializer serializer)
+            {
+                var info = this.SerdeInfo;
+                var type = serializer.WriteType(info, 0);
+                type.WriteI32(info, 0, value.Id);
+                type.WriteString(info, 1, value.Name!);
+                type.WriteString(info, 2, value.Email!);
+                type.End(info);
+            }
+        }
+
+        [Fact]
+        public void WriteTypeFieldCountIgnoredForJson()
+        {
+            var value = new ContactManual(7, "Carol", "carol@example.com");
+            Assert.Equal(
+                """{"id":7,"name":"Carol","email":"carol@example.com"}""",
+                Serde.Json.JsonSerializer.Serialize(value, new WrongCountSerialize())
+            );
+        }
+
         [GenerateSerialize]
         private partial record BigData(List<int> Values);
 

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Json.Test.Test.ISerde.g.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Json.Test.Test.ISerde.g.cs
@@ -15,7 +15,7 @@ partial class Test
         void global::Serde.ISerialize<Serde.Json.Test.Test>.Serialize(Serde.Json.Test.Test value, global::Serde.ISerializer serializer)
         {
             var _l_info = global::Serde.SerdeInfoProvider.GetInfo(this);
-            var _l_type = serializer.WriteType(_l_info);
+            var _l_type = serializer.WriteType(_l_info, 4);
             _l_type.WriteValue<System.Numerics.Vector2, Serde.Json.Test.Vector2Proxy>(_l_info, 0, value.v2);
             _l_type.WriteValue<System.Numerics.Vector2[][], Serde.ArrayProxy.Ser<System.Numerics.Vector2[], Serde.ArrayProxy.Ser<System.Numerics.Vector2, Serde.Json.Test.Vector2Proxy>>>(_l_info, 1, value.vertices);
             _l_type.WriteValue<System.Numerics.Vector2[][], Serde.ArrayProxy.Ser<System.Numerics.Vector2[], Serde.ArrayProxy.Ser<System.Numerics.Vector2, Serde.Json.Test.Vector2Proxy2>>>(_l_info, 2, value.weights);

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Json.Test.Vector2Proxy.ISerde.g.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Json.Test.Vector2Proxy.ISerde.g.cs
@@ -15,7 +15,7 @@ partial class Vector2Proxy
         void global::Serde.ISerialize<System.Numerics.Vector2>.Serialize(System.Numerics.Vector2 value, global::Serde.ISerializer serializer)
         {
             var _l_info = global::Serde.SerdeInfoProvider.GetInfo(this);
-            var _l_type = serializer.WriteType(_l_info);
+            var _l_type = serializer.WriteType(_l_info, 2);
             _l_type.WriteF32(_l_info, 0, value.X);
             _l_type.WriteF32(_l_info, 1, value.Y);
             _l_type.End(_l_info);

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Json.Test.Vector2Proxy2.ISerde.g.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Json.Test.Vector2Proxy2.ISerde.g.cs
@@ -15,7 +15,7 @@ partial class Vector2Proxy2
         void global::Serde.ISerialize<System.Numerics.Vector2>.Serialize(System.Numerics.Vector2 value, global::Serde.ISerializer serializer)
         {
             var _l_info = global::Serde.SerdeInfoProvider.GetInfo(this);
-            var _l_type = serializer.WriteType(_l_info);
+            var _l_type = serializer.WriteType(_l_info, 2);
             _l_type.WriteF32(_l_info, 0, value.X);
             _l_type.WriteF32(_l_info, 1, value.Y);
             _l_type.End(_l_info);

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Json.Test.Vector3Proxy.ISerde.g.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Json.Test.Vector3Proxy.ISerde.g.cs
@@ -15,7 +15,7 @@ partial class Vector3Proxy
         void global::Serde.ISerialize<System.Numerics.Vector3>.Serialize(System.Numerics.Vector3 value, global::Serde.ISerializer serializer)
         {
             var _l_info = global::Serde.SerdeInfoProvider.GetInfo(this);
-            var _l_type = serializer.WriteType(_l_info);
+            var _l_type = serializer.WriteType(_l_info, 3);
             _l_type.WriteF32(_l_info, 0, value.X);
             _l_type.WriteF32(_l_info, 1, value.Y);
             _l_type.WriteF32(_l_info, 2, value.Z);

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Json.Test.Vector4Proxy.ISerde.g.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Json.Test.Vector4Proxy.ISerde.g.cs
@@ -15,7 +15,7 @@ partial class Vector4Proxy
         void global::Serde.ISerialize<System.Numerics.Vector4>.Serialize(System.Numerics.Vector4 value, global::Serde.ISerializer serializer)
         {
             var _l_info = global::Serde.SerdeInfoProvider.GetInfo(this);
-            var _l_type = serializer.WriteType(_l_info);
+            var _l_type = serializer.WriteType(_l_info, 4);
             _l_type.WriteF32(_l_info, 0, value.X);
             _l_type.WriteF32(_l_info, 1, value.Y);
             _l_type.WriteF32(_l_info, 2, value.Z);

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.AllInOne.ISerialize.g.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.AllInOne.ISerialize.g.cs
@@ -15,7 +15,10 @@ partial record AllInOne
         void global::Serde.ISerialize<Serde.Test.AllInOne>.Serialize(Serde.Test.AllInOne value, global::Serde.ISerializer serializer)
         {
             var _l_info = global::Serde.SerdeInfoProvider.GetInfo(this);
-            var _l_type = serializer.WriteType(_l_info);
+            var _l_fieldCount = 26;
+            if (value.NullStringField is null) _l_fieldCount--;
+            if (value.NullIntField is null) _l_fieldCount--;
+            var _l_type = serializer.WriteType(_l_info, _l_fieldCount);
             _l_type.WriteBool(_l_info, 0, value.BoolField);
             _l_type.WriteChar(_l_info, 1, value.CharField);
             _l_type.WriteU8(_l_info, 2, value.ByteField);

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.AsTests.Point.ISerde.g.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.AsTests.Point.ISerde.g.cs
@@ -17,7 +17,7 @@ partial class AsTests
             void global::Serde.ISerialize<Serde.Test.AsTests.Point>.Serialize(Serde.Test.AsTests.Point value, global::Serde.ISerializer serializer)
             {
                 var _l_info = global::Serde.SerdeInfoProvider.GetInfo(this);
-                var _l_type = serializer.WriteType(_l_info);
+                var _l_type = serializer.WriteType(_l_info, 2);
                 _l_type.WriteI32(_l_info, 0, value.X);
                 _l_type.WriteI32(_l_info, 1, value.Y);
                 _l_type.End(_l_info);

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.CustomImplTests.RgbWithFieldMap.ISerialize.g.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.CustomImplTests.RgbWithFieldMap.ISerialize.g.cs
@@ -17,7 +17,7 @@ partial class CustomImplTests
             void global::Serde.ISerialize<Serde.Test.CustomImplTests.RgbWithFieldMap>.Serialize(Serde.Test.CustomImplTests.RgbWithFieldMap value, global::Serde.ISerializer serializer)
             {
                 var _l_info = global::Serde.SerdeInfoProvider.GetInfo(this);
-                var _l_type = serializer.WriteType(_l_info);
+                var _l_type = serializer.WriteType(_l_info, 3);
                 _l_type.WriteI32(_l_info, 0, value.Red);
                 _l_type.WriteI32(_l_info, 1, value.Green);
                 _l_type.WriteI32(_l_info, 2, value.Blue);

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.GenericWrapperTests.CustomArrayWrapExplicitOnType.ISerde.g.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.GenericWrapperTests.CustomArrayWrapExplicitOnType.ISerde.g.cs
@@ -17,7 +17,7 @@ partial class GenericWrapperTests
             void global::Serde.ISerialize<Serde.Test.GenericWrapperTests.CustomArrayWrapExplicitOnType>.Serialize(Serde.Test.GenericWrapperTests.CustomArrayWrapExplicitOnType value, global::Serde.ISerializer serializer)
             {
                 var _l_info = global::Serde.SerdeInfoProvider.GetInfo(this);
-                var _l_type = serializer.WriteType(_l_info);
+                var _l_type = serializer.WriteType(_l_info, 1);
                 _l_type.WriteValue<Serde.Test.GenericWrapperTests.CustomImArray2<int>, Serde.Test.GenericWrapperTests.CustomImArray2Proxy.Ser<int, global::Serde.I32Proxy>>(_l_info, 0, value.A);
                 _l_type.End(_l_info);
             }

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.GenericWrapperTests.CustomImArrayExplicitWrapOnMember.ISerde.g.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.GenericWrapperTests.CustomImArrayExplicitWrapOnMember.ISerde.g.cs
@@ -17,7 +17,7 @@ partial class GenericWrapperTests
             void global::Serde.ISerialize<Serde.Test.GenericWrapperTests.CustomImArrayExplicitWrapOnMember>.Serialize(Serde.Test.GenericWrapperTests.CustomImArrayExplicitWrapOnMember value, global::Serde.ISerializer serializer)
             {
                 var _l_info = global::Serde.SerdeInfoProvider.GetInfo(this);
-                var _l_type = serializer.WriteType(_l_info);
+                var _l_type = serializer.WriteType(_l_info, 1);
                 _l_type.WriteValue<Serde.Test.GenericWrapperTests.CustomImArray<int>, Serde.Test.GenericWrapperTests.CustomImArrayProxy.Ser<int, global::Serde.I32Proxy>>(_l_info, 0, value.A);
                 _l_type.End(_l_info);
             }

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonSerializerTests.BasicDU.ISerialize.g.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonSerializerTests.BasicDU.ISerialize.g.cs
@@ -17,7 +17,7 @@ partial class JsonSerializerTests
             void ISerialize<Serde.Test.JsonSerializerTests.BasicDU>.Serialize(Serde.Test.JsonSerializerTests.BasicDU value, ISerializer serializer)
             {
                 var _l_serdeInfo = global::Serde.SerdeInfoProvider.GetInfo(this);
-                var _l_type = serializer.WriteType(_l_serdeInfo);
+                var _l_type = serializer.WriteType(_l_serdeInfo, 1);
                 switch (value)
                 {
                     case Serde.Test.JsonSerializerTests.BasicDU.A c:

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonSerializerTests.BasicDU._m_AProxy.ISerialize.g.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonSerializerTests.BasicDU._m_AProxy.ISerialize.g.cs
@@ -19,7 +19,7 @@ partial class JsonSerializerTests
                 void global::Serde.ISerialize<Serde.Test.JsonSerializerTests.BasicDU.A>.Serialize(Serde.Test.JsonSerializerTests.BasicDU.A value, global::Serde.ISerializer serializer)
                 {
                     var _l_info = global::Serde.SerdeInfoProvider.GetInfo(this);
-                    var _l_type = serializer.WriteType(_l_info);
+                    var _l_type = serializer.WriteType(_l_info, 1);
                     _l_type.WriteI32(_l_info, 0, value.X);
                     _l_type.End(_l_info);
                 }

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonSerializerTests.BasicDU._m_BProxy.ISerialize.g.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonSerializerTests.BasicDU._m_BProxy.ISerialize.g.cs
@@ -19,7 +19,7 @@ partial class JsonSerializerTests
                 void global::Serde.ISerialize<Serde.Test.JsonSerializerTests.BasicDU.B>.Serialize(Serde.Test.JsonSerializerTests.BasicDU.B value, global::Serde.ISerializer serializer)
                 {
                     var _l_info = global::Serde.SerdeInfoProvider.GetInfo(this);
-                    var _l_type = serializer.WriteType(_l_info);
+                    var _l_type = serializer.WriteType(_l_info, 1);
                     _l_type.WriteString(_l_info, 0, value.Y);
                     _l_type.End(_l_info);
                 }

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonSerializerTests.BigData.ISerialize.g.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonSerializerTests.BigData.ISerialize.g.cs
@@ -17,7 +17,7 @@ partial class JsonSerializerTests
             void global::Serde.ISerialize<Serde.Test.JsonSerializerTests.BigData>.Serialize(Serde.Test.JsonSerializerTests.BigData value, global::Serde.ISerializer serializer)
             {
                 var _l_info = global::Serde.SerdeInfoProvider.GetInfo(this);
-                var _l_type = serializer.WriteType(_l_info);
+                var _l_type = serializer.WriteType(_l_info, 1);
                 _l_type.WriteValue<System.Collections.Generic.List<int>, Serde.ListProxy.Ser<int, global::Serde.I32Proxy>>(_l_info, 0, value.Values);
                 _l_type.End(_l_info);
             }

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonSerializerTests.Color.ISerialize.g.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonSerializerTests.Color.ISerialize.g.cs
@@ -17,7 +17,7 @@ partial class JsonSerializerTests
             void global::Serde.ISerialize<Serde.Test.JsonSerializerTests.Color>.Serialize(Serde.Test.JsonSerializerTests.Color value, global::Serde.ISerializer serializer)
             {
                 var _l_info = global::Serde.SerdeInfoProvider.GetInfo(this);
-                var _l_type = serializer.WriteType(_l_info);
+                var _l_type = serializer.WriteType(_l_info, 3);
                 _l_type.WriteI32(_l_info, 0, value.Red);
                 _l_type.WriteI32(_l_info, 1, value.Green);
                 _l_type.WriteI32(_l_info, 2, value.Blue);

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonSerializerTests.ContactGen.ISerdeInfoProvider.g.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonSerializerTests.ContactGen.ISerdeInfoProvider.g.cs
@@ -1,0 +1,20 @@
+
+#nullable enable
+
+namespace Serde.Test;
+
+partial class JsonSerializerTests
+{
+    partial record ContactGen
+    {
+        private static global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
+            "ContactGen",
+            typeof(Serde.Test.JsonSerializerTests.ContactGen).GetCustomAttributesData(),
+            new global::Serde.SerdeInfo.FieldInfo[] {
+                new("id", global::Serde.SerdeInfoProvider.GetSerializeInfo<int, global::Serde.I32Proxy>()),
+                new("name", global::Serde.SerdeInfoProvider.GetSerializeInfo<string?, Serde.NullableRefProxy.Ser<string, global::Serde.StringProxy>>()),
+                new("email", global::Serde.SerdeInfoProvider.GetSerializeInfo<string?, Serde.NullableRefProxy.Ser<string, global::Serde.StringProxy>>())
+            }
+        );
+    }
+}

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonSerializerTests.ContactGen.ISerialize.g.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonSerializerTests.ContactGen.ISerialize.g.cs
@@ -1,0 +1,32 @@
+
+#nullable enable
+
+using System;
+using Serde;
+
+namespace Serde.Test;
+
+partial class JsonSerializerTests
+{
+    partial record ContactGen
+    {
+        sealed partial class _SerObj : Serde.ISerialize<Serde.Test.JsonSerializerTests.ContactGen>
+        {
+            global::Serde.ISerdeInfo global::Serde.ISerdeInfoProvider.SerdeInfo => Serde.Test.JsonSerializerTests.ContactGen.s_serdeInfo;
+
+            void global::Serde.ISerialize<Serde.Test.JsonSerializerTests.ContactGen>.Serialize(Serde.Test.JsonSerializerTests.ContactGen value, global::Serde.ISerializer serializer)
+            {
+                var _l_info = global::Serde.SerdeInfoProvider.GetInfo(this);
+                var _l_fieldCount = 3;
+                if (value.Name is null) _l_fieldCount--;
+                if (value.Email is null) _l_fieldCount--;
+                var _l_type = serializer.WriteType(_l_info, _l_fieldCount);
+                _l_type.WriteI32(_l_info, 0, value.Id);
+                _l_type.WriteStringIfNotNull(_l_info, 1, value.Name);
+                _l_type.WriteStringIfNotNull(_l_info, 2, value.Email);
+                _l_type.End(_l_info);
+            }
+
+        }
+    }
+}

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonSerializerTests.ContactGen.ISerializeProvider.g.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonSerializerTests.ContactGen.ISerializeProvider.g.cs
@@ -1,0 +1,11 @@
+
+namespace Serde.Test;
+
+partial class JsonSerializerTests
+{
+    partial record ContactGen : Serde.ISerializeProvider<Serde.Test.JsonSerializerTests.ContactGen>
+    {
+        static global::Serde.ISerialize<Serde.Test.JsonSerializerTests.ContactGen> global::Serde.ISerializeProvider<Serde.Test.JsonSerializerTests.ContactGen>.Instance { get; }
+            = new Serde.Test.JsonSerializerTests.ContactGen._SerObj();
+    }
+}

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonSerializerTests.DtWrap.ISerialize.g.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonSerializerTests.DtWrap.ISerialize.g.cs
@@ -17,7 +17,7 @@ partial class JsonSerializerTests
             void global::Serde.ISerialize<Serde.Test.JsonSerializerTests.DtWrap>.Serialize(Serde.Test.JsonSerializerTests.DtWrap value, global::Serde.ISerializer serializer)
             {
                 var _l_info = global::Serde.SerdeInfoProvider.GetInfo(this);
-                var _l_type = serializer.WriteType(_l_info);
+                var _l_type = serializer.WriteType(_l_info, 1);
                 _l_type.WriteDateTime(_l_info, 0, value.Value);
                 _l_type.End(_l_info);
             }

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonSerializerTests.DtoWrap.ISerialize.g.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonSerializerTests.DtoWrap.ISerialize.g.cs
@@ -17,7 +17,7 @@ partial class JsonSerializerTests
             void global::Serde.ISerialize<Serde.Test.JsonSerializerTests.DtoWrap>.Serialize(Serde.Test.JsonSerializerTests.DtoWrap value, global::Serde.ISerializer serializer)
             {
                 var _l_info = global::Serde.SerdeInfoProvider.GetInfo(this);
-                var _l_type = serializer.WriteType(_l_info);
+                var _l_type = serializer.WriteType(_l_info, 1);
                 _l_type.WriteDateTimeOffset(_l_info, 0, value.Value);
                 _l_type.End(_l_info);
             }

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonSerializerTests.NullableByteArrayWrap.ISerde.g.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonSerializerTests.NullableByteArrayWrap.ISerde.g.cs
@@ -17,7 +17,9 @@ partial class JsonSerializerTests
             void global::Serde.ISerialize<Serde.Test.JsonSerializerTests.NullableByteArrayWrap>.Serialize(Serde.Test.JsonSerializerTests.NullableByteArrayWrap value, global::Serde.ISerializer serializer)
             {
                 var _l_info = global::Serde.SerdeInfoProvider.GetInfo(this);
-                var _l_type = serializer.WriteType(_l_info);
+                var _l_fieldCount = 1;
+                if (value.Bytes is null) _l_fieldCount--;
+                var _l_type = serializer.WriteType(_l_info, _l_fieldCount);
                 _l_type.WriteValueIfNotNull<byte[], Serde.NullableRefProxy.Ser<byte[], global::Serde.ByteArrayProxy>>(_l_info, 0, value.Bytes);
                 _l_type.End(_l_info);
             }

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonSerializerTests.NullableFields.ISerialize.g.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.JsonSerializerTests.NullableFields.ISerialize.g.cs
@@ -17,7 +17,9 @@ partial class JsonSerializerTests
             void global::Serde.ISerialize<Serde.Test.JsonSerializerTests.NullableFields>.Serialize(Serde.Test.JsonSerializerTests.NullableFields value, global::Serde.ISerializer serializer)
             {
                 var _l_info = global::Serde.SerdeInfoProvider.GetInfo(this);
-                var _l_type = serializer.WriteType(_l_info);
+                var _l_fieldCount = 2;
+                if (value.S is null) _l_fieldCount--;
+                var _l_type = serializer.WriteType(_l_info, _l_fieldCount);
                 _l_type.WriteStringIfNotNull(_l_info, 0, value.S);
                 _l_type.WriteValue<System.Collections.Generic.Dictionary<string, string?>, Serde.DictProxy.Ser<string, string?, global::Serde.StringProxy, Serde.NullableRefProxy.Ser<string, global::Serde.StringProxy>>>(_l_info, 1, value.D);
                 _l_type.End(_l_info);

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.MaxSizeType.ISerde.g.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.MaxSizeType.ISerde.g.cs
@@ -15,7 +15,7 @@ partial struct MaxSizeType
         void global::Serde.ISerialize<Serde.Test.MaxSizeType>.Serialize(Serde.Test.MaxSizeType value, global::Serde.ISerializer serializer)
         {
             var _l_info = global::Serde.SerdeInfoProvider.GetInfo(this);
-            var _l_type = serializer.WriteType(_l_info);
+            var _l_type = serializer.WriteType(_l_info, 64);
             _l_type.WriteU8(_l_info, 0, value.Field1);
             _l_type.WriteU8(_l_info, 1, value.Field2);
             _l_type.WriteU8(_l_info, 2, value.Field3);

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.MemberOrdinalTests.FullyOrdered.ISerde.g.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.MemberOrdinalTests.FullyOrdered.ISerde.g.cs
@@ -17,7 +17,7 @@ partial class MemberOrdinalTests
             void global::Serde.ISerialize<Serde.Test.MemberOrdinalTests.FullyOrdered>.Serialize(Serde.Test.MemberOrdinalTests.FullyOrdered value, global::Serde.ISerializer serializer)
             {
                 var _l_info = global::Serde.SerdeInfoProvider.GetInfo(this);
-                var _l_type = serializer.WriteType(_l_info);
+                var _l_type = serializer.WriteType(_l_info, 4);
                 _l_type.WriteI32(_l_info, 0, value.B);
                 _l_type.WriteI32(_l_info, 1, value.D);
                 _l_type.WriteI32(_l_info, 2, value.C);

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.MemberOrdinalTests.NoOrdinals.ISerde.g.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.MemberOrdinalTests.NoOrdinals.ISerde.g.cs
@@ -17,7 +17,7 @@ partial class MemberOrdinalTests
             void global::Serde.ISerialize<Serde.Test.MemberOrdinalTests.NoOrdinals>.Serialize(Serde.Test.MemberOrdinalTests.NoOrdinals value, global::Serde.ISerializer serializer)
             {
                 var _l_info = global::Serde.SerdeInfoProvider.GetInfo(this);
-                var _l_type = serializer.WriteType(_l_info);
+                var _l_type = serializer.WriteType(_l_info, 2);
                 _l_type.WriteI32(_l_info, 0, value.A);
                 _l_type.WriteI32(_l_info, 1, value.B);
                 _l_type.End(_l_info);

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.MemberOrdinalTests.OrderedWithSkip.ISerde.g.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.MemberOrdinalTests.OrderedWithSkip.ISerde.g.cs
@@ -17,7 +17,7 @@ partial class MemberOrdinalTests
             void global::Serde.ISerialize<Serde.Test.MemberOrdinalTests.OrderedWithSkip>.Serialize(Serde.Test.MemberOrdinalTests.OrderedWithSkip value, global::Serde.ISerializer serializer)
             {
                 var _l_info = global::Serde.SerdeInfoProvider.GetInfo(this);
-                var _l_type = serializer.WriteType(_l_info);
+                var _l_type = serializer.WriteType(_l_info, 2);
                 _l_type.WriteI32(_l_info, 0, value.B);
                 _l_type.WriteI32(_l_info, 1, value.A);
                 _l_type.End(_l_info);

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.MemberOrdinalTests.Reordered.ISerde.g.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.MemberOrdinalTests.Reordered.ISerde.g.cs
@@ -17,7 +17,7 @@ partial class MemberOrdinalTests
             void global::Serde.ISerialize<Serde.Test.MemberOrdinalTests.Reordered>.Serialize(Serde.Test.MemberOrdinalTests.Reordered value, global::Serde.ISerializer serializer)
             {
                 var _l_info = global::Serde.SerdeInfoProvider.GetInfo(this);
-                var _l_type = serializer.WriteType(_l_info);
+                var _l_type = serializer.WriteType(_l_info, 3);
                 _l_type.WriteI32(_l_info, 0, value.B);
                 _l_type.WriteI32(_l_info, 1, value.C);
                 _l_type.WriteI32(_l_info, 2, value.A);

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.MemberOrdinalTests.SparseOrdinals.ISerde.g.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.MemberOrdinalTests.SparseOrdinals.ISerde.g.cs
@@ -17,7 +17,7 @@ partial class MemberOrdinalTests
             void global::Serde.ISerialize<Serde.Test.MemberOrdinalTests.SparseOrdinals>.Serialize(Serde.Test.MemberOrdinalTests.SparseOrdinals value, global::Serde.ISerializer serializer)
             {
                 var _l_info = global::Serde.SerdeInfoProvider.GetInfo(this);
-                var _l_type = serializer.WriteType(_l_info);
+                var _l_type = serializer.WriteType(_l_info, 3);
                 _l_type.WriteI32(_l_info, 0, value.B);
                 _l_type.WriteI32(_l_info, 1, value.C);
                 _l_type.WriteI32(_l_info, 2, value.A);

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.NullableValueTypeTests.EmitNull.ISerde.g.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.NullableValueTypeTests.EmitNull.ISerde.g.cs
@@ -17,7 +17,7 @@ partial class NullableValueTypeTests
             void global::Serde.ISerialize<Serde.Test.NullableValueTypeTests.EmitNull>.Serialize(Serde.Test.NullableValueTypeTests.EmitNull value, global::Serde.ISerializer serializer)
             {
                 var _l_info = global::Serde.SerdeInfoProvider.GetInfo(this);
-                var _l_type = serializer.WriteType(_l_info);
+                var _l_type = serializer.WriteType(_l_info, 1);
                 _l_type.WriteValue<int?, Serde.NullableProxy.Ser<int, global::Serde.I32Proxy>>(_l_info, 0, value.Value);
                 _l_type.End(_l_info);
             }

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.NullableValueTypeTests.OmitByDefault.ISerde.g.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.NullableValueTypeTests.OmitByDefault.ISerde.g.cs
@@ -17,7 +17,9 @@ partial class NullableValueTypeTests
             void global::Serde.ISerialize<Serde.Test.NullableValueTypeTests.OmitByDefault>.Serialize(Serde.Test.NullableValueTypeTests.OmitByDefault value, global::Serde.ISerializer serializer)
             {
                 var _l_info = global::Serde.SerdeInfoProvider.GetInfo(this);
-                var _l_type = serializer.WriteType(_l_info);
+                var _l_fieldCount = 1;
+                if (value.Value is null) _l_fieldCount--;
+                var _l_type = serializer.WriteType(_l_info, _l_fieldCount);
                 _l_type.WriteValueIfNotNull<int, Serde.NullableProxy.Ser<int, global::Serde.I32Proxy>>(_l_info, 0, value.Value);
                 _l_type.End(_l_info);
             }

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.NullableValueTypeTests.Outer.ISerde.g.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.NullableValueTypeTests.Outer.ISerde.g.cs
@@ -17,7 +17,7 @@ partial class NullableValueTypeTests
             void global::Serde.ISerialize<Serde.Test.NullableValueTypeTests.Outer>.Serialize(Serde.Test.NullableValueTypeTests.Outer value, global::Serde.ISerializer serializer)
             {
                 var _l_info = global::Serde.SerdeInfoProvider.GetInfo(this);
-                var _l_type = serializer.WriteType(_l_info);
+                var _l_type = serializer.WriteType(_l_info, 2);
                 _l_type.WriteValue<Serde.Test.NullableValueTypeTests.OmitByDefault, Serde.Test.NullableValueTypeTests.OmitByDefault>(_l_info, 0, value.Inner);
                 _l_type.WriteI32(_l_info, 1, value.Trailing);
                 _l_type.End(_l_info);

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.NullableValueTypeTests.TwoFields.ISerde.g.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.NullableValueTypeTests.TwoFields.ISerde.g.cs
@@ -17,7 +17,10 @@ partial class NullableValueTypeTests
             void global::Serde.ISerialize<Serde.Test.NullableValueTypeTests.TwoFields>.Serialize(Serde.Test.NullableValueTypeTests.TwoFields value, global::Serde.ISerializer serializer)
             {
                 var _l_info = global::Serde.SerdeInfoProvider.GetInfo(this);
-                var _l_type = serializer.WriteType(_l_info);
+                var _l_fieldCount = 2;
+                if (value.First is null) _l_fieldCount--;
+                if (value.Second is null) _l_fieldCount--;
+                var _l_type = serializer.WriteType(_l_info, _l_fieldCount);
                 _l_type.WriteValueIfNotNull<int, Serde.NullableProxy.Ser<int, global::Serde.I32Proxy>>(_l_info, 0, value.First);
                 _l_type.WriteValueIfNotNull<int, Serde.NullableProxy.Ser<int, global::Serde.I32Proxy>>(_l_info, 1, value.Second);
                 _l_type.End(_l_info);

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.RoundtripTests.ForeignPointProxy.ISerde.g.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.RoundtripTests.ForeignPointProxy.ISerde.g.cs
@@ -18,7 +18,7 @@ partial class RoundtripTests
             {
                 var _l_self = (Serde.Test.RoundtripTests.ForeignPointProxy)value;
                 var _l_info = global::Serde.SerdeInfoProvider.GetInfo(this);
-                var _l_type = serializer.WriteType(_l_info);
+                var _l_type = serializer.WriteType(_l_info, 2);
                 _l_type.WriteI32(_l_info, 0, _l_self.X);
                 _l_type.WriteI32(_l_info, 1, _l_self.Y);
                 _l_type.End(_l_info);

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.RoundtripTests.Point.ISerde.g.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.RoundtripTests.Point.ISerde.g.cs
@@ -17,7 +17,7 @@ partial class RoundtripTests
             void global::Serde.ISerialize<Serde.Test.RoundtripTests.Point>.Serialize(Serde.Test.RoundtripTests.Point value, global::Serde.ISerializer serializer)
             {
                 var _l_info = global::Serde.SerdeInfoProvider.GetInfo(this);
-                var _l_type = serializer.WriteType(_l_info);
+                var _l_type = serializer.WriteType(_l_info, 2);
                 _l_type.WriteI32(_l_info, 0, value.X);
                 _l_type.WriteI32(_l_info, 1, value.Y);
                 _l_type.End(_l_info);

--- a/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.TupleTests.TupleHolder.ISerde.g.cs
+++ b/test/Serde.Test/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Test.TupleTests.TupleHolder.ISerde.g.cs
@@ -17,7 +17,7 @@ partial class TupleTests
             void global::Serde.ISerialize<Serde.Test.TupleTests.TupleHolder>.Serialize(Serde.Test.TupleTests.TupleHolder value, global::Serde.ISerializer serializer)
             {
                 var _l_info = global::Serde.SerdeInfoProvider.GetInfo(this);
-                var _l_type = serializer.WriteType(_l_info);
+                var _l_type = serializer.WriteType(_l_info, 3);
                 _l_type.WriteValue<(int, string), Serde.TupleProxy.Ser<int, string, global::Serde.I32Proxy, global::Serde.StringProxy>>(_l_info, 0, value.Pair);
                 _l_type.WriteValue<(int, (string, bool)), Serde.TupleProxy.Ser<int, (string, bool), global::Serde.I32Proxy, Serde.TupleProxy.Ser<string, bool, global::Serde.StringProxy, global::Serde.BoolProxy>>>(_l_info, 1, value.Nested);
                 _l_type.WriteValue<System.Collections.Generic.List<(int, int)>, Serde.ListProxy.Ser<(int, int), Serde.TupleProxy.Ser<int, int, global::Serde.I32Proxy, global::Serde.I32Proxy>>>(_l_info, 2, value.Points);


### PR DESCRIPTION
The current expectation is that types will always have a field count carried on their ISerdeInfo instance.

However, this runs into problems with nullable fields. Nullable fields are not serialized by default when null, so the number of actual fields is lower than the number of reported fields. This causes complications for formats with length-prefixed collections as they have to backpatch the "real" field count after figuring out if the fields were written.

By adding a field count that's calculated at runtime the serializer can specify the real number of fields before type serialization starts.

Right now this method is optional. It will become required in the future, and the existing method with no field count will become deprecated.