### PR TITLE
Add field name overload to ISerdeInfo returning a ReadOnlyMemory

### DIFF
--- a/src/serde/ISerdeInfo.cs
+++ b/src/serde/ISerdeInfo.cs
@@ -44,6 +44,11 @@ public interface ISerdeInfo
     Utf8Span GetFieldName(int index);
 
     /// <summary>
+    /// Get the field name as a UTF8 memory block for the field at the given index. The index must be valid.
+    /// </summary>
+    ReadOnlyMemory<byte> GetFieldNameMem(int index);
+
+    /// <summary>
     /// Get the attributes for the field at the given index. The index must be valid. This list may be
     /// modified from the original set of attributes in source code or metadata to reflect only the
     /// attributes that are relevant to serialization or deserialization.

--- a/src/serde/PublicApi.cssig
+++ b/src/serde/PublicApi.cssig
@@ -410,6 +410,7 @@ namespace Serde
         Serde.PrimitiveKind? PrimitiveKind { get; }
         System.Collections.Generic.IList<System.Reflection.CustomAttributeData> Attributes { get; }
         System.Collections.Generic.IList<System.Reflection.CustomAttributeData> GetFieldAttributes(int index);
+        System.ReadOnlyMemory<byte> GetFieldNameMem(int index);
         System.ReadOnlySpan<byte> GetFieldName(int index);
         bool HasExplicitFieldOrdinals { get; }
         int FieldCount { get; }

--- a/src/serde/SerdeInfo.cs
+++ b/src/serde/SerdeInfo.cs
@@ -259,7 +259,9 @@ public static class SerdeInfo
 
         public IList<CustomAttributeData> Attributes => [];
 
-        public Utf8Span GetFieldName(int index) =>
+        public Utf8Span GetFieldName(int index) => GetFieldNameMem(index).Span;
+
+        public ReadOnlyMemory<byte> GetFieldNameMem(int index) =>
             index >= 0 && index < TypeArgInfos.Length
                 ? ISerdeInfo.UTF8Encoding.GetBytes(TypeArgInfos[index].Name)
                 : throw GetOOR(index);
@@ -307,7 +309,11 @@ file sealed record NullableSerdeInfo(ISerdeInfo UnderlyingInfo) : ISerdeInfo
 
     public IList<CustomAttributeData> Attributes => [];
 
-    public Utf8Span GetFieldName(int index) => index == 0 ? "Value"u8 : throw GetOOR(index);
+    public Utf8Span GetFieldName(int index) => GetFieldNameMem(index).Span;
+
+    private static readonly ReadOnlyMemory<byte> _valueUtf8Name = "Value"u8.ToArray();
+
+    public ReadOnlyMemory<byte> GetFieldNameMem(int index) => index == 0 ? _valueUtf8Name : throw GetOOR(index);
 
     public string GetFieldStringName(int index) => index == 0 ? "Value" : throw GetOOR(index);
 
@@ -336,6 +342,8 @@ file sealed class WrappingInfo(ISerdeInfo underlying, string name) : ISerdeInfo
 
     public Utf8Span GetFieldName(int index) => underlying.GetFieldName(index);
 
+    public ReadOnlyMemory<byte> GetFieldNameMem(int index) => underlying.GetFieldNameMem(index);
+
     public string GetFieldStringName(int index) => underlying.GetFieldStringName(index);
 
     public IList<CustomAttributeData> GetFieldAttributes(int index) =>
@@ -358,6 +366,7 @@ file interface INoFieldsInfo : ISerdeInfo
     int ISerdeInfo.FieldCount => 0;
 
     Utf8Span ISerdeInfo.GetFieldName(int index) => throw GetOOR(index);
+    ReadOnlyMemory<byte> ISerdeInfo.GetFieldNameMem(int index) => throw GetOOR(index);
     string ISerdeInfo.GetFieldStringName(int index) => throw GetOOR(index);
     IList<CustomAttributeData> ISerdeInfo.GetFieldAttributes(int index) => throw GetOOR(index);
 
@@ -518,9 +527,11 @@ file sealed record TypeWithFieldsInfo : ISerdeInfo
         return _indexToInfo[index].CustomAttributesData;
     }
 
-    public Utf8Span GetFieldName(int index)
+    public Utf8Span GetFieldName(int index) => GetFieldNameMem(index).Span;
+
+    public ReadOnlyMemory<byte> GetFieldNameMem(int index)
     {
-        return _indexToInfo[index].Utf8Name.Span;
+        return _indexToInfo[index].Utf8Name;
     }
 
     public string GetFieldStringName(int index)
@@ -598,8 +609,9 @@ file sealed class UnionSerdeInfo(
     /// <summary>
     /// The field name for a union is the name of the case.
     /// </summary>
-    public Utf8Span GetFieldName(int index) =>
-        ISerdeInfo.UTF8Encoding.GetBytes(GetFieldStringName(index));
+    public Utf8Span GetFieldName(int index) => GetFieldNameMem(index).Span;
+
+    public ReadOnlyMemory<byte> GetFieldNameMem(int index) => ISerdeInfo.UTF8Encoding.GetBytes(GetFieldStringName(index));
 
     public string GetFieldStringName(int index) => caseInfos[index].Name;
 

--- a/src/serde/SerdeInfo.cs
+++ b/src/serde/SerdeInfo.cs
@@ -313,7 +313,8 @@ file sealed record NullableSerdeInfo(ISerdeInfo UnderlyingInfo) : ISerdeInfo
 
     private static readonly ReadOnlyMemory<byte> _valueUtf8Name = "Value"u8.ToArray();
 
-    public ReadOnlyMemory<byte> GetFieldNameMem(int index) => index == 0 ? _valueUtf8Name : throw GetOOR(index);
+    public ReadOnlyMemory<byte> GetFieldNameMem(int index) =>
+        index == 0 ? _valueUtf8Name : throw GetOOR(index);
 
     public string GetFieldStringName(int index) => index == 0 ? "Value" : throw GetOOR(index);
 
@@ -611,7 +612,8 @@ file sealed class UnionSerdeInfo(
     /// </summary>
     public Utf8Span GetFieldName(int index) => GetFieldNameMem(index).Span;
 
-    public ReadOnlyMemory<byte> GetFieldNameMem(int index) => ISerdeInfo.UTF8Encoding.GetBytes(GetFieldStringName(index));
+    public ReadOnlyMemory<byte> GetFieldNameMem(int index) =>
+        ISerdeInfo.UTF8Encoding.GetBytes(GetFieldStringName(index));
 
     public string GetFieldStringName(int index) => caseInfos[index].Name;
 

--- a/src/serde/json/JsonValue.cs
+++ b/src/serde/json/JsonValue.cs
@@ -88,6 +88,8 @@ namespace Serde.Json
 
             public Utf8Span GetFieldName(int index) => throw GetOOR(index);
 
+            public ReadOnlyMemory<byte> GetFieldNameMem(int index) => throw GetOOR(index);
+
             public string GetFieldStringName(int index) => throw GetOOR(index);
 
             public int TryGetIndex(Utf8Span fieldName) => ITypeDeserializer.IndexNotFound;

--- a/test/Serde.Test/JsonDeserializeTests.cs
+++ b/test/Serde.Test/JsonDeserializeTests.cs
@@ -705,7 +705,9 @@ namespace Serde.Test
                         _ => throw new System.ArgumentOutOfRangeException(nameof(index)),
                     };
 
-                public ReadOnlySpan<byte> GetFieldName(int index) =>
+                public ReadOnlySpan<byte> GetFieldName(int index) => GetFieldNameMem(index).Span;
+
+                public ReadOnlyMemory<byte> GetFieldNameMem(int index) =>
                     Encoding.UTF8.GetBytes(GetFieldStringName(index));
 
                 public string GetFieldStringName(int index) =>

--- a/test/Serde.Test/JsonSerializerTests.cs
+++ b/test/Serde.Test/JsonSerializerTests.cs
@@ -424,6 +424,9 @@ namespace Serde.Test
                     throw new System.NotImplementedException();
 
                 public System.ReadOnlySpan<byte> GetFieldName(int index) =>
+                    GetFieldNameMem(index).Span;
+
+                public System.ReadOnlyMemory<byte> GetFieldNameMem(int index) =>
                     Encoding.UTF8.GetBytes(GetFieldStringName(index));
 
                 public string GetFieldStringName(int index) =>


### PR DESCRIPTION
This is important because spans may not be suspended over awaits. This change allows using the UTF-8 field names in async methods.