### PR TITLE
Port unit tests from xunit.v3 to NXTest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -454,3 +454,6 @@ $RECYCLE.BIN/
 
 # Verify
 *.received.*
+
+# NXTest generated files
+**/generated/NXTest.Generators/

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -21,8 +21,9 @@
     <PackageVersion Include="System.Net.Http" Version="4.3.4" />
     <PackageVersion Include="System.Security.Cryptography.X509Certificates" Version="4.3.2" />
     <PackageVersion Include="PolyKit.Embedded" Version="3.0.9" />
+    <PackageVersion Include="Verify" Version="31.20.0" />
     <PackageVersion Include="Verify.SourceGenerators" Version="2.5.0" />
-    <PackageVersion Include="Verify.XunitV3" Version="31.20.0" />
-    <PackageVersion Include="xunit.v3" Version="3.2.2" />
+    <PackageVersion Include="xunit.v3.assert" Version="3.2.2" />
+    <PackageVersion Include="NXTest" Version="0.1.4" />
   </ItemGroup>
 </Project>

--- a/test/Serde.Generation.Test/AllInOneTest.cs
+++ b/test/Serde.Generation.Test/AllInOneTest.cs
@@ -1,7 +1,6 @@
 using System.IO;
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
-using VerifyXunit;
 using Xunit;
 
 namespace Serde.Test;

--- a/test/Serde.Generation.Test/GeneratorTestUtils.cs
+++ b/test/Serde.Generation.Test/GeneratorTestUtils.cs
@@ -15,40 +15,47 @@ using Microsoft.CodeAnalysis.CSharp.Testing;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Testing;
 using Microsoft.CodeAnalysis.Text;
+using VerifyNXTest;
 using VerifyTests;
-using VerifyXunit;
 using Xunit;
 
 namespace Serde.Test
 {
     public static class GeneratorTestUtils
     {
-        public static Task VerifyDiagnostics(string src, params DiagnosticResult[] diagnostics) =>
-            VerifyMultiFile(src);
+        public static Task VerifyDiagnostics(
+            string src,
+            [CallerMemberName] string caller = "",
+            [CallerFilePath] string sourceFile = ""
+        ) => VerifyMultiFile(src, caller: caller, sourceFile: sourceFile);
 
         public static Task VerifyGeneratedCode(
             string src,
             string typeName,
             string expected,
-            params DiagnosticResult[] diagnostics
-        ) => VerifyMultiFile(src);
+            [CallerMemberName] string caller = "",
+            [CallerFilePath] string sourceFile = ""
+        ) => VerifyMultiFile(src, caller: caller, sourceFile: sourceFile);
 
         public static Task<VerifyResult[]> VerifyMultiFile(
             string src,
-            MetadataReference[]? additionalRefs = null
+            MetadataReference[]? additionalRefs = null,
+            [CallerMemberName] string caller = "",
+            [CallerFilePath] string sourceFile = ""
         )
         {
             var settings = new VerifySettings();
             settings.UseDirectory("test_output/");
             settings.UseUniqueDirectory();
-            return VerifyGeneratedCode(src, settings, additionalRefs);
+            return VerifyGeneratedCode(src, settings, additionalRefs, caller, sourceFile);
         }
 
         public static Task<VerifyResult[]> VerifyGeneratedCode(
             string src,
             string directoryName,
             string testMethodName,
-            bool multiFile
+            bool multiFile,
+            [CallerFilePath] string sourceFile = ""
         )
         {
             var settings = new VerifySettings();
@@ -58,20 +65,31 @@ namespace Serde.Test
             {
                 settings.UseUniqueDirectory();
             }
-            return VerifyGeneratedCode(src, settings);
+            return VerifyGeneratedCode(
+                src,
+                settings,
+                additionalRefs: null,
+                methodName: testMethodName,
+                sourceFile: sourceFile,
+                typeName: directoryName
+            );
         }
 
         public static async Task<VerifyResult[]> VerifyGeneratedCode(
             string src,
             VerifySettings settings,
-            MetadataReference[]? additionalRefs = null
+            MetadataReference[]? additionalRefs,
+            string methodName,
+            string sourceFile,
+            string? typeName = null
         )
         {
+            typeName ??= Path.GetFileNameWithoutExtension(sourceFile);
             var generatorInstance = new SerdeImplRoslynGenerator();
             GeneratorDriver driver = CSharpGeneratorDriver.Create(generatorInstance);
             Compilation comp = await CreateCompilation(src, additionalRefs);
             driver = driver.RunGeneratorsAndUpdateCompilation(comp, out comp, out _);
-            var verify = Verifier.Verify(driver, settings);
+            var verify = Verifier.Verify(driver, settings, typeName, methodName, sourceFile);
             var diags = comp.GetDiagnostics()
                 .Where(d => d.Severity >= DiagnosticSeverity.Warning)
                 .Where(d => d.Id != "CS0649")

--- a/test/Serde.Generation.Test/GlobalUsings.cs
+++ b/test/Serde.Generation.Test/GlobalUsings.cs
@@ -1,0 +1,1 @@
+global using NXTest;

--- a/test/Serde.Generation.Test/MemberFormatTests.cs
+++ b/test/Serde.Generation.Test/MemberFormatTests.cs
@@ -1,5 +1,4 @@
 using System.Threading.Tasks;
-using VerifyXunit;
 using Xunit;
 using static Serde.Test.GeneratorTestUtils;
 

--- a/test/Serde.Generation.Test/ModuleInitializer.cs
+++ b/test/Serde.Generation.Test/ModuleInitializer.cs
@@ -1,6 +1,5 @@
 using System.Runtime.CompilerServices;
 using VerifyTests;
-using VerifyXunit;
 
 internal static class ModuleInit
 {

--- a/test/Serde.Generation.Test/ProxyTests.cs
+++ b/test/Serde.Generation.Test/ProxyTests.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Testing;
-using VerifyXunit;
 using Xunit;
 using static Serde.Test.GeneratorTestUtils;
 
@@ -185,9 +184,8 @@ readonly partial struct StringWrap
     }
 }";
             return VerifyDiagnostics(
-                src,
                 // (3,18): error ERR_CantWrapSpecialType: The type 'string' can't be automatically wrapped because it is a built-in type.
-                DiagnosticResult.CompilerError("ERR_CantWrapSpecialType").WithSpan("", 3, 2, 3, 29)
+                src
             );
         }
 
@@ -201,9 +199,8 @@ using Serde;
 partial record struct StringWrap(string Wrapped);
 ";
             return VerifyDiagnostics(
-                src,
                 // (3,2): error ERR_CantWrapSpecialType: The type 'string' can't be automatically wrapped because it is a built-in type.
-                DiagnosticResult.CompilerError("ERR_CantWrapSpecialType").WithSpan("", 3, 2, 3, 28)
+                src
             );
         }
 

--- a/test/Serde.Generation.Test/Serde.Generation.Test.csproj
+++ b/test/Serde.Generation.Test/Serde.Generation.Test.csproj
@@ -18,8 +18,9 @@
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzer.Testing" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.SourceGenerators.Testing" />
     <PackageReference Include="Verify.SourceGenerators" />
-    <PackageReference Include="Verify.XunitV3" />
-    <PackageReference Include="xunit.v3" />
+    <PackageReference Include="Verify" />
+    <PackageReference Include="xunit.v3.assert" />
+    <PackageReference Include="NXTest" />
     <ProjectReference Include="../../src/serde/Serde.csproj" />
     <ProjectReference Include="../../src/generator/SerdeGenerator.csproj" />
   </ItemGroup>

--- a/test/Serde.Generation.Test/VerifyNXTest.cs
+++ b/test/Serde.Generation.Test/VerifyNXTest.cs
@@ -1,0 +1,37 @@
+using System.Threading.Tasks;
+using VerifyTests;
+
+namespace VerifyNXTest
+{
+    /// <summary>
+    /// Minimal, test-framework-agnostic replacement for the <c>Verify.XunitV3</c> integration.
+    /// The Verify engine (<see cref="InnerVerifier"/>) lives in the framework-agnostic core; the
+    /// only thing a framework package supplies is the snapshot identity (type/method name) and the
+    /// source file. NXTest has no ambient test context, so callers thread those values in explicitly.
+    /// </summary>
+    public static class Verifier
+    {
+        public static SettingsTask Verify(
+            object? target,
+            VerifySettings settings,
+            string typeName,
+            string methodName,
+            string sourceFile
+        ) =>
+            new SettingsTask(
+                settings,
+                async resolvedSettings =>
+                {
+                    using var verifier = new InnerVerifier(
+                        sourceFile,
+                        resolvedSettings,
+                        typeName,
+                        methodName,
+                        methodParameters: null,
+                        new PathInfo()
+                    );
+                    return await verifier.Verify(target);
+                }
+            );
+    }
+}

--- a/test/Serde.Test/GlobalUsings.cs
+++ b/test/Serde.Test/GlobalUsings.cs
@@ -1,0 +1,1 @@
+global using NXTest;

--- a/test/Serde.Test/JsonFsCheck.cs
+++ b/test/Serde.Test/JsonFsCheck.cs
@@ -18,7 +18,7 @@ using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 
 namespace Serde.Test
 {
-    public class JsonFsCheck
+    public class JsonFsCheck : TestBase
     {
         private static readonly EmitOptions s_emitOptions = new EmitOptions();
         private static readonly ReferenceAssemblies s_net10Refs = new ReferenceAssemblies(
@@ -37,10 +37,7 @@ namespace Serde.Test
         [Fact]
         public async Task CheckPrimitiveEquivalentsAsync()
         {
-            var resolvedRefs = await s_net10Refs.ResolveAsync(
-                null,
-                TestContext.Current.CancellationToken
-            );
+            var resolvedRefs = await s_net10Refs.ResolveAsync(null, CancellationToken);
 
             TestTypeGenerators
                 .GenTopLevelTypeDef.Array[100]

--- a/test/Serde.Test/Serde.Test.csproj
+++ b/test/Serde.Test/Serde.Test.csproj
@@ -24,7 +24,8 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="xunit.v3" />
+    <PackageReference Include="xunit.v3.assert" />
+    <PackageReference Include="NXTest" />
     <ProjectReference Include="../../src/serde/Serde.csproj" />
     <ProjectReference
       Include="../../src/generator/SerdeGenerator.csproj"


### PR DESCRIPTION
Migrate both test projects to run on NXTest (agocke/nxtest) on Microsoft.Testing.Platform, replacing xunit.v3 as the test framework.

- Reference xunit.v3.assert (for Xunit.Assert) + the NXTest meta-package instead of xunit.v3; add `global using NXTest;` so [Fact]/[Theory]/ [InlineData] resolve to NXTest attributes.
- Serde.Generation.Test: Verify only ships an xunit.v3 integration, so add VerifyNXTest.cs, a small framework-agnostic shim over Verify's core InnerVerifier, and thread caller info (type/method/source file) through GeneratorTestUtils via [CallerMemberName]/[CallerFilePath]. Drop Verify.XunitV3 in favor of Verify core; keep Verify.SourceGenerators.
- Serde.Test: no Verify usage; JsonFsCheck now derives from NXTest.TestBase and uses its CancellationToken in place of xunit's TestContext.Current.
- Directory.Packages.props: pin NXTest 0.1.4; drop now-unused xunit.v3 and Verify.XunitV3.

dotnet test: 231/231 pass (109 Serde.Generation.Test + 122 Serde.Test).